### PR TITLE
 Correction du document 'phi1363.phi002.digilibLT-lat1.xml'

### DIFF
--- a/.github/workflows/hooktest.yml
+++ b/.github/workflows/hooktest.yml
@@ -17,4 +17,4 @@ jobs:
         run: pip3 install HookTest
       - name: Run Hooktest
         run: |
-          hooktest ./ --scheme tei --workers 3 --verbose 5 --manifest --countword --console table --allowfailure 
+          hooktest ./ --scheme tei --workers 3 --verbose 7 --manifest --countword --console table --allowfailure 

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -86,7 +86,7 @@
       <div type="section" n="1">
         <p>Nomen generis neutri, numeri pluralis, si solum ponatur, elocutio figurata est, ut “vadit
           per lata camporum”, “natat per alta fluminum”, pro eo quod est: vadit per lata spatia
-          camporum, natat per alta loca fluminum. </p>
+          camporum, natat per alta loca fluminum.</p>
       </div>
       <div type="section" n="2">
         <p> Item si sermo, qui solet iungi genitivo, iungatur ablativo, ut <quote type="poetry">
@@ -96,22 +96,22 @@
       <div type="section" n="3">
         <p> Item si, cum de temporum et locorum spatiis loquimur, accusativo potius quam ablativo
           utamur, ut “totam noctem sedi”, “abest milia decem”, id est: tota nocte sedi, abest
-          milibus decem. </p>
+          milibus decem.</p>
       </div>
       <div type="section" n="4">
         <p>Item si sermo per se plenus nomen accipiat genitivi casus, ut “homo <quote type="poetry"
             >«integer vitae»</quote>”, “homo <quote type="poetry">«sceleris purus»</quote>”, id est:
-          homo integer, homo purus. </p>
+          homo integer, homo purus.</p>
       </div>
       <div type="section" n="5">
         <p>Item si utamur declinatione activa, cui passiva significatio est, ut <quote type="poetry"
             >«nox praecipitat»</quote>,<quote type="poetry">«pavor insinuat»</quote>, id est:
-          praecipitatur nox, insinuatur pavor. </p>
+          praecipitatur nox, insinuatur pavor.</p>
       </div>
       <div type="section" n="6">
         <p>Item si utamur infinito modo tempore praesenti pro indicativo imperfecto, ut: <quote
             type="poetry">«solam nam perfidus ille / te colere»</quote>, <quote type="poetry"
-            >«arcanos etiam tibi credere sensus»</quote>; id est: te colebat, tibi credebat. </p>
+            >«arcanos etiam tibi credere sensus»</quote>; id est: te colebat, tibi credebat.</p>
       </div>
       <div type="section" n="7">
         <p> Item si participio praeteriti temporis vel nomini iungas accusativum casum, ut “fessus
@@ -125,12 +125,12 @@
       <div type="section" n="9">
         <p> Item si duobus modis verbi utamur sine alterius interpositione sermonis, ut <quote
             type="poetry">«dat ferre»</quote>, “concedit abscedere”, id est: dat ut ferat, concedit
-          ut abscedat. </p>
+          ut abscedat.</p>
       </div>
       <div type="section" n="10">
         <p> Item si verbum, quod accusativum casum regit, iungatur dativo, ut est <quote
             type="poetry">«it clamor caelo»</quote>, “dixerat illo”, id est: it clamor in caelum,
-          dixerat in illum. </p>
+          dixerat in illum.</p>
       </div>
       <div type="section" n="11">
         <p> Item si pronomen componendum adiectione particulae quae est ‘–cumque’ nos geminaverimus,
@@ -155,7 +155,7 @@
       <div type="section" n="15">
         <p> Item si per accusativum et ‘in’ prepositionem dicamus quod dicitur vulgariter per
           ablativum, ut “solutus in libidinem”, “fractus in luxuriam”, id est: solutus libidine,
-          fractus luxuria. </p>
+          fractus luxuria.</p>
       </div>
       <div type="section" n="16">
         <p>Item si per genitivum proferamus, quod simpliciter per accusativum dicitur, ut est “natus
@@ -174,7 +174,7 @@
       </div>
       <div type="section" n="19">
         <p>Item si ‘in’ prepositione detracta nomen et verbum copulemus mutato casu, ut “impressus
