### PR TITLE
Correstion fichier stoa0077.stoa024.digilibLT-lat1.xml 

### DIFF
--- a/data/stoa0077/stoa024/stoa0077.stoa024.digilibLT-lat1.xml
+++ b/data/stoa0077/stoa024/stoa0077.stoa024.digilibLT-lat1.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Anecdoton Holderi quod dicitur, scilicet excerpta ex Cassiodori libello de ordine generis Cassiodororum </title>
+                <title>Anecdoton Holderi quod dicitur, scilicet excerpta ex Cassiodori libello de
+                    ordine generis Cassiodororum </title>
                 <author>Cassiodorus</author>
                 <respStmt>
                     <resp>Correzione linguistica</resp>
@@ -21,85 +21,100 @@
                 <date>2012</date>
                 <availability>
                     <p>
-                  <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
-               </p>
+                        <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
+                    </p>
                 </availability>
                 <idno>dlt000075</idno>
             </publicationStmt>
             <sourceDesc>
-                <p>Magni Aurelii Cassiodori, Variarum Libri XII, cura et studio Å.J. Frigh, Turnholti 1973 (Corpus Christianorum. Series Latina XCVI)</p>
+                <p>Magni Aurelii Cassiodori, Variarum Libri XII, cura et studio Å.J. Frigh,
+                    Turnholti 1973 (Corpus Christianorum. Series Latina XCVI)</p>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+            <refsDecl n="CTS">
+                <cRefPattern n="paragraph" matchPattern="(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:p[@n='$1'])">
+                    <p>This pointer pattern extracts paragraphs</p>
+                </cRefPattern>
+            </refsDecl>
             <projectDesc>
                 <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-                <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+                <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+                    Lana</p>
             </projectDesc>
             <editorialDecl>
-               
-                
+
+
                 <p>
-               <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
-            </p>
-                <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-                    l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-                    e commenti e ogni altro contenuto redatto da editori moderni. </p>
-                <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-                    correttezza di trascrizione</p>
-                <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-                    distinzione u/v minuscole.</p>
+                    <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
+                </p>
+                <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non
+                    seguendone l'impaginazione. Sono stati invece esclusi dalla digitalizzazione
+                    apparati, introduzioni, note e commenti e ogni altro contenuto redatto da
+                    editori moderni. </p>
+                <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la
+                    massima correttezza di trascrizione</p>
+                <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di
+                    riferimento per la distinzione u/v minuscole.</p>
                 <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-                <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-                    grassetto, corsivo, spaziatura espansa.</p>
