### PR TITLE
Correction fichier stoa0077.stoa016.digilibLT-lat1.xml

### DIFF
--- a/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
+++ b/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
@@ -44,7 +44,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
             <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
@@ -100,7 +100,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change who="Léa Maronet" when="2021-04-03">Correction de la langue.</change>
+         <change who="Léa Maronet" when="2021-04-03">Correction de la langue et du Xpath.</change>
       </revisionDesc>
    </teiHeader>
 
@@ -201,6 +201,8 @@
             <p>
                <milestone unit="par" n="55"/> Nunc ordo scripturae, qui ab antiquis positus cognoscitur, nihilominus est dicendus. </p>
          </div>
+         
+         <div>
    
          <div type="cap" n="1">
             <head>[I.] ANNAEI CORNVTI DE ENVNTIATIONE VEL ORTHOGRAPHIA ISTA RELATA SVNT</head>
@@ -792,6 +794,8 @@
                <milestone unit="par" n="22"/> ‘Harpyia’, quod Grecum nomen est, per <hi rend="italic">y</hi> Grecum sequente <hi rend="italic">i</hi> Latino scribendum est, quoniam apud eos <hi rend="italic">yi</hi> diptongon est.</p>
             <p>
                <milestone unit="par" n="23"/> ‘Ara’, cum ‘altare’ significat, sine aspiratione, cum uero ‘cubile’ porcorum, cum aspiratione scribendum. </p>
+         </div>
+   
          </div>
    
          <div type="pr" n="pr">

--- a/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
+++ b/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
@@ -44,7 +44,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
             <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>

--- a/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
+++ b/data/stoa0077/stoa016/stoa0077.stoa016.digilibLT-lat1.xml
@@ -96,9 +96,12 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
+      <revisionDesc>
+         <change who="Léa Maronet" when="2021-04-03">Correction de la langue.</change>
+      </revisionDesc>
    </teiHeader>
 
    <text>


### PR DESCRIPTION
Fixed #20 
Dans le cadre du devoir de Git, j'ai corrigé le fichier stoa0077.stoa016.digilibLT-lat1.xml (fichier 2/5).

- [x] Correction des balises div.
- [x] Correction du Xpath.
- [x] Correction de la langue "la" et "lat".
- [x] Rédaction d'un revisionDesc.

J'ai travaillé sur une branche "Devoir" puis j'ai effectué cette _pull request_ depuis cette branche vers la branche "master" de Chartes-TNAH.