-          caeno”, “inductus tectis”, id est: in caenum pressus, in tecta ductus. </p>
+          caeno”, “inductus tectis”, id est: in caenum pressus, in tecta ductus.</p>
       </div>
       <div type="section" n="20">
         <p>Item si dicamus aliquem aliquid dixisse, et subauditione locum relinquamus, ut “Africani

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -74,7 +74,7 @@
     </encodingDesc>
     <profileDesc>
       <langUsage>
-        <language ident="la">Latino</language>
+        <language ident="lat">Latino</language>
       </langUsage>
     </profileDesc>
     <revisionDesc>

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -1,170 +1,185 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
   <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>σχήματα λόγου</title>
-            <author> Asper (Aemilius Asper?) </author>
-            <respStmt>
-               <resp>Correzione linguistica</resp>
-               <name>Filippo Bognini</name>
-            </respStmt>
-            <respStmt>
-               <resp>Codifica XML</resp>
-               <name>Alice Borgna</name>
-            </respStmt>
-         </titleStmt>
-         <publicationStmt>
-            <publisher>digilibLT</publisher>
-            <pubPlace>Vercelli</pubPlace>
-            <date>2016</date>
-            <availability>
-               <p>
-                  <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
-               </p>
-            </availability>
-            <idno>dlt000024</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <p>Filippo Bognini, <hi rend="italic"> Il trattato </hi> σχήματα λόγου<hi rend="italic">: un
+    <fileDesc>
+      <titleStmt>
+        <title>σχήματα λόγου</title>
+        <author> Asper (Aemilius Asper?) </author>
+        <respStmt>
+          <resp>Correzione linguistica</resp>
+          <name>Filippo Bognini</name>
+        </respStmt>
+        <respStmt>
+          <resp>Codifica XML</resp>
+          <name>Alice Borgna</name>
+        </respStmt>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>digilibLT</publisher>
+        <pubPlace>Vercelli</pubPlace>
+        <date>2016</date>
+        <availability>
+          <p>
+            <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
+          </p>
+        </availability>
+        <idno>dlt000024</idno>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Filippo Bognini, <hi rend="italic"> Il trattato </hi> σχήματα λόγου<hi rend="italic">: un
             nuovo testo ascrivibile a Emilio Aspro? </hi> in «Italia Medioevale e Umanistica», 49
           (2008), pp. 1-51. </p>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
-         <projectDesc>
-            <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
-         </projectDesc>
-         <editorialDecl>
-            <p>
-               <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT</hi>
-            </p>
-            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <refsDecl n="CTS">
+        <cRefPattern n="section" matchPattern="(\w+)"
+          replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+          <p>This pointer pattern extracts section</p>
+        </cRefPattern>
+      </refsDecl>
+      <projectDesc>
+        <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
+        <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+      </projectDesc>
+      <editorialDecl>
+        <p>
+          <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT</hi>
+        </p>
+        <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
           l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni,
           note e commenti e ogni altro contenuto redatto da editori moderni.</p>
-            <p>I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
+        <p>I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
           correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
+        <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
           distinzione u/v minuscole.</p>
-            <p>Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi> :
+        <p>Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+        <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi> :
           grassetto, corsivo, spaziatura espansa. </p>