-                <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-                    &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-                    <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-                    si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-                    [...]<lb/> lacuna integrata dagli editori:
-                    &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
+                <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic"
+                        >corpus</hi>: grassetto, corsivo, spaziatura espansa.</p>
+                <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/>
+                    espunzioni: &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/>
+                    integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+                    <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+                    &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+                    &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+                    &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+                <p>Sono stati marcati i termini in lingua greca &lt;foreign
+                    xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+                <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                        target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                        >Note di trascrizione e codifica di testi latini tardoantichi
+                        [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
                 </p>
-                <p>Sono stati marcati i termini in lingua greca
-                    &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-                </p>
-                <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-                    [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
-            </p>
             </editorialDecl>
-           
+
         </encodingDesc>
         <profileDesc>
             <langUsage>
-                <language ident="la">Latino</language>
+                <language ident="lat">Latino</language>
             </langUsage>
         </profileDesc>
+        <revisionDesc>
+            <change who="Léa Maronet" when="2021-04-03">Correction de la numérotation des
+                paragraphes.</change>
+        </revisionDesc>
     </teiHeader>
 
     <text>
         <body xml:lang="lat" n="urn:cts:latinLit:stoa0077.stoa024.digilibLT-lat1">
             <div type="opus">
-            <head>Anecdoton Holderi quod dicitur, scilicet excerpta ex Cassiodori libello de ordine generis Cassiodororum</head>
-                <p>Excerpta ex libello Cassiodori Senatoris monachi serui dei ex patricio et consule
-                    ordinario, quaestore et magistro officiorum, quem scripsit ad Rufinum Petronium
-                    Nicomachum ex consule ordinario patricium et magistrum officiorum. </p>
-                <p> Ordo generis Cassiodororum: qui scriptores extiterint ex eorum genere uel ex
-                    quibus eruditis. Symmachus patricius et consul ordinarius, uir philosophus, qui
-                    antiqui Catonis fuit nouellus imitator, sed uirtutes ueterum sanctissima
+                <head>Anecdoton Holderi quod dicitur, scilicet excerpta ex Cassiodori libello de
+                    ordine generis Cassiodororum</head>
+                <p n="1">Excerpta ex libello Cassiodori Senatoris monachi serui dei ex patricio et
+                    consule ordinario, quaestore et magistro officiorum, quem scripsit ad Rufinum
+                    Petronium Nicomachum ex consule ordinario patricium et magistrum officiorum. </p>
+                <p n="2"> Ordo generis Cassiodororum: qui scriptores extiterint ex eorum genere uel
+                    ex quibus eruditis. Symmachus patricius et consul ordinarius, uir philosophus,
+                    qui antiqui Catonis fuit nouellus imitator, sed uirtutes ueterum sanctissima
                     religione transcendit. Dixit sententiam pro allecticiis in senatu parentesque
                     suos imitatus historiam quoque Romanam septem libris edidit. </p>
-                <p> Boethius dignitatibus summis excelluit, utraque lingua peritissimus orator fuit.
-                    Qui regem Theodericum in senatu pro consulatu filiorum luculenta oratione
+                <p n="3"> Boethius dignitatibus summis excelluit, utraque lingua peritissimus orator
+                    fuit. Qui regem Theodericum in senatu pro consulatu filiorum luculenta oratione
                     laudauit. Scripsit librum de sancta trinitate et capita quaedam dogmatica et
                     librum contra Nestorium. Condidit et carmen bucolicum. Sed in opere artis
                     logicae, id est dialecticae, transferendo ac mathematicis disciplinis talis
                     fuit, ut antiquos auctores aut aequiperaret aut uinceret. </p>
-                <p> Cassiodorus Senator uir eruditissimus et multis dignitatibus pollens iuuenis
-                    adeo, dum patris Cassiodori patricii et praefecti praetorii consiliarius fieret
-                    et laudes Theoderici regis Gothorum facundissime recitasset, ab eo quaestor est
-                    factus, patricius et consul ordinarius postmodum, dehinc magister officiorum et
-                    praefectus praetorio. Composuit et formulas dictionum, quas in duodecim libris
-                    ordinauit et Variarum titulum superposuit. Scripsit praecipiente Theoderico rege
-                    historiam Gothicam, originem eorum et loca mores XII libris enuntians. </p>
+                <p n="4"> Cassiodorus Senator uir eruditissimus et multis dignitatibus pollens
+                    iuuenis adeo, dum patris Cassiodori patricii et praefecti praetorii consiliarius
+                    fieret et laudes Theoderici regis Gothorum facundissime recitasset, ab eo
+                    quaestor est factus, patricius et consul ordinarius postmodum, dehinc magister
+                    officiorum et praefectus praetorio. Composuit et formulas dictionum, quas in
+                    duodecim libris ordinauit et Variarum titulum superposuit. Scripsit praecipiente
+                    Theoderico rege historiam Gothicam, originem eorum et loca mores XII libris
+                    enuntians. </p>
             </div>
         </body>
     </text>


### PR DESCRIPTION
Fixed #13 
Dans le cadre du devoir de Git, j'ai corrigé le fichier stoa0077.stoa024.digilibLT-lat1.xml (fichier 1/5). 

- [x] Correction de la numérotation des paragraphes.
- [x] Correction du Xpath.
- [x] Correction de la langue "la" et "lat".
- [x] Rédaction d'un revisionDesc.

J'ai travaillé sur une branche "Essai" que j'ai merge à ma branche "master" puis j'ai effectué cette _pull resquet_ depuis ma branche "master" vers la branche "master" de Chartes-TNAH.