-            <p> Sono stati normalizzati e marcati nel modo seguente i diacritici. <lb/> espunzioni:
-          &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;
-          <lb/>
-               <hi rend="italic">loci desperati</hi> :
-           &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo si visualizzano †testo† e †testo
-          <lb/> lacuna materiale: &lt;gap/&gt; si visualizza [...] <lb/> lacuna integrata
-          dagli editori: &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-        </p>
-            <p> Sono stati marcati i termini in lingua greca
-          &lt;foreign xml:lang="grc"&gt;αβγ&lt;/foreign&gt;
-        </p>
-            <p> Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
+        <p> Sono stati normalizzati e marcati nel modo seguente i diacritici. <lb/> espunzioni:
+          &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+          &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt; <lb/>
+          <hi rend="italic">loci desperati</hi> : &lt;unclear&gt;testo&lt;/unclear&gt; o
+          &lt;unclear/&gt; testo si visualizzano †testo† e †testo <lb/> lacuna materiale:
+          &lt;gap/&gt; si visualizza [...] <lb/> lacuna integrata dagli editori:
+          &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+        <p> Sono stati marcati i termini in lingua greca &lt;foreign
+          xml:lang="grc"&gt;αβγ&lt;/foreign&gt; </p>
+        <p> Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+            target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+            >Note di trascrizione e codifica di testi latini tardoantichi
             [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
-            </p>
-         </editorialDecl>
-      </encodingDesc>
-      <profileDesc>
-         <langUsage>
-            <language ident="la">Latino</language>
-         </langUsage>
-      </profileDesc>
+        </p>
+      </editorialDecl>
+    </encodingDesc>
+    <profileDesc>
+      <langUsage>
+        <language ident="la">Latino</language>
+      </langUsage>
+    </profileDesc>
+    <revisionDesc>
+      <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par CapiTainS.</changewho>
+    </revisionDesc>
   </teiHeader>
   <text>
-      <body xml:lang="lat" n="urn:cts:latinLit:phi1363.phi002.digilibLT-lat1">
-         <div type="section" n="1">
-            <p>Nomen generis neutri, numeri pluralis, si solum ponatur, elocutio figurata est, ut “vadit
+    <body xml:lang="lat" n="urn:cts:latinLit:phi1363.phi002.digilibLT-lat1">
+      <div type="section" n="1">
+        <p>Nomen generis neutri, numeri pluralis, si solum ponatur, elocutio figurata est, ut “vadit
           per lata camporum”, “natat per alta fluminum”, pro eo quod est: vadit per lata spatia
           camporum, natat per alta loca fluminum. </p>
-         </div>
-         <div type="section" n="2">
-            <p> Item si sermo, qui solet iungi genitivo, iungatur ablativo, ut <quote type="poetry">
+      </div>
+      <div type="section" n="2">
+        <p> Item si sermo, qui solet iungi genitivo, iungatur ablativo, ut <quote type="poetry">
             “homo vita optima”, “pater «pulchra prole»”</quote>, id est: homo vitae optimae, pater
           pulchrae prolis.</p>
-         </div>
-         <div type="section" n="3">
-            <p> Item si, cum de temporum et locorum spatiis loquimur, accusativo potius quam ablativo
+      </div>
+      <div type="section" n="3">
+        <p> Item si, cum de temporum et locorum spatiis loquimur, accusativo potius quam ablativo
           utamur, ut “totam noctem sedi”, “abest milia decem”, id est: tota nocte sedi, abest
           milibus decem. </p>
-         </div>
-         <div type="section" n="4">
-            <p>Item si sermo per se plenus nomen accipiat genitivi casus, ut “homo <quote type="poetry">«integer vitae»</quote>”, “homo <quote type="poetry">«sceleris purus»</quote>”, id est:
+      </div>
+      <div type="section" n="4">
+        <p>Item si sermo per se plenus nomen accipiat genitivi casus, ut “homo <quote type="poetry"
+            >«integer vitae»</quote>”, “homo <quote type="poetry">«sceleris purus»</quote>”, id est:
           homo integer, homo purus. </p>
-         </div>
-         <div type="section" n="5">
-            <p>Item si utamur declinatione activa, cui passiva significatio est, ut <quote type="poetry">«nox praecipitat»</quote>,<quote type="poetry">«pavor insinuat»</quote>, id est:
+      </div>
+      <div type="section" n="5">
+        <p>Item si utamur declinatione activa, cui passiva significatio est, ut <quote type="poetry"
+            >«nox praecipitat»</quote>,<quote type="poetry">«pavor insinuat»</quote>, id est:
           praecipitatur nox, insinuatur pavor. </p>
-         </div>
-         <div type="section" n="6">
-            <p>Item si utamur infinito modo tempore praesenti pro indicativo imperfecto, ut: <quote type="poetry">«solam nam perfidus ille / te colere»</quote>, <quote type="poetry">«arcanos etiam tibi credere sensus»</quote>; id est: te colebat, tibi credebat. </p>
-         </div>
-         <div type="section" n="7">
-            <p> Item si participio praeteriti temporis vel nomini iungas accusativum casum, ut “fessus
+      </div>
+      <div type="section" n="6">
+        <p>Item si utamur infinito modo tempore praesenti pro indicativo imperfecto, ut: <quote
+            type="poetry">«solam nam perfidus ille / te colere»</quote>, <quote type="poetry"
+            >«arcanos etiam tibi credere sensus»</quote>; id est: te colebat, tibi credebat. </p>
+      </div>
+      <div type="section" n="7">
+        <p> Item si participio praeteriti temporis vel nomini iungas accusativum casum, ut “fessus
           membra”, <quote type="poetry">«oculos suffusa»</quote>, id est: fessa membra habens,
           oculos suffusos habens.</p>
-         </div>
-         <div type="section" n="8">
-            <p> Item si utamur nomine loco adverbii, ut <quote type="poetry">«torvum clamat»</quote>,
+      </div>
+      <div type="section" n="8">
+        <p> Item si utamur nomine loco adverbii, ut <quote type="poetry">«torvum clamat»</quote>,
           “horrendum resonat”, id est: torve clamat, horrende resonat. </p>
-         </div>
-         <div type="section" n="9">
-            <p> Item si duobus modis verbi utamur sine alterius interpositione sermonis, ut <quote type="poetry">«dat ferre»</quote>, “concedit abscedere”, id est: dat ut ferat, concedit
+      </div>
+      <div type="section" n="9">
+        <p> Item si duobus modis verbi utamur sine alterius interpositione sermonis, ut <quote
+            type="poetry">«dat ferre»</quote>, “concedit abscedere”, id est: dat ut ferat, concedit
           ut abscedat. </p>
-         </div>
-         <div type="section" n="10">
-            <p> Item si verbum, quod accusativum casum regit, iungatur dativo, ut est <quote type="poetry">«it clamor caelo»</quote>, “dixerat illo”, id est: it clamor in caelum,
+      </div>
+      <div type="section" n="10">
+        <p> Item si verbum, quod accusativum casum regit, iungatur dativo, ut est <quote
+            type="poetry">«it clamor caelo»</quote>, “dixerat illo”, id est: it clamor in caelum,
           dixerat in illum. </p>
-         </div>
-         <div type="section" n="11">
-            <p> Item si pronomen componendum adiectione particulae quae est ‘–cumque’ nos geminaverimus,
+      </div>
+      <div type="section" n="11">
+        <p> Item si pronomen componendum adiectione particulae quae est ‘–cumque’ nos geminaverimus,
           ut est <quote type="poetry">«quisquis es armatus»</quote>, <quote type="poetry">«quanta
             quanta haec mea paupertas est»</quote>, id est: quicumque es armatus, quantacumque est
           haec mea paupertas.</p>
-         </div>
-         <div type="section" n="12">
-            <p>Item si in sermone, in quo possumus dicere ‘qualis’, dicamus ‘quid’, ut <quote type="poetry">«quid morbi est»</quote>, <quote type="poetry">«quid mali est»</quote>, id
+      </div>
+      <div type="section" n="12">
+        <p>Item si in sermone, in quo possumus dicere ‘qualis’, dicamus ‘quid’, ut <quote
+            type="poetry">«quid morbi est»</quote>, <quote type="poetry">«quid mali est»</quote>, id
           est: qualis morbus est, quale malum est.</p>
-         </div>
-         <div type="section" n="13">
-            <p> Item si numerum per genitivum casum proferamus, ut “habeo mille hominum”, “potitus sum
+      </div>
+      <div type="section" n="13">
+        <p> Item si numerum per genitivum casum proferamus, ut “habeo mille hominum”, “potitus sum
           trium milium hostium”, id est: habeo mille homines, potitus sum tria milia hostes.</p>
-         </div>
-         <div type="section" n="14">
-            <p> Item si pro fixae appellationis genitivo feminini generis, neutri mobilis genitivis
+      </div>
+      <div type="section" n="14">
+        <p> Item si pro fixae appellationis genitivo feminini generis, neutri mobilis genitivis
           utamur, ut <quote type="poetry">«servantissimus aequi»</quote>, “amans iusti”, id est:
           servantissimus aequitatis, amans iustitiae.</p>
-         </div>
-         <div type="section" n="15">
-            <p> Item si per accusativum et ‘in’ prepositionem dicamus quod dicitur vulgariter per
+      </div>
+      <div type="section" n="15">
+        <p> Item si per accusativum et ‘in’ prepositionem dicamus quod dicitur vulgariter per
           ablativum, ut “solutus in libidinem”, “fractus in luxuriam”, id est: solutus libidine,
           fractus luxuria. </p>
-         </div>
-         <div type="section" n="16">
-            <p>Item si per genitivum proferamus, quod simpliciter per accusativum dicitur, ut est “natus
+      </div>
+      <div type="section" n="16">
+        <p>Item si per genitivum proferamus, quod simpliciter per accusativum dicitur, ut est “natus
           perdendae rei publicae”, “genitus augendae civitatis”, id est: natus ad perdendam rem
           publicam, genitus ad augendam civitatem.</p>
-         </div>
-         <div type="section" n="17">
-            <p> Item si ‘in’ ponamus pro ‘inter’, ut <quote type="prose">«in amicis habere»</quote>,
+      </div>
+      <div type="section" n="17">
+        <p> Item si ‘in’ ponamus pro ‘inter’, ut <quote type="prose">«in amicis habere»</quote>,
             <quote type="prose">«leonem in primis ferire»</quote>, id est: inter amicos habere,
           leonem inter primos ferire.</p>
-         </div>
-         <div type="section" n="18">
-            <p> Item si ‘in’ ponamus pro ‘intra’, ut est “<quote type="poetry">«in diebus
+      </div>
+      <div type="section" n="18">
+        <p> Item si ‘in’ ponamus pro ‘intra’, ut est “<quote type="poetry">«in diebus
             paucis»</quote> fiet”, “in paucis mensibus veniet”, id est: intra paucos dies fiet,
           intra paucos menses veniet.</p>
-         </div>
-         <div type="section" n="19">
-            <p>Item si ‘in’ prepositione detracta nomen et verbum copulemus mutato casu, ut “impressus
+      </div>
+      <div type="section" n="19">
+        <p>Item si ‘in’ prepositione detracta nomen et verbum copulemus mutato casu, ut “impressus
           caeno”, “inductus tectis”, id est: in caenum pressus, in tecta ductus. </p>
-         </div>
-         <div type="section" n="20">
-            <p>Item si dicamus aliquem aliquid dixisse, et subauditione locum relinquamus, ut “Africani
+      </div>
+      <div type="section" n="20">
+        <p>Item si dicamus aliquem aliquid dixisse, et subauditione locum relinquamus, ut “Africani
           est”, “Catonis fuit”, id est: Africani est hoc dictum, Catonis fuit hoc studium.</p>
-         </div>
-      </body>
+      </div>
+    </body>
   </text>
 </TEI>

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -80,6 +80,8 @@
     <revisionDesc>
       <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par
         CapiTainS.</change>
+      <change who="Hippolyte Souvay" when="2021-04-01">Attribution d'un nom au pointeur Xpath
+        CapiTainS.</change>
     </revisionDesc>
   </teiHeader>
   <text>

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -78,7 +78,7 @@
       </langUsage>
     </profileDesc>
     <revisionDesc>
-      <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par CapiTainS.</changewho>
+      <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par CapiTainS.</change>
     </revisionDesc>
   </teiHeader>
   <text>

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
     </fileDesc>
     <encodingDesc>
       <refsDecl n="CTS">
-        <cRefPattern n="unknown" matchPattern="(\w+)"
+        <cRefPattern n="section" matchPattern="(\w+)"
           replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
-          <p>This pointer pattern extracts unknwon</p>
+          <p>This pointer pattern extracts sections</p>
         </cRefPattern>
       </refsDecl>
       <projectDesc>
@@ -78,7 +78,8 @@
       </langUsage>
     </profileDesc>
     <revisionDesc>
-      <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par CapiTainS.</change>
+      <change who="Hippolyte Souvay" when="2021-03-27">Correction du Xpath généré par
+        CapiTainS.</change>
     </revisionDesc>
   </teiHeader>
   <text>

--- a/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
+++ b/data/phi1363/phi002/phi1363.phi002.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
     </fileDesc>
     <encodingDesc>
       <refsDecl n="CTS">
-        <cRefPattern n="section" matchPattern="(\w+)"
+        <cRefPattern n="unknown" matchPattern="(\w+)"
           replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
-          <p>This pointer pattern extracts section</p>
+          <p>This pointer pattern extracts unknwon</p>
         </cRefPattern>
       </refsDecl>
       <projectDesc>


### PR DESCRIPTION
Corrections apportées au documents 'phi1363.phi002.digilibLT-lat1.xml' : 
- Correction du Xpath généré automatiquement par CapiTainS.
- Correction de l'identifiant renvoyant au latin dans le TEI-Header (la -> lat).

(Modification de la verbosité du Hooktest à 7.
