### PR TITLE
Correction du fichier "stoa0364.stoa001.digilibLT-lat1.xml"

### DIFF
--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -88,15 +88,10 @@
          </langUsage>
       </profileDesc>
    </teiHeader>
-
    <text>
-
-
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0364.stoa001.digilibLT-lat1">
-
          <div type="lib" n="I">
             <head>LIBER PRIMVS</head>
-
             <div type="cap" n="1">
                <head>
                   <supplied>Fabula Promethei</supplied>.</head>
@@ -1734,10 +1729,8 @@
                   tectum prona portaret. Vnde incuruatis aedificiis hoc est nomen impositum. </p>
             </div>
          </div>
-
          <div type="lib" n="II">
             <head>LIBER SECVNDVS</head>
-
             <div type="cap" n="1">
                <head> Fabula Saturni et eius filiorum.</head>
                <p>
@@ -3286,10 +3279,8 @@
                   Troiana. </p>
             </div>
          </div>
-
          <div type="lib" n="III">
             <head>LIBER TERTIVS</head>
-
             <div type="cap" n="1">
                <head> De genealogia deorum et heroum.</head>
                <p>
@@ -3887,8 +3878,6 @@
             </div>
 
          </div>
-
       </body>
    </text>
-
 </TEI>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -84,7 +84,7 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
    </teiHeader>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -26,45 +26,59 @@
          </publicationStmt>
          <sourceDesc>
             <p>
-               <hi rend="italic">Le premier mythographe du Vatican</hi>, texte établi par Nevio Zorzetti et traduit par Jacques Berlioz, Paris 1995 (Collection des Universités de France)</p>
+               <hi rend="italic">Le premier mythographe du Vatican</hi>, texte établi par Nevio
+               Zorzetti et traduit par Jacques Berlioz, Paris 1995 (Collection des Universités de
+               France)</p>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl>
+         <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
+            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
+            <p>This pointer pattern extracts chapters</p>
+         </cRefPattern>
+         <cRefPattern n="book" matchPattern="(\w+)"
+            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+            <p>This pointer pattern extracts books</p>
+         </cRefPattern>
+         </refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
          </projectDesc>
          <editorialDecl>
             <p>
                <hi rend="bold">Modifiche apportate al testo dell'edizione di riferimento </hi>
             </p>
-            <p>In I. 76, 2 è stato corretto l'errore di stampa <hi rend="italic">Iou</hi> con <hi rend="italic">Ioue et</hi> sulla base dell'edizione Kulcsár (1987).</p>
+            <p>In I. 76, 2 è stato corretto l'errore di stampa <hi rend="italic">Iou</hi> con <hi
+                  rend="italic">Ioue et</hi> sulla base dell'edizione Kulcsár (1987).</p>
             <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
             <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-     l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-     e commenti e ogni altro contenuto redatto da editori moderni. </p>
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
             <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-     correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-     distinzione u/v minuscole.</p>
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
             <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
             <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-     grassetto, corsivo, spaziatura espansa.</p>
+               grassetto, corsivo, spaziatura espansa.</p>
             <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-     &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-               <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-     si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-     [...]<lb/> lacuna integrata dagli editori:
-     &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-    </p>
-            <p>Sono stati marcati i termini in lingua greca
-     &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-    </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-      [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
          </editorialDecl>
       </encodingDesc>
@@ -79,619 +93,1645 @@
 
 
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0364.stoa001.digilibLT-lat1">
-   
+
          <div type="lib" n="I">
             <head>LIBER PRIMVS</head>
 
             <div type="cap" n="1">
-               <head> 
+               <head>
                   <supplied>Fabula Promethei</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Prometheus post factos a se homines dicitur auxilio Mineruae caelum ascendisse et, adhibita facula, ad rotam solis ignem furatus, quem hominibus indicauit. <milestone unit="par" n="2"/> Ob quam rem irati dii duo mala inmiserunt terris, febres, id est macies, et morbos. <milestone unit="par" n="3"/> Ipsum etiam Prometheum per Mercurium in Caucaso monte religarunt ad saxum et adhibita est aquila, quae cor eius exederet. <milestone unit="par" n="4"/> Haec autem omnia non sine ratione finguntur. <milestone unit="par" n="5"/> Nam Prometheus uir prudentissimus fuit; unde et primus astrologiam Assyriis indicauit, quam residens in Caucaso monte nimia cura comprehenderat. <milestone unit="par" n="6"/> Dicitur autem aquila cor eius edere; quod est nimia sollicitudo, qua ille affec<del>u</del>tus siderum omnes motus deprehenderat. <milestone unit="par" n="7"/> Et hoc quia per prudentiam fecit, duce Mercurio, qui prudentiae et rationis deus est, ad saxum dicitur religatus. <milestone unit="par" n="8"/> Deprehendit praeterea rationem fulminum et hominibus indicauit, unde caelestem ignem dicitur esse furatus; nam quadam arte ab eodem monstrata supernus ignis olim eliciebatur. <milestone unit="par" n="9"/> Qui mortalibus profuit donec bene eo usi sunt; nam postea malo hominum usu in perniciem uersus est, sicut in Liuio lectum est de Tullio Hostilio, qui eo igni exustus est cum omnibus suis. <milestone unit="par" n="10"/> Hinc est quod igne rapto ab iratis numinibus morbus hominibus di<supplied>cit</supplied>ur immissus.</p>
+               <p>
+                  <milestone unit="par" n="1"/> Prometheus post factos a se homines dicitur auxilio
+                  Mineruae caelum ascendisse et, adhibita facula, ad rotam solis ignem furatus, quem
+                  hominibus indicauit. <milestone unit="par" n="2"/> Ob quam rem irati dii duo mala
+                  inmiserunt terris, febres, id est macies, et morbos. <milestone unit="par" n="3"/>
+                  Ipsum etiam Prometheum per Mercurium in Caucaso monte religarunt ad saxum et
+                  adhibita est aquila, quae cor eius exederet. <milestone unit="par" n="4"/> Haec
+                  autem omnia non sine ratione finguntur. <milestone unit="par" n="5"/> Nam
+                  Prometheus uir prudentissimus fuit; unde et primus astrologiam Assyriis indicauit,
+                  quam residens in Caucaso monte nimia cura comprehenderat. <milestone unit="par"
+                     n="6"/> Dicitur autem aquila cor eius edere; quod est nimia sollicitudo, qua
+                  ille affec<del>u</del>tus siderum omnes motus deprehenderat. <milestone unit="par"
+                     n="7"/> Et hoc quia per prudentiam fecit, duce Mercurio, qui prudentiae et
+                  rationis deus est, ad saxum dicitur religatus. <milestone unit="par" n="8"/>
+                  Deprehendit praeterea rationem fulminum et hominibus indicauit, unde caelestem
+                  ignem dicitur esse furatus; nam quadam arte ab eodem monstrata supernus ignis olim
+                  eliciebatur. <milestone unit="par" n="9"/> Qui mortalibus profuit donec bene eo
+                  usi sunt; nam postea malo hominum usu in perniciem uersus est, sicut in Liuio
+                  lectum est de Tullio Hostilio, qui eo igni exustus est cum omnibus suis.
+                     <milestone unit="par" n="10"/> Hinc est quod igne rapto ab iratis numinibus
+                  morbus hominibus di<supplied>cit</supplied>ur immissus.</p>
             </div>
 
             <div type="cap" n="2">
                <head> Fabula Neptuni et Mineruae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum Neptunus et Minerua de Athenarum nomine contenderent, placuit diis ut eius nomine appellarentur, qui munus melius mortalibus obtulisse<del>n</del>t. <milestone unit="par" n="2"/> Tunc Neptunus percusso litore equum, animal bellis aptum, produxit; Minerua iactata hasta olivam creauit, quae res est melior comprobata et pacis insigne. <milestone unit="par" n="3"/> Vnde ex Mineruae nomine, quae graece Attis dicitur, Athenae dicta est urbs. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum Neptunus et Minerua de Athenarum nomine
+                  contenderent, placuit diis ut eius nomine appellarentur, qui munus melius
+                  mortalibus obtulisse<del>n</del>t. <milestone unit="par" n="2"/> Tunc Neptunus
+                  percusso litore equum, animal bellis aptum, produxit; Minerua iactata hasta olivam
+                  creauit, quae res est melior comprobata et pacis insigne. <milestone unit="par"
+                     n="3"/> Vnde ex Mineruae nomine, quae graece Attis dicitur, Athenae dicta est
+                  urbs. </p>
             </div>
 
             <div type="cap" n="3">
                <head> Fabula Scyllae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Scyllae duae fuerunt. <milestone unit="par" n="2"/> Vna Phorci et Cret<supplied>ae</supplied>idos filia, quam cum amaret Glaucus, deus marinus, dum ipse amaretur a Circe et eam contemneret, illa irata fontem, in quo se Scylla solebat abluere, infecit uenenis; in quem cum descendisset puella, media parte in feras commutata est.</p>
-               <p> 
-                  <milestone unit="par" n="3"/> Altera uero Scylla fuit Nisi, Megarensium regis, filia; contra quos dum deuictis iam Atheniensibus pugnaret Minos propter filii Androgei interitum, quem Athenienses et Megarenses dolo necauerant, amatus est a Scylla, Nisi filia. <milestone unit="par" n="4"/> Quae ut hosti posset placere, comam purpuream parenti abscisam ei obtulit, quam Nisus ita habuerat consecratam, ut tamdiu regno potiretur, quamdiu illam habuisset intactam. <milestone unit="par" n="5"/> Postea et Scylla, a Minoe contempta, dolore in auem conuersa est et Nisus extinctus deorum miseratione in auis mutatus est formam; quae aues hodie flagrant inter se magna discordia.</p>
+               <p>
+                  <milestone unit="par" n="1"/> Scyllae duae fuerunt. <milestone unit="par" n="2"/>
+                  Vna Phorci et Cret<supplied>ae</supplied>idos filia, quam cum amaret Glaucus, deus
+                  marinus, dum ipse amaretur a Circe et eam contemneret, illa irata fontem, in quo
+                  se Scylla solebat abluere, infecit uenenis; in quem cum descendisset puella, media
+                  parte in feras commutata est.</p>
+               <p>
+                  <milestone unit="par" n="3"/> Altera uero Scylla fuit Nisi, Megarensium regis,
+                  filia; contra quos dum deuictis iam Atheniensibus pugnaret Minos propter filii
+                  Androgei interitum, quem Athenienses et Megarenses dolo necauerant, amatus est a
+                  Scylla, Nisi filia. <milestone unit="par" n="4"/> Quae ut hosti posset placere,
+                  comam purpuream parenti abscisam ei obtulit, quam Nisus ita habuerat consecratam,
+                  ut tamdiu regno potiretur, quamdiu illam habuisset intactam. <milestone unit="par"
+                     n="5"/> Postea et Scylla, a Minoe contempta, dolore in auem conuersa est et
+                  Nisus extinctus deorum miseratione in auis mutatus est formam; quae aues hodie
+                  flagrant inter se magna discordia.</p>
             </div>
 
             <div type="cap" n="4">
                <head> Fabula Terei et Progne<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tereus rex Thracum fuit, qui cum Pandionis, Athenarum regis, filiam Prognen nomine duxisset uxorem et post aliquantum tempus ab ea rogaretur sibi Philomelam sororem uidendam accersiret, profectus Athenas, dum abducit puellam, eam uitiauit in itinere et ei linguam, ne facinus indicaret, abscidit. <milestone unit="par" n="2"/> Illa tamen rem, in ueste suo cruore descriptam, misit sorori; qua cognita Progne Ityn filium interemit et patri epulandum apposuit. <milestone unit="par" n="3"/> Postea omnes in aues mutati sunt: Tereus in upupam, Itys in phassam, Progne in hirundinem, Philomela in lusciniam.</p>
+               <p>
+                  <milestone unit="par" n="1"/> Tereus rex Thracum fuit, qui cum Pandionis,
+                  Athenarum regis, filiam Prognen nomine duxisset uxorem et post aliquantum tempus
+                  ab ea rogaretur sibi Philomelam sororem uidendam accersiret, profectus Athenas,
+                  dum abducit puellam, eam uitiauit in itinere et ei linguam, ne facinus indicaret,
+                  abscidit. <milestone unit="par" n="2"/> Illa tamen rem, in ueste suo cruore
+                  descriptam, misit sorori; qua cognita Progne Ityn filium interemit et patri
+                  epulandum apposuit. <milestone unit="par" n="3"/> Postea omnes in aues mutati
+                  sunt: Tereus in upupam, Itys in phassam, Progne in hirundinem, Philomela in
+                  lusciniam.</p>
             </div>
 
             <div type="cap" n="5">
                <head> Fabula Cyclopis et Aci<supplied>dis</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cyclops dicitur nympham amasse Galateam; quae cum Acin quendam pastorem <supplied>amaret</supplied> et Polyphemum sperneret, ille iratus Acin necauit. <milestone unit="par" n="2"/> Qui postea Galateae miseratione in fontem mutatus est, qui hodieque <unclear>acinea</unclear> Acilius dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cyclops dicitur nympham amasse Galateam; quae cum
+                  Acin quendam pastorem <supplied>amaret</supplied> et Polyphemum sperneret, ille
+                  iratus Acin necauit. <milestone unit="par" n="2"/> Qui postea Galateae miseratione
+                  in fontem mutatus est, qui hodieque <unclear>acinea</unclear> Acilius dicitur.
+               </p>
             </div>
 
             <div type="cap" n="6">
                <head> Fabula Siluani et Cyparissi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Siluanus deus est siluarum. <milestone unit="par" n="2"/> Hic amauit puerum, Cyparissum nomine, qui habebat mansuetissimam ceruam; hanc cum Siluanus nescius occidisset, puer extinctus est dolore. <milestone unit="par" n="3"/> Quem amator deus in cypressum arborem nominis eius conuertit, quam pro solacio portare dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Siluanus deus est siluarum. <milestone unit="par"
+                     n="2"/> Hic amauit puerum, Cyparissum nomine, qui habebat mansuetissimam
+                  ceruam; hanc cum Siluanus nescius occidisset, puer extinctus est dolore.
+                     <milestone unit="par" n="3"/> Quem amator deus in cypressum arborem nominis
+                  eius conuertit, quam pro solacio portare dicitur. </p>
             </div>
 
             <div type="cap" n="7">
                <head> Fabula Cereris et Proserpinae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ceres cum raptam a Plutone Proserpinam filiam diu quaesisset, tandem aliquando eam esse apud inferos comperit, quia a Plutone, siue Orco, fratre Iouis rapta fuerat. <milestone unit="par" n="2"/> Pro qua re cum Iouis implorasset auxilium, ille respondit posse eam reuerti, si nihil apud inferos gustasset. <milestone unit="par" n="3"/> Illa autem Punici mali in Elysio grana gustauerat, quam rem Ascalaphus, Stygis filius, prodidit; inde Proserpina ad <del>ad</del> superos remeare non potuit. <milestone unit="par" n="4"/> Sane Ceres postea meruisse dicitur, ut Proserpina sex esset cum matre mensibus, sex cum marito. <milestone unit="par" n="5"/> Quod ideo fingitur quia Proserpina ipsa est et luna, quae toto anno sex mensibus crescit, sex deficit — scilicet per singulos menses quindenis diebus —, ut crescens apud superos et deficiens apud inferos uideatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Ceres cum raptam a Plutone Proserpinam filiam diu
+                  quaesisset, tandem aliquando eam esse apud inferos comperit, quia a Plutone, siue
+                  Orco, fratre Iouis rapta fuerat. <milestone unit="par" n="2"/> Pro qua re cum
+                  Iouis implorasset auxilium, ille respondit posse eam reuerti, si nihil apud
+                  inferos gustasset. <milestone unit="par" n="3"/> Illa autem Punici mali in Elysio
+                  grana gustauerat, quam rem Ascalaphus, Stygis filius, prodidit; inde Proserpina ad
+                     <del>ad</del> superos remeare non potuit. <milestone unit="par" n="4"/> Sane
+                  Ceres postea meruisse dicitur, ut Proserpina sex esset cum matre mensibus, sex cum
+                  marito. <milestone unit="par" n="5"/> Quod ideo fingitur quia Proserpina ipsa est
+                  et luna, quae toto anno sex mensibus crescit, sex deficit — scilicet per singulos
+                  menses quindenis diebus —, ut crescens apud superos et deficiens apud inferos
+                  uideatur. </p>
             </div>
 
             <div type="cap" n="8">
                <head> Fabula Celei et Triptol<supplied>emi</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Eleusin ciuitas est Atticae prouinciae, haud longe ab Athenis. <milestone unit="par" n="2"/> In qua cum regnaret Celeus et Cererem, quaerentem filiam, liberalissime suscepisset hospitio, illa pro remuneratione ostendit ei omne genus agriculturae. <milestone unit="par" n="3"/> Filium etiam ei Triptolemum recens natum per noctem igne fouit, per diem diuino lacte nutriuit et eum alatis serpentibus superpositum per totum orbem misit ad usum frumentorum hominibus indicandum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Eleusin ciuitas est Atticae prouinciae, haud longe
+                  ab Athenis. <milestone unit="par" n="2"/> In qua cum regnaret Celeus et Cererem,
+                  quaerentem filiam, liberalissime suscepisset hospitio, illa pro remuneratione
+                  ostendit ei omne genus agriculturae. <milestone unit="par" n="3"/> Filium etiam ei
+                  Triptolemum recens natum per noctem igne fouit, per diem diuino lacte nutriuit et
+                  eum alatis serpentibus superpositum per totum orbem misit ad usum frumentorum
+                  hominibus indicandum. </p>
             </div>
 
             <div type="cap" n="9">
                <head> Fabula Cey<supplied>ci</supplied>s et Alcyone<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ceyx, filius Luciferi, habuit uxorem Alcyonem. <milestone unit="par" n="2"/> A qua cum prohibitus isset ad consulendum Apollinem de statu regni sui, naufragio periit; cuius corpus cum ad uxorem Alcyonem fuisset delatum, illa se praecipitauit in pelagus. <milestone unit="par" n="3"/> Postea miseratione Thetidis et Luciferi conuersi sunt ambo in aues marinas, quae alcyones uocantur. <milestone unit="par" n="4"/> Istae autem aues nidos faciunt in mari media hieme, quibus diebus tanta est tranquillitas, ut penitus in mari nihil possit moueri; inde et dies ipsi Alcyonia nominantur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Ceyx, filius Luciferi, habuit uxorem Alcyonem.
+                     <milestone unit="par" n="2"/> A qua cum prohibitus isset ad consulendum
+                  Apollinem de statu regni sui, naufragio periit; cuius corpus cum ad uxorem
+                  Alcyonem fuisset delatum, illa se praecipitauit in pelagus. <milestone unit="par"
+                     n="3"/> Postea miseratione Thetidis et Luciferi conuersi sunt ambo in aues
+                  marinas, quae alcyones uocantur. <milestone unit="par" n="4"/> Istae autem aues
+                  nidos faciunt in mari media hieme, quibus diebus tanta est tranquillitas, ut
+                  penitus in mari nihil possit moueri; inde et dies ipsi Alcyonia nominantur. </p>
             </div>
 
             <div type="cap" n="10">
                <head> Fabula Cereris et Lyciorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum Ceres filiam suam Proserpinam quaereret, ad releuandam sitim accessit ad quendam fontem. <milestone unit="par" n="2"/> Tunc Lycii rustici, a potu eam prohibentes, aquam pedibus conturbauerunt suis; et dum contra eam turpem sonum emittere<supplied>n</supplied>t, illa irata eos in <supplied>ranas conuertit, quae nunc quoque ad illius soni imitationem coaxant. <milestone unit="par" n="3"/> Postea Lycum regem</supplied> Scythiae, qui Triptolemum occidere uoluera<del>n</del>t, in lyncem feram conuertit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum Ceres filiam suam Proserpinam quaereret, ad
+                  releuandam sitim accessit ad quendam fontem. <milestone unit="par" n="2"/> Tunc
+                  Lycii rustici, a potu eam prohibentes, aquam pedibus conturbauerunt suis; et dum
+                  contra eam turpem sonum emittere<supplied>n</supplied>t, illa irata eos in
+                     <supplied>ranas conuertit, quae nunc quoque ad illius soni imitationem coaxant.
+                        <milestone unit="par" n="3"/> Postea Lycum regem</supplied> Scythiae, qui
+                  Triptolemum occidere uoluera<del>n</del>t, in lyncem feram conuertit. </p>
             </div>
 
             <div type="cap" n="11">
                <head> Fabula Titanum gigantum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Titanas — gigantes —Terra, id est Ceres, irata ob sui <unclear>ad nisas tantali</unclear> derisione<supplied>m</supplied> genuit ex se contra Saturnum et postea contra Iouem, sed et ad omnes deos expellendos, in eius ultionem. <milestone unit="par" n="2"/> Qui montium supra montes aggestu et congerie in caelum uoluerunt ascendere et deos inde propellere. <milestone unit="par" n="3"/> Ad quos oppugnandos Iuppiter omnes deos conuocauit et uenerunt inter ceteros Liber pater, Vulcanus, Satyri, Sileni, asellis uecti. <milestone unit="par" n="4"/> Quorum uidelicet asinorum exterritorum nimio confuso clamore, gigantibus inaudito, hostes Titanae territi fug<del>i</del>ere, <milestone unit="par" n="5"/> quamuis antea et ipsi dii a Typhoei gigantis aspectu perterriti in diuersa monstra et animalia transformati aufugissent. <milestone unit="par" n="6"/> Iuppiter autem auxilio aquilae, quae fulmina sibi portans ministrabat, eos deuicit et in Aetna conclusit absque uno Titane, id est Sole. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Titanas — gigantes —Terra, id est Ceres, irata ob
+                  sui <unclear>ad nisas tantali</unclear> derisione<supplied>m</supplied> genuit ex
+                  se contra Saturnum et postea contra Iouem, sed et ad omnes deos expellendos, in
+                  eius ultionem. <milestone unit="par" n="2"/> Qui montium supra montes aggestu et
+                  congerie in caelum uoluerunt ascendere et deos inde propellere. <milestone
+                     unit="par" n="3"/> Ad quos oppugnandos Iuppiter omnes deos conuocauit et
+                  uenerunt inter ceteros Liber pater, Vulcanus, Satyri, Sileni, asellis uecti.
+                     <milestone unit="par" n="4"/> Quorum uidelicet asinorum exterritorum nimio
+                  confuso clamore, gigantibus inaudito, hostes Titanae territi fug<del>i</del>ere,
+                     <milestone unit="par" n="5"/> quamuis antea et ipsi dii a Typhoei gigantis
+                  aspectu perterriti in diuersa monstra et animalia transformati aufugissent.
+                     <milestone unit="par" n="6"/> Iuppiter autem auxilio aquilae, quae fulmina sibi
+                  portans ministrabat, eos deuicit et in Aetna conclusit absque uno Titane, id est
+                  Sole. </p>
             </div>
 
             <div type="cap" n="12">
-               <head> 
+               <head>
                   <supplied>Fabula Tantali</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tantalus, pater Pelopis, gigas, uolens probare diuinitatem deorum Pelopem filium suum eis ad epulandum posuit. <milestone unit="par" n="2"/> Vnde pro hac feritate damnatus est, ut in Eridano stans flumine siti pereat fameque laborans poma, quae sunt in praefati fluminis ripa, uide<supplied>a</supplied>t ne<supplied>c</supplied> contingat. <milestone unit="par" n="3"/> Postea dii petente Tantalo cum uoluisse<supplied>n</supplied>t filium eius reuocare ab inferis, Ceres, quae in conuiuio ceteris diis abstinentibus sola brachium Pelopis consumpserat, eburneum brachium ei restituit. <milestone unit="par" n="4"/> Quod ideo fingitur, quia Ceres ipsa est terra, quae uniuersa corpora consumit, ossa tamen reseruans. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tantalus, pater Pelopis, gigas, uolens probare
+                  diuinitatem deorum Pelopem filium suum eis ad epulandum posuit. <milestone
+                     unit="par" n="2"/> Vnde pro hac feritate damnatus est, ut in Eridano stans
+                  flumine siti pereat fameque laborans poma, quae sunt in praefati fluminis ripa,
+                     uide<supplied>a</supplied>t ne<supplied>c</supplied> contingat. <milestone
+                     unit="par" n="3"/> Postea dii petente Tantalo cum
+                     uoluisse<supplied>n</supplied>t filium eius reuocare ab inferis, Ceres, quae in
+                  conuiuio ceteris diis abstinentibus sola brachium Pelopis consumpserat, eburneum
+                  brachium ei restituit. <milestone unit="par" n="4"/> Quod ideo fingitur, quia
+                  Ceres ipsa est terra, quae uniuersa corpora consumit, ossa tamen reseruans. </p>
             </div>
 
             <div type="cap" n="13">
                <head> Fabula Tityi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tityus unus fuit gigantum. <milestone unit="par" n="2"/> Qui uolens cum Latona concumbere sagittis Apollinis et Dianae interfectus est et ita damnatus est apud inferos, ut duo uultures ei appositi et sibi succedentes iecur illius comedant, semper ad rediuivam renascens poenam. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tityus unus fuit gigantum. <milestone unit="par"
+                     n="2"/> Qui uolens cum Latona concumbere sagittis Apollinis et Dianae
+                  interfectus est et ita damnatus est apud inferos, ut duo uultures ei appositi et
+                  sibi succedentes iecur illius comedant, semper ad rediuivam renascens poenam. </p>
             </div>
 
             <div type="cap" n="14">
                <head> Fabula Ixionis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ixion gigas uolens concumbere cum Iunone, opposita ei est nubes, cum qua concubuit. <milestone unit="par" n="2"/> Et cum inde iactaret se quasi de concubitu Iunonis, hac lege damnatus est, ut rotam serpentibus innexam semper contra montem apud inferos uoluat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Ixion gigas uolens concumbere cum Iunone, opposita
+                  ei est nubes, cum qua concubuit. <milestone unit="par" n="2"/> Et cum inde
+                  iactaret se quasi de concubitu Iunonis, hac lege damnatus est, ut rotam
+                  serpentibus innexam semper contra montem apud inferos uoluat. </p>
             </div>
 
             <div type="cap" n="15">
                <head> Fabula Circe<supplied>s</supplied> et Vlixis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Circe, Solis filia, in insula Maeonia sedens, delatos ad se in feras mutabat. <milestone unit="par" n="2"/> Ad hanc forte delatus Vlixes, Eurylochum cum uiginti et duobus sociis misit, quos ab humana specie commutauit; sed Eurylochus inde fugit et Vlixi nuntiauit. <milestone unit="par" n="3"/> Is solus ad eam proficiscebatur, cui in itinere Mercurius remedium dedit monstrauitque quomodo Circen deciperet. <milestone unit="par" n="4"/> Qui postquam ad eam uenit, ab ea poculo accepto Mercurii remedium miscuit et eduxit ensem eique minatus est, ut sibi socios restitueret. <milestone unit="par" n="5"/> Tunc Circe sensit sine uoluntate deorum non hoc factum esse fideque data socios ei restituit. <milestone unit="par" n="6"/> Ipse uero cum ea concubuit et Telegonum ex ea procreauit. <milestone unit="par" n="7"/> Cuius manu postea occisus occub<supplied>u</supplied>it. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Circe, Solis filia, in insula Maeonia sedens,
+                  delatos ad se in feras mutabat. <milestone unit="par" n="2"/> Ad hanc forte
+                  delatus Vlixes, Eurylochum cum uiginti et duobus sociis misit, quos ab humana
+                  specie commutauit; sed Eurylochus inde fugit et Vlixi nuntiauit. <milestone
+                     unit="par" n="3"/> Is solus ad eam proficiscebatur, cui in itinere Mercurius
+                  remedium dedit monstrauitque quomodo Circen deciperet. <milestone unit="par" n="4"
+                  /> Qui postquam ad eam uenit, ab ea poculo accepto Mercurii remedium miscuit et
+                  eduxit ensem eique minatus est, ut sibi socios restitueret. <milestone unit="par"
+                     n="5"/> Tunc Circe sensit sine uoluntate deorum non hoc factum esse fideque
+                  data socios ei restituit. <milestone unit="par" n="6"/> Ipse uero cum ea concubuit
+                  et Telegonum ex ea procreauit. <milestone unit="par" n="7"/> Cuius manu postea
+                  occisus occub<supplied>u</supplied>it. </p>
             </div>
 
             <div type="cap" n="16">
                <head> Fabula Tiresiae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tiresias dum iret per siluam, uidit duos serpentes coire; quos cum uirga percussisset, in feminam mutatus est. <milestone unit="par" n="2"/> Post octo annos dum uideret eos similiter concumbentes et eos rursus percuteret, in pristinam restitutus est naturam. <milestone unit="par" n="3"/> Et cum inter Iouem et Iunonem lis esset, in quo sexu maior esset uoluptas libidinis, adhibitus est iste iudex, qui utrumque sexum fuerat expertus et inter<supplied>ro</supplied>gatus dixit femineam uoluptatem triplo maiorem esse uirili. <milestone unit="par" n="4"/> Pro qua re Iuno irata priuauit eum oculis, quasi gratiosum in Iouem et iniuriosum in se; pro qua iniuria cum obcaecatus esset, Iuppiter futurorum <supplied>ei</supplied> praebuit praescientiam. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tiresias dum iret per siluam, uidit duos serpentes
+                  coire; quos cum uirga percussisset, in feminam mutatus est. <milestone unit="par"
+                     n="2"/> Post octo annos dum uideret eos similiter concumbentes et eos rursus
+                  percuteret, in pristinam restitutus est naturam. <milestone unit="par" n="3"/> Et
+                  cum inter Iouem et Iunonem lis esset, in quo sexu maior esset uoluptas libidinis,
+                  adhibitus est iste iudex, qui utrumque sexum fuerat expertus et
+                     inter<supplied>ro</supplied>gatus dixit femineam uoluptatem triplo maiorem esse
+                  uirili. <milestone unit="par" n="4"/> Pro qua re Iuno irata priuauit eum oculis,
+                  quasi gratiosum in Iouem et iniuriosum in se; pro qua iniuria cum obcaecatus
+                  esset, Iuppiter futurorum <supplied>ei</supplied> praebuit praescientiam. </p>
             </div>
 
             <div type="cap" n="17">
                <head> Fabula Lycaonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter, humani sceleris impatiens, simulata hominis specie ad Lycaonem regem Arcadiae uenit, qui sibi quasi mortali praeparans mortem humana membra deuoranda ei apposuit. <milestone unit="par" n="2"/> Quae postquam Iuppiter sensit, non eum penitus interemit, sed, ne supplicii amitteret sensum, lupi eum in formam conuertit; qui et adhuc mores in rabie et nomen Lycaonis in appellatione seruat. </p>
                <p>
-                  <milestone unit="par" n="3"/>  Idem Lycaon habuerat filiam Callisto; quam cum uitiasset Iuppiter, Iuno eam in ursam conuertit; et postea Iuppiter miseratus in signum transtulit caeleste. </p>
+                  <milestone unit="par" n="1"/> Iuppiter, humani sceleris impatiens, simulata
+                  hominis specie ad Lycaonem regem Arcadiae uenit, qui sibi quasi mortali praeparans
+                  mortem humana membra deuoranda ei apposuit. <milestone unit="par" n="2"/> Quae
+                  postquam Iuppiter sensit, non eum penitus interemit, sed, ne supplicii amitteret
+                  sensum, lupi eum in formam conuertit; qui et adhuc mores in rabie et nomen
+                  Lycaonis in appellatione seruat. </p>
+               <p>
+                  <milestone unit="par" n="3"/> Idem Lycaon habuerat filiam Callisto; quam cum
+                  uitiasset Iuppiter, Iuno eam in ursam conuertit; et postea Iuppiter miseratus in
+                  signum transtulit caeleste. </p>
             </div>
 
             <div type="cap" n="18">
                <head> Fabula Io<supplied>nis</supplied> et Argi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Io, Inachi regis — uel amnis — filia, cum aequales specie sua praecederet, a Ioue adamata est, qui admotis precibus desiderium expleuit; et, ne puella Iunonis iram procideret, a compressore in uaccam transfigurata est. <milestone unit="par" n="2"/> Cuius cum Iuno fallaciam deprehendisset, petiit uaccam a Ioue uelut munus sibi dari, eo quod speciosior esset ceteris armentis, quae in Peloponeso cernuntur; Iuppiter uero, ne si negasset proderet puellam, tradidit. <milestone unit="par" n="3"/> At Iuno, ne pellex eius amplius Ioue potiretur, Argum, centum ocul<del>u</del>os habentem, ei custodem praefecit, quem Mercurius iussu Iouis interemit. <milestone unit="par" n="4"/> Iuno Argum, quia ob custodiam sibi mortu<supplied>u</supplied>s est, in pauonem transformauit et receptum in suam tutelam pennis insignibus <supplied>quibus</supplied> amissa lumina <supplied>indicaret</supplied> exornauit. <milestone unit="par" n="5"/> Io cum Furiis exagitata orbem terrarum percurrisset, nouissime in Aegyptum delata est; ibi placata Iunone a Ioue pristinam formam recepit atque nominabatur Isis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Io, Inachi regis — uel amnis — filia, cum aequales
+                  specie sua praecederet, a Ioue adamata est, qui admotis precibus desiderium
+                  expleuit; et, ne puella Iunonis iram procideret, a compressore in uaccam
+                  transfigurata est. <milestone unit="par" n="2"/> Cuius cum Iuno fallaciam
+                  deprehendisset, petiit uaccam a Ioue uelut munus sibi dari, eo quod speciosior
+                  esset ceteris armentis, quae in Peloponeso cernuntur; Iuppiter uero, ne si
+                  negasset proderet puellam, tradidit. <milestone unit="par" n="3"/> At Iuno, ne
+                  pellex eius amplius Ioue potiretur, Argum, centum ocul<del>u</del>os habentem, ei
+                  custodem praefecit, quem Mercurius iussu Iouis interemit. <milestone unit="par"
+                     n="4"/> Iuno Argum, quia ob custodiam sibi mortu<supplied>u</supplied>s est, in
+                  pauonem transformauit et receptum in suam tutelam pennis insignibus
+                     <supplied>quibus</supplied> amissa lumina <supplied>indicaret</supplied>
+                  exornauit. <milestone unit="par" n="5"/> Io cum Furiis exagitata orbem terrarum
+                  percurrisset, nouissime in Aegyptum delata est; ibi placata Iunone a Ioue
+                  pristinam formam recepit atque nominabatur Isis. </p>
             </div>
 
             <div type="cap" n="19">
                <head> Fabula Icari et Erigonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Icarus, pater Erigonis, cum acceptum a Libero patre uinum mortalibus indicaret, occisus est a rusticis, qui, cum plus aequo potassent ebriati, se uenenum accepisse crediderant. <milestone unit="par" n="2"/> Huius canis est reuersus ad Erigonem filiam, quae, cum eius comitata uestigia peruenisset ad patris cadauer, laqueo uitam finiuit. <milestone unit="par" n="3"/> Haec deorum miseratione inter astra relata est, quam uirginem uocant; canis quoque ille inter sidera collocatus. <milestone unit="par" n="4"/> Sed post aliquantum tempus Atheniensibus mor<del>i</del>bus immissus est talis, ut eorum uirgines quodam furore compellerentur ad laqueum responditque oraculum sedari posse illam pestilentiam, si Erigonis et Icari cadauera require<del>i</del>rentur. <milestone unit="par" n="5"/> Quae cum diu quaesita nusquam inuenirentur, ad ostend<supplied>end</supplied>am suam deuotionem Athenienses, ut et in alieno ea querere uiderentur elemento, suspenderunt de arboribus funem, ad quem se tenentes homines huc atque illuc agitabantur, ut quasi et per aerem illorum cadauera quaerere uiderentur. <milestone unit="par" n="6"/> Sed cum inde plerique caderent, inuentum est, ut formas ad oris sui similitudinem facerent et eas pro se suspensas mouerent; unde oscilla dicta sunt ab eo, quod in his <del>s</del>cillerentur — id est mouerentur — ora. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Icarus, pater Erigonis, cum acceptum a Libero patre
+                  uinum mortalibus indicaret, occisus est a rusticis, qui, cum plus aequo potassent
+                  ebriati, se uenenum accepisse crediderant. <milestone unit="par" n="2"/> Huius
+                  canis est reuersus ad Erigonem filiam, quae, cum eius comitata uestigia
+                  peruenisset ad patris cadauer, laqueo uitam finiuit. <milestone unit="par" n="3"/>
+                  Haec deorum miseratione inter astra relata est, quam uirginem uocant; canis quoque
+                  ille inter sidera collocatus. <milestone unit="par" n="4"/> Sed post aliquantum
+                  tempus Atheniensibus mor<del>i</del>bus immissus est talis, ut eorum uirgines
+                  quodam furore compellerentur ad laqueum responditque oraculum sedari posse illam
+                  pestilentiam, si Erigonis et Icari cadauera require<del>i</del>rentur. <milestone
+                     unit="par" n="5"/> Quae cum diu quaesita nusquam inuenirentur, ad
+                     ostend<supplied>end</supplied>am suam deuotionem Athenienses, ut et in alieno
+                  ea querere uiderentur elemento, suspenderunt de arboribus funem, ad quem se
+                  tenentes homines huc atque illuc agitabantur, ut quasi et per aerem illorum
+                  cadauera quaerere uiderentur. <milestone unit="par" n="6"/> Sed cum inde plerique
+                  caderent, inuentum est, ut formas ad oris sui similitudinem facerent et eas pro se
+                  suspensas mouerent; unde oscilla dicta sunt ab eo, quod in his
+                  <del>s</del>cillerentur — id est mouerentur — ora. </p>
             </div>
 
             <div type="cap" n="20">
                <head> Fabula Iphigeniae et Orestis et Pyladis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Graeci dum irent contra Troiam et ad insulam quae Aulide uocabatur uenissent, Agamemnon rex uolens se sagittis exercere uidit ceruam Dianae, quam eius ignorans esse interfecit. <milestone unit="par" n="2"/> Ventis autem contrariis ibi diu detenti, ex oraculo Apollinis responsum est Agamemnonio sanguine uentos esse placandos. <milestone unit="par" n="3"/> Tunc Vlixes — ut erat astutissimus — in patriam reuersus filiarn Agamemnonis Iphigeniam simulans nuptias secum adduxit. <milestone unit="par" n="4"/> Adducta autem cum iam in eo esset ut immolaretur, Minerua miserta circumstantium oculis nubem opposuit et pro eadem ceruam, ut dicitur, apposuit. <milestone unit="par" n="5"/> Illa autem translata ad Tauricam regionem Scytharum regi Thoanti tradita est. <milestone unit="par" n="6"/> Sacerdosque facta Dictynnae Dianae, dum, secundum statutam consuetudinem, umano sanguine et maxime hospitum numen placaret, agnouit fratrem Orestem, qui accepto oraculo carendi furoris causa cum amico fidissimo Pylade Colchos petierat. <milestone unit="par" n="7"/> Et cum his occiso<del>s</del> Thoante simulacrum sustulit, absconditum fasce lignorum — unde et fascellis dicitur, non tantum a face cum qua pingitur —, et Ariciam detulit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Graeci dum irent contra Troiam et ad insulam quae
+                  Aulide uocabatur uenissent, Agamemnon rex uolens se sagittis exercere uidit ceruam
+                  Dianae, quam eius ignorans esse interfecit. <milestone unit="par" n="2"/> Ventis
+                  autem contrariis ibi diu detenti, ex oraculo Apollinis responsum est Agamemnonio
+                  sanguine uentos esse placandos. <milestone unit="par" n="3"/> Tunc Vlixes — ut
+                  erat astutissimus — in patriam reuersus filiarn Agamemnonis Iphigeniam simulans
+                  nuptias secum adduxit. <milestone unit="par" n="4"/> Adducta autem cum iam in eo
+                  esset ut immolaretur, Minerua miserta circumstantium oculis nubem opposuit et pro
+                  eadem ceruam, ut dicitur, apposuit. <milestone unit="par" n="5"/> Illa autem
+                  translata ad Tauricam regionem Scytharum regi Thoanti tradita est. <milestone
+                     unit="par" n="6"/> Sacerdosque facta Dictynnae Dianae, dum, secundum statutam
+                  consuetudinem, umano sanguine et maxime hospitum numen placaret, agnouit fratrem
+                  Orestem, qui accepto oraculo carendi furoris causa cum amico fidissimo Pylade
+                  Colchos petierat. <milestone unit="par" n="7"/> Et cum his occiso<del>s</del>
+                  Thoante simulacrum sustulit, absconditum fasce lignorum — unde et fascellis
+                  dicitur, non tantum a face cum qua pingitur —, et Ariciam detulit. </p>
             </div>
 
             <div type="cap" n="21">
                <head> Fabula Hippodame<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hippodame filia fuit Oenomai, regis Elidis et Pisarum; hic equos habuit uelocissimos, utpote uentorum flatu creatos. <milestone unit="par" n="2"/> Qui procos filiae multos necauit, sub hac condicione prouocatos ad curule certamen, ut aut <supplied>uictus</supplied> traderet filiam, aut uictos necaret. <milestone unit="par" n="3"/> Postea, cum Pelopem amasset, Hippodamia corrupit Myrtilum, aurigam patris, primi coitus pactione. <milestone unit="par" n="4"/> Qui factis cereis axibus, cum uictore Pelope a puella promissum posceret praemium, ab eius praecipitatus est marito in mare, cui nomen imposuit; nam ab eo Myrte<del>t</del>um dicitur pelagus. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hippodame filia fuit Oenomai, regis Elidis et
+                  Pisarum; hic equos habuit uelocissimos, utpote uentorum flatu creatos. <milestone
+                     unit="par" n="2"/> Qui procos filiae multos necauit, sub hac condicione
+                  prouocatos ad curule certamen, ut aut <supplied>uictus</supplied> traderet filiam,
+                  aut uictos necaret. <milestone unit="par" n="3"/> Postea, cum Pelopem amasset,
+                  Hippodamia corrupit Myrtilum, aurigam patris, primi coitus pactione. <milestone
+                     unit="par" n="4"/> Qui factis cereis axibus, cum uictore Pelope a puella
+                  promissum posceret praemium, ab eius praecipitatus est marito in mare, cui nomen
+                  imposuit; nam ab eo Myrte<del>t</del>um dicitur pelagus. </p>
             </div>
 
             <div type="cap" n="22">
                <head> Fabula Myrtili, Atrei et Thyestae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Mercurius, aegre ferens a Pelope Myrtilum, filium suum, in mare praecipitatum spoliatumque uitae lege, repperit uindictam, qua consolaretur o<supplied>r</supplied>bitatem. <milestone unit="par" n="2"/> Nam Pelopis filiis, Atreo et Thyestae, tantum discordiae iniecit, ut germanitatis iura disrumperent. <milestone unit="par" n="3"/> Cum igitur alternis uicibus regnum regerent et sciret Thyestes regnum penes eum fataliter mansurum, qui arietem aurei uelleris haberet — quem tum Atreus regnum ingressus custodiebat —, corrumpens Europam, fratris sui uxorem, eum ad se transferri posse sperabat. <milestone unit="par" n="4"/> Quod ille postquam didicit, eum cum duobus filiis suis expulit et postea simulata gratia ad eum misit eique ad se uocatos filios suos interemptos apposuit epulandos; eique post epulas filiorum capita signum conuiuii ostendit feralis. <milestone unit="par" n="5"/> In cuius rei ultionem cum Thyestes consulta de oraculis posceret, responsum est per eum certam uenire uindictam, qui ex ipso et filia Pelopia natus esset. <milestone unit="par" n="6"/> Vnde ille cito amplexus filiae inuadit, ex qua natus est puer, quem illa in siluas propter conscientiam incestus abiecit; hic caprae uberibus nutritus ex eadem re Aegisthus nomen accepit. <milestone unit="par" n="7"/> Atreum uero in uindictam patris, cum adoleuisset, occidit. <milestone unit="par" n="8"/> Idem et Agamemnonem, cum Clytemnestram uxorem eius adulterasset, occidit. <milestone unit="par" n="9"/> Qui postea ab Oreste, filio Agamemnonis, cum ea quam adulterauerat occisus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Mercurius, aegre ferens a Pelope Myrtilum, filium
+                  suum, in mare praecipitatum spoliatumque uitae lege, repperit uindictam, qua
+                  consolaretur o<supplied>r</supplied>bitatem. <milestone unit="par" n="2"/> Nam
+                  Pelopis filiis, Atreo et Thyestae, tantum discordiae iniecit, ut germanitatis iura
+                  disrumperent. <milestone unit="par" n="3"/> Cum igitur alternis uicibus regnum
+                  regerent et sciret Thyestes regnum penes eum fataliter mansurum, qui arietem aurei
+                  uelleris haberet — quem tum Atreus regnum ingressus custodiebat —, corrumpens
+                  Europam, fratris sui uxorem, eum ad se transferri posse sperabat. <milestone
+                     unit="par" n="4"/> Quod ille postquam didicit, eum cum duobus filiis suis
+                  expulit et postea simulata gratia ad eum misit eique ad se uocatos filios suos
+                  interemptos apposuit epulandos; eique post epulas filiorum capita signum conuiuii
+                  ostendit feralis. <milestone unit="par" n="5"/> In cuius rei ultionem cum Thyestes
+                  consulta de oraculis posceret, responsum est per eum certam uenire uindictam, qui
+                  ex ipso et filia Pelopia natus esset. <milestone unit="par" n="6"/> Vnde ille cito
+                  amplexus filiae inuadit, ex qua natus est puer, quem illa in siluas propter
+                  conscientiam incestus abiecit; hic caprae uberibus nutritus ex eadem re Aegisthus
+                  nomen accepit. <milestone unit="par" n="7"/> Atreum uero in uindictam patris, cum
+                  adoleuisset, occidit. <milestone unit="par" n="8"/> Idem et Agamemnonem, cum
+                  Clytemnestram uxorem eius adulterasset, occidit. <milestone unit="par" n="9"/> Qui
+                  postea ab Oreste, filio Agamemnonis, cum ea quam adulterauerat occisus est. </p>
             </div>
 
             <div type="cap" n="23">
                <head> Fabula Phrixi et Helle<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phrixus et Helles, frater et soror, Athamantis regis et Neobolis filii fuerunt. <milestone unit="par" n="2"/> Hii insania a Libero abiecti cum in silua errarent, Neobola mater eorum dicitur uenisse et arietem uellere aureo insignitum exhibuisse, in quo praedictos filios suos iussit ascendere et in Colchos ad regem Oetam transire<del>t</del> ibique arietem immolare. <milestone unit="par" n="3"/> Vel aliter. <milestone unit="par" n="4"/> Cum Neobole, quae et Nubes, insania Liberi patris concita siluam peteret, ne larem mariti repeteret, filiis suis Phrixo et Hellae Athamas nouercam nomine Ino superduxit. <milestone unit="par" n="5"/> Quae nouercali odio pueris exitium machinans, matronas petiit ut frumenta serenda corrumperent; quo facto fames innata est. <milestone unit="par" n="6"/> Cum ad Apollinem consultum ciuitas misisset, Ino eum, qui missus fuit, corrupit, ut referret oraculo dictum filios Nubis immolandos; nam et ipsa dixit eos frumenta incendisse. <milestone unit="par" n="7"/> Pater, timens populi inuidiam, filios suos arbitrio nouercae commisit, sed occulte illis remedium dedit. <milestone unit="par" n="8"/> Nam Phrixum mortis suae ignarum submisit, ut arietem aureum uellus habentem adduceret; qui Iunonis nut<supplied>u</supplied> ammonitus ut cum sorore fugeret, <del>et</del> confestim se cum ea morti subtraxit. <milestone unit="par" n="9"/> Deinde cum arieti adhaerentes mare supernatarent, Helles puella in mare cecidit et nomen ponto dedit; nam ex illa Hellespontum dicitur. <milestone unit="par" n="10"/> Phrixus, ad Colchos delatus, arietem inunolauit et uellus aureum Martis templo dedicauit, quod draco custodiebat informis. <milestone unit="par" n="11"/> Oeta rex Phrixum libens recepit filiamque uxorem dedit. <milestone unit="par" n="12"/> Et cum ex ea liberos accepisset, ueritus est Oeta ne se a regno deiceret — quod ei responsum ex <supplied>prodi</supplied>giis fuerat — aduena, Aeoli progenie<supplied>s</supplied>. <milestone unit="par" n="13"/> 
-                  <supplied>Et cum</supplied> mortem caueret, Phrixum interfecit. <milestone unit="par" n="14"/> At filii eius ratem ascenderunt, ut ad auum Athalantem transirent; hos naufragos Aeson excepit. <milestone unit="par" n="15"/> Postea Iason Colchos profectus est pro uellere aureo tollendo et draconem occidit et uellus sustulit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phrixus et Helles, frater et soror, Athamantis regis
+                  et Neobolis filii fuerunt. <milestone unit="par" n="2"/> Hii insania a Libero
+                  abiecti cum in silua errarent, Neobola mater eorum dicitur uenisse et arietem
+                  uellere aureo insignitum exhibuisse, in quo praedictos filios suos iussit
+                  ascendere et in Colchos ad regem Oetam transire<del>t</del> ibique arietem
+                  immolare. <milestone unit="par" n="3"/> Vel aliter. <milestone unit="par" n="4"/>
+                  Cum Neobole, quae et Nubes, insania Liberi patris concita siluam peteret, ne larem
+                  mariti repeteret, filiis suis Phrixo et Hellae Athamas nouercam nomine Ino
+                  superduxit. <milestone unit="par" n="5"/> Quae nouercali odio pueris exitium
+                  machinans, matronas petiit ut frumenta serenda corrumperent; quo facto fames
+                  innata est. <milestone unit="par" n="6"/> Cum ad Apollinem consultum ciuitas
+                  misisset, Ino eum, qui missus fuit, corrupit, ut referret oraculo dictum filios
+                  Nubis immolandos; nam et ipsa dixit eos frumenta incendisse. <milestone unit="par"
+                     n="7"/> Pater, timens populi inuidiam, filios suos arbitrio nouercae commisit,
+                  sed occulte illis remedium dedit. <milestone unit="par" n="8"/> Nam Phrixum mortis
+                  suae ignarum submisit, ut arietem aureum uellus habentem adduceret; qui Iunonis
+                     nut<supplied>u</supplied> ammonitus ut cum sorore fugeret, <del>et</del>
+                  confestim se cum ea morti subtraxit. <milestone unit="par" n="9"/> Deinde cum
+                  arieti adhaerentes mare supernatarent, Helles puella in mare cecidit et nomen
+                  ponto dedit; nam ex illa Hellespontum dicitur. <milestone unit="par" n="10"/>
+                  Phrixus, ad Colchos delatus, arietem inunolauit et uellus aureum Martis templo
+                  dedicauit, quod draco custodiebat informis. <milestone unit="par" n="11"/> Oeta
+                  rex Phrixum libens recepit filiamque uxorem dedit. <milestone unit="par" n="12"/>
+                  Et cum ex ea liberos accepisset, ueritus est Oeta ne se a regno deiceret — quod ei
+                  responsum ex <supplied>prodi</supplied>giis fuerat — aduena, Aeoli
+                     progenie<supplied>s</supplied>. <milestone unit="par" n="13"/>
+                  <supplied>Et cum</supplied> mortem caueret, Phrixum interfecit. <milestone
+                     unit="par" n="14"/> At filii eius ratem ascenderunt, ut ad auum Athalantem
+                  transirent; hos naufragos Aeson excepit. <milestone unit="par" n="15"/> Postea
+                  Iason Colchos profectus est pro uellere aureo tollendo et draconem occidit et
+                  uellus sustulit. </p>
             </div>
 
             <div type="cap" n="24">
                <head> Historia de Pelia et Iasone.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pelias — uel Peleus —: rex Pelopontium, cuius frater erat Iason; quique Iason filium nomine Iasonem habuit. <milestone unit="par" n="2"/> Igitur praedictus Peleas filium fratris timuit ob uirtutem sui ac probitatem, ne se deiceret de regno, et ob hanc causam eum ad Colchos misit, <milestone unit="par" n="3"/> ut inde detulisset pellem auream, in qua Iouis in caelum ascendit; putauit enim causam ipsi esse mortis. <milestone unit="par" n="4"/> Argos autem quidam fecit nauim, a suo nomine quae dicta est Argo, a qua dicti sunt Argonautae Iason et socii eius. <milestone unit="par" n="5"/> Tiphys uero eius gubernator erat, quando nauigantes Colchos in uia peruenerunt Troiam. <milestone unit="par" n="6"/> Quos Laomedon, rex Troiae, in portum ire non permisit. <milestone unit="par" n="7"/> Deinde reuersi sunt, dicentes ea quae sibi Laomedon rex Troiae fecit. <milestone unit="par" n="8"/> Qua ex causa Peleas et Hercules Troiam uenerunt; ex quibus expugnata est et Laomedon intefectus. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pelias — uel Peleus —: rex Pelopontium, cuius frater
+                  erat Iason; quique Iason filium nomine Iasonem habuit. <milestone unit="par" n="2"
+                  /> Igitur praedictus Peleas filium fratris timuit ob uirtutem sui ac probitatem,
+                  ne se deiceret de regno, et ob hanc causam eum ad Colchos misit, <milestone
+                     unit="par" n="3"/> ut inde detulisset pellem auream, in qua Iouis in caelum
+                  ascendit; putauit enim causam ipsi esse mortis. <milestone unit="par" n="4"/>
+                  Argos autem quidam fecit nauim, a suo nomine quae dicta est Argo, a qua dicti sunt
+                  Argonautae Iason et socii eius. <milestone unit="par" n="5"/> Tiphys uero eius
+                  gubernator erat, quando nauigantes Colchos in uia peruenerunt Troiam. <milestone
+                     unit="par" n="6"/> Quos Laomedon, rex Troiae, in portum ire non permisit.
+                     <milestone unit="par" n="7"/> Deinde reuersi sunt, dicentes ea quae sibi
+                  Laomedon rex Troiae fecit. <milestone unit="par" n="8"/> Qua ex causa Peleas et
+                  Hercules Troiam uenerunt; ex quibus expugnata est et Laomedon intefectus. </p>
             </div>
 
             <div type="cap" n="25">
                <head> Fabula Iasonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iason cum responso Apollinis Colchos peteret ad rapiendum uellus aureum, quod Phrixus Mar<del>i</del>ti dicauerat, eo obtentu ut tauros, qui apud Colchos erant indomabiles, primum sub iuga mitteret, <milestone unit="par" n="2"/> Medea, summa ueneficarum, pulchritudinem eius mirata, egit suo ueneficio, ut tauros subiugaret et peruigilem draconem occideret. <milestone unit="par" n="3"/> Quo occiso eiusdem dentes seuit iunctis tauris Vulcani igne<supplied>m</supplied> efflantibus, unde <supplied>nati armati sunt, qui primum fecerunt impetum in Iasonem frustra, postea</supplied> mutuis <supplied>se</supplied> uulneribus conciderunt. <milestone unit="par" n="4"/> Has autem ei condiciones Aetes rex proposuerat, cui Apollo responderat tamdiu eum regnaturum, quamdiu illud uellus fuisset in templo. <milestone unit="par" n="5"/> Iason aureo uellere potitus postea Medeam uxorem habuit. <milestone unit="par" n="6"/> Sed cum induceret pellicem, nomine Glaucen, filiam Creontis, Medea dedit tunicam pellici suae infectam uenenis et allio; quam cum indueret, coepit cremari incendio. <milestone unit="par" n="7"/> Tunc Medea animum Iasonis contra se saeuientis non sustinens alato serpente aufugit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iason cum responso Apollinis Colchos peteret ad
+                  rapiendum uellus aureum, quod Phrixus Mar<del>i</del>ti dicauerat, eo obtentu ut
+                  tauros, qui apud Colchos erant indomabiles, primum sub iuga mitteret, <milestone
+                     unit="par" n="2"/> Medea, summa ueneficarum, pulchritudinem eius mirata, egit
+                  suo ueneficio, ut tauros subiugaret et peruigilem draconem occideret. <milestone
+                     unit="par" n="3"/> Quo occiso eiusdem dentes seuit iunctis tauris Vulcani
+                     igne<supplied>m</supplied> efflantibus, unde <supplied>nati armati sunt, qui
+                     primum fecerunt impetum in Iasonem frustra, postea</supplied> mutuis
+                     <supplied>se</supplied> uulneribus conciderunt. <milestone unit="par" n="4"/>
+                  Has autem ei condiciones Aetes rex proposuerat, cui Apollo responderat tamdiu eum
+                  regnaturum, quamdiu illud uellus fuisset in templo. <milestone unit="par" n="5"/>
+                  Iason aureo uellere potitus postea Medeam uxorem habuit. <milestone unit="par"
+                     n="6"/> Sed cum induceret pellicem, nomine Glaucen, filiam Creontis, Medea
+                  dedit tunicam pellici suae infectam uenenis et allio; quam cum indueret, coepit
+                  cremari incendio. <milestone unit="par" n="7"/> Tunc Medea animum Iasonis contra
+                  se saeuientis non sustinens alato serpente aufugit. </p>
             </div>
 
             <div type="cap" n="26">
                <head> Fabula Orithyiae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Orithyia — Erectes, regis Atheniensium, filia et Penthesileae, uirgo pulcherrima, ab Aquilone uento adamata est et nupta ex ipso duos filios habuit, Zetum et Calain, pennatos iuuenes. <milestone unit="par" n="2"/> Qui inter Argonautas cum Iasone fuerunt et a Phineo Harpyias fugauere. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Orithyia — Erectes, regis Atheniensium, filia et
+                  Penthesileae, uirgo pulcherrima, ab Aquilone uento adamata est et nupta ex ipso
+                  duos filios habuit, Zetum et Calain, pennatos iuuenes. <milestone unit="par" n="2"
+                  /> Qui inter Argonautas cum Iasone fuerunt et a Phineo Harpyias fugauere. </p>
             </div>
 
             <div type="cap" n="27">
                <head> Fabula Phinei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phineus rex fuit Arcadiae; hic suis liberis superduxit nouercam, cuius instinctu eos caecauit, ob quam rem irati dii ei oculos sustulerunt et adhibuerunt Harpyias. <milestone unit="par" n="2"/> Quae cum ei diu cibos arriperent, Iasonem, cum Argonautis propter uellus aureum Colchos petentem, suscepit hospitio, cui et ductorem dedit. <milestone unit="par" n="3"/> Hoc ergo beneficio illecti Argonautae Zetum et Calain, filios Boreae et Orithyiae, alatos iuuenes, ad pellendas Harpyias miserunt. <milestone unit="par" n="4"/> Quas cum strictis gladiis persequerentur pulsas de Arcadia, peruenerunt ad insulas, quae appellabantur Plotae, et, cum ulterius uellent tendere, ab Iride moniti ut desisterent a Iouis canibus, suos conuerterunt uolatus; quorum conuersio, id est strophe, nomen insulis dedit. <milestone unit="par" n="5"/> Vt autem canes Iouis dicerentur, haec ratio <supplied>est</supplied> quia ipsae Furiae dicuntur; unde et auari finguntur Furias pati, qui abstinent partis. <milestone unit="par" n="6"/> Sane apud inferos Furiae dicuntur et canes, apud superos Dirae et aues, in medio uero Harpyiae dicuntur; unde duplex in his inuenitur effigies. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phineus rex fuit Arcadiae; hic suis liberis
+                  superduxit nouercam, cuius instinctu eos caecauit, ob quam rem irati dii ei oculos
+                  sustulerunt et adhibuerunt Harpyias. <milestone unit="par" n="2"/> Quae cum ei diu
+                  cibos arriperent, Iasonem, cum Argonautis propter uellus aureum Colchos petentem,
+                  suscepit hospitio, cui et ductorem dedit. <milestone unit="par" n="3"/> Hoc ergo
+                  beneficio illecti Argonautae Zetum et Calain, filios Boreae et Orithyiae, alatos
+                  iuuenes, ad pellendas Harpyias miserunt. <milestone unit="par" n="4"/> Quas cum
+                  strictis gladiis persequerentur pulsas de Arcadia, peruenerunt ad insulas, quae
+                  appellabantur Plotae, et, cum ulterius uellent tendere, ab Iride moniti ut
+                  desisterent a Iouis canibus, suos conuerterunt uolatus; quorum conuersio, id est
+                  strophe, nomen insulis dedit. <milestone unit="par" n="5"/> Vt autem canes Iouis
+                  dicerentur, haec ratio <supplied>est</supplied> quia ipsae Furiae dicuntur; unde
+                  et auari finguntur Furias pati, qui abstinent partis. <milestone unit="par" n="6"
+                  /> Sane apud inferos Furiae dicuntur et canes, apud superos Dirae et aues, in
+                  medio uero Harpyiae dicuntur; unde duplex in his inuenitur effigies. </p>
             </div>
 
             <div type="cap" n="28">
                <head> Historia Leandri et Herus.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sestios et Abidon urbes uicinae erant et interfluentis maris arto diuisae; una earum celebris extitit per Leandrum, pulcherrimum iuuenem, altera per <del>C</del>heron pulcherrimam mulierem. <milestone unit="par" n="2"/> Quibus absentibus amor imis concaluit mentibus; iuuenis autem impatiens ignis omni modo quaerebat premendae uirginis copiam, sed nullo ad Heron terra<del>m</del> aditu inuento, simul calore et audacia impulsus, se ponto tradidit sicque natando singulas noctes puellam adiit, oblato ex aduerso turris lumine puellae studio, quo nocturnum iter ad eam dirigere posset. <milestone unit="par" n="3"/> Quadam uero nocte cum acrius solito imminens uentus faculam extingueret, errando et inscius quo cursum teneret nando interiit. <milestone unit="par" n="4"/> Cuius corpus dum postero die eiectum <supplied>in</supplied> litore fluctibus Hero uidisset, dolore instincta culmi<del>mi</del>ne cecidit. <milestone unit="par" n="5"/> Sic cum quo sortita fuit partem mundanae uoluptatis, cum eo et pertulit damnum mortiferae acerbitatis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sestios et Abidon urbes uicinae erant et
+                  interfluentis maris arto diuisae; una earum celebris extitit per Leandrum,
+                  pulcherrimum iuuenem, altera per <del>C</del>heron pulcherrimam mulierem.
+                     <milestone unit="par" n="2"/> Quibus absentibus amor imis concaluit mentibus;
+                  iuuenis autem impatiens ignis omni modo quaerebat premendae uirginis copiam, sed
+                  nullo ad Heron terra<del>m</del> aditu inuento, simul calore et audacia impulsus,
+                  se ponto tradidit sicque natando singulas noctes puellam adiit, oblato ex aduerso
+                  turris lumine puellae studio, quo nocturnum iter ad eam dirigere posset.
+                     <milestone unit="par" n="3"/> Quadam uero nocte cum acrius solito imminens
+                  uentus faculam extingueret, errando et inscius quo cursum teneret nando interiit.
+                     <milestone unit="par" n="4"/> Cuius corpus dum postero die eiectum
+                     <supplied>in</supplied> litore fluctibus Hero uidisset, dolore instincta
+                     culmi<del>mi</del>ne cecidit. <milestone unit="par" n="5"/> Sic cum quo sortita
+                  fuit partem mundanae uoluptatis, cum eo et pertulit damnum mortiferae acerbitatis.
+               </p>
             </div>
 
             <div type="cap" n="29">
                <head> Fabula Cleobis et Bitonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum mos esset Argiuam sacerdotem iunctis bubus ire ad templa Iunonis et sollemni die boues non inuenirentur — pestilentia enim, quae per Atticam transierat, uniuersa consumpserat —, duo sacerdotis filii Cleobis et Bito matrem subeuntes iugo ad templa duxere. <milestone unit="par" n="2"/> Tum Iuno probans eorum religionem obtulit matri ut quod uellet posceret filiis; illa pia responsione ait ut quod sciret dea utile mortalibus ipsa praestaret. <milestone unit="par" n="3"/> Altero itaque die sacerdotis iuuenes reperti sunt mortui; ex quo probatum est nihil esse morte praestantius. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum mos esset Argiuam sacerdotem iunctis bubus ire
+                  ad templa Iunonis et sollemni die boues non inuenirentur — pestilentia enim, quae
+                  per Atticam transierat, uniuersa consumpserat —, duo sacerdotis filii Cleobis et
+                  Bito matrem subeuntes iugo ad templa duxere. <milestone unit="par" n="2"/> Tum
+                  Iuno probans eorum religionem obtulit matri ut quod uellet posceret filiis; illa
+                  pia responsione ait ut quod sciret dea utile mortalibus ipsa praestaret.
+                     <milestone unit="par" n="3"/> Altero itaque die sacerdotis iuuenes reperti sunt
+                  mortui; ex quo probatum est nihil esse morte praestantius. </p>
             </div>
 
             <div type="cap" n="30">
                <head> Historia Amulii et Numitoris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Amulius et Numitor fratres fuerunt; Amulius fratrem imperio pepulit et filium eius necauit, filiam uero Iliam Vestae sacerdotem fecit, ut spem sobolis aufer<supplied>r</supplied>et, a qua se puniri <supplied>posse</supplied> cognouerat. <milestone unit="par" n="2"/> Hanc, ut multi dicunt, Mars compressit, unde nati sunt Remus et Romus, quos cum matre Amulius praecipitari iussit in Tiberim. <milestone unit="par" n="3"/> Tum, ut quidam dicunt, Iliam sibi Anien fecit uxorem, ut alii Amnen; pueri uero expositi ad uicinam ripam sunt. <milestone unit="par" n="4"/> Hos Faustus repperit pastor, cuius uxor erat nuper meretrix Acca Larentia, quae susceptos aluit pueros. <milestone unit="par" n="5"/> Hi postea auum suum Numitorem occiso Amulio in regno reuocarunt. <milestone unit="par" n="6"/> Quibus dum cum patre angustum Albae uideretur imperium, recesserunt et captatis a<supplied>u</supplied>guriis urbem condiderunt. <milestone unit="par" n="7"/> Sed Remus prior sex uultures uidit, Romus postea duodecim; quae res bellum creauit, in quo extinctus est Remus. <milestone unit="par" n="8"/> Et a Romi nomine Romani appellati; ut autem pro Romo Rom<supplied>ul</supplied>us diceretur, blandimenti genere factum est, quod gaudet diminutione. <milestone unit="par" n="9"/> Quod a lupa dicuntur alti, fabulosum figmentum est ad celandam auctorum Romani generis turpitudinem. <milestone unit="par" n="10"/> Nec in<supplied>con</supplied>grue fictum est; nam et meretrices lupas uocamus — unde et lupanaria — et constat hoc animal esse in tutela Martis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Amulius et Numitor fratres fuerunt; Amulius fratrem
+                  imperio pepulit et filium eius necauit, filiam uero Iliam Vestae sacerdotem fecit,
+                  ut spem sobolis aufer<supplied>r</supplied>et, a qua se puniri
+                     <supplied>posse</supplied> cognouerat. <milestone unit="par" n="2"/> Hanc, ut
+                  multi dicunt, Mars compressit, unde nati sunt Remus et Romus, quos cum matre
+                  Amulius praecipitari iussit in Tiberim. <milestone unit="par" n="3"/> Tum, ut
+                  quidam dicunt, Iliam sibi Anien fecit uxorem, ut alii Amnen; pueri uero expositi
+                  ad uicinam ripam sunt. <milestone unit="par" n="4"/> Hos Faustus repperit pastor,
+                  cuius uxor erat nuper meretrix Acca Larentia, quae susceptos aluit pueros.
+                     <milestone unit="par" n="5"/> Hi postea auum suum Numitorem occiso Amulio in
+                  regno reuocarunt. <milestone unit="par" n="6"/> Quibus dum cum patre angustum
+                  Albae uideretur imperium, recesserunt et captatis a<supplied>u</supplied>guriis
+                  urbem condiderunt. <milestone unit="par" n="7"/> Sed Remus prior sex uultures
+                  uidit, Romus postea duodecim; quae res bellum creauit, in quo extinctus est Remus.
+                     <milestone unit="par" n="8"/> Et a Romi nomine Romani appellati; ut autem pro
+                  Romo Rom<supplied>ul</supplied>us diceretur, blandimenti genere factum est, quod
+                  gaudet diminutione. <milestone unit="par" n="9"/> Quod a lupa dicuntur alti,
+                  fabulosum figmentum est ad celandam auctorum Romani generis turpitudinem.
+                     <milestone unit="par" n="10"/> Nec in<supplied>con</supplied>grue fictum est;
+                  nam et meretrices lupas uocamus — unde et lupanaria — et constat hoc animal esse
+                  in tutela Martis. </p>
             </div>
 
             <div type="cap" n="31">
                <head> Fabula Lynci.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lyncus rex Scythiae fuit; qui missum a Ce<supplied>re</supplied>re Triptolemum ut omnibus frumenta ministrare<supplied>t</supplied>, susceptum hospitio, ut in se tanta gloria migraret, interimere cogitauit. <milestone unit="par" n="2"/> Ob quam rem irata Ceres eum conuertit lyncem, feram uarii coloris, ut ipse uariae mentis extiterat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lyncus rex Scythiae fuit; qui missum a
+                     Ce<supplied>re</supplied>re Triptolemum ut omnibus frumenta
+                     ministrare<supplied>t</supplied>, susceptum hospitio, ut in se tanta gloria
+                  migraret, interimere cogitauit. <milestone unit="par" n="2"/> Ob quam rem irata
+                  Ceres eum conuertit lyncem, feram uarii coloris, ut ipse uariae mentis extiterat.
+               </p>
             </div>
 
             <div type="cap" n="32">
                <head> Fabula Oenopionis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Oenopion rex cum liberos non haberet, a Ioue, Mercurio Neptunoque — quos hospitio susceperat — hortan<del>tan</del>tibus ut ab his aliquid postularet, petiit ut sibi concederent liberos. <milestone unit="par" n="2"/> Illi, intra corium immolati sibi bouis urina facta, praeceperunt ut obrutum terra completis matemis mensibus solueretur. <milestone unit="par" n="3"/> Quo facto inuentus est puer; cui nomen ab urina impositum est, ut Orion diceretur. <milestone unit="par" n="4"/> Qui postea uenator factus, dum uellet cum Diana concumbere, ut Horatius dicit, eius sagittis occisus est, ut Lucanus, immisso scorpione periit et deorum miseratione relatus inter sidera collocatus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Oenopion rex cum liberos non haberet, a Ioue,
+                  Mercurio Neptunoque — quos hospitio susceperat — hortan<del>tan</del>tibus ut ab
+                  his aliquid postularet, petiit ut sibi concederent liberos. <milestone unit="par"
+                     n="2"/> Illi, intra corium immolati sibi bouis urina facta, praeceperunt ut
+                  obrutum terra completis matemis mensibus solueretur. <milestone unit="par" n="3"/>
+                  Quo facto inuentus est puer; cui nomen ab urina impositum est, ut Orion diceretur.
+                     <milestone unit="par" n="4"/> Qui postea uenator factus, dum uellet cum Diana
+                  concumbere, ut Horatius dicit, eius sagittis occisus est, ut Lucanus, immisso
+                  scorpione periit et deorum miseratione relatus inter sidera collocatus est. </p>
             </div>
 
             <div type="cap" n="33">
                <head> Fabula Orionis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Orion, praedictus filius Neptuni, uenator acerrimus fuit. <milestone unit="par" n="2"/> Is abiens ad Minopionem, Cretensium regem, hospitio susceptus est et temptauit filias eius uiolenter rapere. <milestone unit="par" n="3"/> At uero Minopes Libero patri, cuius filius uidebatur, immolauit; inde Liber<del>o</del> pater misit Satyros, qui Orionem ebriosum ligauerunt et uinctum Minopioni tradiderunt, ut ipse eum puniret. <milestone unit="par" n="4"/> Tunc ille oculos eius eruit. <milestone unit="par" n="5"/> Postea uero Orion didicit responso lumina se recepturum, si ad orientem uenisset. <milestone unit="par" n="6"/> At ille sonum cyclopum, fulmina fabricantium, auribus secutus, unum ex ipsis rapuit <supplied>et</supplied> eum humeris impositum rogauit ut se ad orientem dirigeret; sic perductus ad orientem lumen recepit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Orion, praedictus filius Neptuni, uenator acerrimus
+                  fuit. <milestone unit="par" n="2"/> Is abiens ad Minopionem, Cretensium regem,
+                  hospitio susceptus est et temptauit filias eius uiolenter rapere. <milestone
+                     unit="par" n="3"/> At uero Minopes Libero patri, cuius filius uidebatur,
+                  immolauit; inde Liber<del>o</del> pater misit Satyros, qui Orionem ebriosum
+                  ligauerunt et uinctum Minopioni tradiderunt, ut ipse eum puniret. <milestone
+                     unit="par" n="4"/> Tunc ille oculos eius eruit. <milestone unit="par" n="5"/>
+                  Postea uero Orion didicit responso lumina se recepturum, si ad orientem uenisset.
+                     <milestone unit="par" n="6"/> At ille sonum cyclopum, fulmina fabricantium,
+                  auribus secutus, unum ex ipsis rapuit <supplied>et</supplied> eum humeris
+                  impositum rogauit ut se ad orientem dirigeret; sic perductus ad orientem lumen
+                  recepit. </p>
             </div>
 
             <div type="cap" n="34">
                <head> Fabula Amaraci.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Amaracus regius unguentarius fuit, qui casu lapsus, dum ferret unguenta, maiorem ex confusione odorem creauit; unde optima unguenta amaracina dicuntur. <milestone unit="par" n="2"/> Hic postea in herbam samsucum uersus est, quam nunc et amaracum dicunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Amaracus regius unguentarius fuit, qui casu lapsus,
+                  dum ferret unguenta, maiorem ex confusione odorem creauit; unde optima unguenta
+                  amaracina dicuntur. <milestone unit="par" n="2"/> Hic postea in herbam samsucum
+                  uersus est, quam nunc et amaracum dicunt. </p>
             </div>
 
             <div type="cap" n="35">
                <head> Historia Palamedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Palamedis cum delectum per Graeciam ageret, simulantem insaniam Vlixen duxit inuitum. <milestone unit="par" n="2"/> Cum enim ille iunctis dissimilis naturae animalibus salem sereret, filium ei Palamedis opposuit: quo uiso Vlixes aratra suspendit et ad bellum ductus habuit iustam causam doloris. <milestone unit="par" n="3"/> Postea cum Vlixes frumentatum missus ad Thraciam nihil aduexisset, a Palamede est uehementer increpatus et cum diceret adeo non esse neglegentiam suam, <supplied>ut</supplied> ne ipse quidem, si pergeret, quicquam posset aduehere, profectus Palamedis infinita frumenta deuexit. <milestone unit="par" n="4"/> Qua inuidia Vlixes auctis inimic<supplied>it</supplied>iis fictam epistulam Priami nomine ad Palamedem, per <del>transmissum dedit captiuo</del> 
-                  <supplied>quam agebat gratias proditionis</supplied> et commemorabat secretum auri pondus esse, transmissum dedit captiuo et eum in itinere fecit occidi. <milestone unit="par" n="5"/> Haec inuenta more militiae regi allata<del>t</del> est et <supplied>l</supplied>e<supplied>cta</supplied> principibus conuocatis; tunc Vlixes, cum se Palamedi <supplied>adesse</supplied> simularet, ait: «Si uerum esse creditis, in tentorio eius aurum quaeratur!». <milestone unit="par" n="6"/> Quo facto inuento auro, quod ipse per noctem corruptis seruis absconderat, Palamedis lapidibus interemptus est. <milestone unit="par" n="7"/> Hunc autem constat fuisse prudentem; nam et tabulam ipse inuenit ad comprimendas otiosi seditiones exercitus. <milestone unit="par" n="8"/> Secundum quosdam ipse repperit litteras, quae res forte sit dubia, tamen certum est <foreign xml:lang="grc">χ</foreign> ab hoc inuentum cum aspiratione. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Palamedis cum delectum per Graeciam ageret,
+                  simulantem insaniam Vlixen duxit inuitum. <milestone unit="par" n="2"/> Cum enim
+                  ille iunctis dissimilis naturae animalibus salem sereret, filium ei Palamedis
+                  opposuit: quo uiso Vlixes aratra suspendit et ad bellum ductus habuit iustam
+                  causam doloris. <milestone unit="par" n="3"/> Postea cum Vlixes frumentatum missus
+                  ad Thraciam nihil aduexisset, a Palamede est uehementer increpatus et cum diceret
+                  adeo non esse neglegentiam suam, <supplied>ut</supplied> ne ipse quidem, si
+                  pergeret, quicquam posset aduehere, profectus Palamedis infinita frumenta deuexit.
+                     <milestone unit="par" n="4"/> Qua inuidia Vlixes auctis
+                     inimic<supplied>it</supplied>iis fictam epistulam Priami nomine ad Palamedem,
+                  per <del>transmissum dedit captiuo</del>
+                  <supplied>quam agebat gratias proditionis</supplied> et commemorabat secretum auri
+                  pondus esse, transmissum dedit captiuo et eum in itinere fecit occidi. <milestone
+                     unit="par" n="5"/> Haec inuenta more militiae regi allata<del>t</del> est et
+                     <supplied>l</supplied>e<supplied>cta</supplied> principibus conuocatis; tunc
+                  Vlixes, cum se Palamedi <supplied>adesse</supplied> simularet, ait: «Si uerum esse
+                  creditis, in tentorio eius aurum quaeratur!». <milestone unit="par" n="6"/> Quo
+                  facto inuento auro, quod ipse per noctem corruptis seruis absconderat, Palamedis
+                  lapidibus interemptus est. <milestone unit="par" n="7"/> Hunc autem constat fuisse
+                  prudentem; nam et tabulam ipse inuenit ad comprimendas otiosi seditiones
+                  exercitus. <milestone unit="par" n="8"/> Secundum quosdam ipse repperit litteras,
+                  quae res forte sit dubia, tamen certum est <foreign xml:lang="grc">χ</foreign> ab
+                  hoc inuentum cum aspiratione. </p>
             </div>
 
             <div type="cap" n="36">
                <head> Fabula Achillis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Achilles, a matre tinctus in Stygiam paludem, toto corpore inuulnerabilis fuit, excepta ea parte qua tentus fuit. <milestone unit="par" n="2"/> Qui cum amatam Polyxenam ut in templo acciperet statuisset, insidiis Paridis post simulacrum latentis occisus est. <milestone unit="par" n="3"/> Vnde fingitur quod tenente Apolline Paris di<supplied>re</supplied>xerit tela. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Achilles, a matre tinctus in Stygiam paludem, toto
+                  corpore inuulnerabilis fuit, excepta ea parte qua tentus fuit. <milestone
+                     unit="par" n="2"/> Qui cum amatam Polyxenam ut in templo acciperet statuisset,
+                  insidiis Paridis post simulacrum latentis occisus est. <milestone unit="par" n="3"
+                  /> Vnde fingitur quod tenente Apolline Paris di<supplied>re</supplied>xerit tela.
+               </p>
             </div>
 
             <div type="cap" n="37">
                <head> Fabula Latonae et Astaries.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Post uitiatam Latonam Iuppiter, cum etiam eius sororem Astarien uitiare uellet, illa optauit a diis, ut in auem conuerteret<supplied>ur</supplied>, uersaque in coturnice fuit. <milestone unit="par" n="2"/> Et cum uellet mare transfretare, quod est coturnicum, affiata a Ioue et in lapidem conuersa diu sub fluctibus latuit; postea supplicante Ioui Latona eleuata superferri aquis coepit. <milestone unit="par" n="3"/> Haec primo Neptuno et Doridi fuit consecrata. <milestone unit="par" n="4"/> Postea cum Iuno grauidam Pythone immisso Latonam persequeretur, terris omnibus expulsa, tandem aliquando applicante se litoribus sorore suscepta <supplied>est</supplied> et illic Dianam primo, post Apollinem peperit; qui statim occiso Pythone ultus est matris iniuriam. <milestone unit="par" n="5"/> Sane nata Diana parturienti Apollinem matri dicitur praebuisse obstetricis officium; unde, cum Diana sit uirgo, tamen a parturientibus inuocatur; haec namque est Iuno Diana Proserpina. <milestone unit="par" n="6"/> Nata igitur duo numina terram sibi natalem errare non passa sunt, sed eam duabus insulis religauerunt. <milestone unit="par" n="7"/> Veritas uero longe alia fuit: nam haec insula cum terrae motu laboraret, qui fit sub terris latentibus uentis, oraculo Apollinis terrae motu caruit; nam praecepit ne illic mo<supplied>r</supplied>tu<supplied>u</supplied>s sepeliretur et iussit quaedam sacrificia fieri. <milestone unit="par" n="8"/> Postea e Mycono Egyaroque uicinis insulis populi uenerunt, qui eam tenerent. <milestone unit="par" n="9"/> Quod autem dicimus Dianam primo natam rationis est; nam constat primam noctem fuisse, cuius instrumentum est luna, id est Diana, post diem, quem sol efficit, qui est Apollo. <milestone unit="par" n="10"/> Vt autem Delos primo Ortygia diceretur, factum est a coturnice, quae graece <foreign xml:lang="grc">OPTYX</foreign> uocatur; Delus autem, quia diu latuit et postea apparuit; nam delon Graeci manifestum dicunt. <milestone unit="par" n="11"/> Vel, quod uerius fuit, quia cum ubique Apollinis responsa obscura sint, manifesta illic responsa dantur. <milestone unit="par" n="12"/> Delos autem et ciuitas dicitur et <supplied>in</supplied>sula; unde interdum recipit praepositionem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Post uitiatam Latonam Iuppiter, cum etiam eius
+                  sororem Astarien uitiare uellet, illa optauit a diis, ut in auem
+                     conuerteret<supplied>ur</supplied>, uersaque in coturnice fuit. <milestone
+                     unit="par" n="2"/> Et cum uellet mare transfretare, quod est coturnicum,
+                  affiata a Ioue et in lapidem conuersa diu sub fluctibus latuit; postea supplicante
+                  Ioui Latona eleuata superferri aquis coepit. <milestone unit="par" n="3"/> Haec
+                  primo Neptuno et Doridi fuit consecrata. <milestone unit="par" n="4"/> Postea cum
+                  Iuno grauidam Pythone immisso Latonam persequeretur, terris omnibus expulsa,
+                  tandem aliquando applicante se litoribus sorore suscepta <supplied>est</supplied>
+                  et illic Dianam primo, post Apollinem peperit; qui statim occiso Pythone ultus est
+                  matris iniuriam. <milestone unit="par" n="5"/> Sane nata Diana parturienti
+                  Apollinem matri dicitur praebuisse obstetricis officium; unde, cum Diana sit
+                  uirgo, tamen a parturientibus inuocatur; haec namque est Iuno Diana Proserpina.
+                     <milestone unit="par" n="6"/> Nata igitur duo numina terram sibi natalem errare
+                  non passa sunt, sed eam duabus insulis religauerunt. <milestone unit="par" n="7"/>
+                  Veritas uero longe alia fuit: nam haec insula cum terrae motu laboraret, qui fit
+                  sub terris latentibus uentis, oraculo Apollinis terrae motu caruit; nam praecepit
+                  ne illic mo<supplied>r</supplied>tu<supplied>u</supplied>s sepeliretur et iussit
+                  quaedam sacrificia fieri. <milestone unit="par" n="8"/> Postea e Mycono Egyaroque
+                  uicinis insulis populi uenerunt, qui eam tenerent. <milestone unit="par" n="9"/>
+                  Quod autem dicimus Dianam primo natam rationis est; nam constat primam noctem
+                  fuisse, cuius instrumentum est luna, id est Diana, post diem, quem sol efficit,
+                  qui est Apollo. <milestone unit="par" n="10"/> Vt autem Delos primo Ortygia
+                  diceretur, factum est a coturnice, quae graece <foreign xml:lang="grc"
+                     >OPTYX</foreign> uocatur; Delus autem, quia diu latuit et postea apparuit; nam
+                  delon Graeci manifestum dicunt. <milestone unit="par" n="11"/> Vel, quod uerius
+                  fuit, quia cum ubique Apollinis responsa obscura sint, manifesta illic responsa
+                  dantur. <milestone unit="par" n="12"/> Delos autem et ciuitas dicitur et
+                     <supplied>in</supplied>sula; unde interdum recipit praepositionem. </p>
             </div>
 
             <div type="cap" n="38">
                <head> Fabula Hesperidum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hesperides, Atlantis filiae, nymph<del>e</del>ae, secundum fabulam hortum habuerunt, in quo erant mala aurea Veneri consecrata; quae Hercules missus ab E<supplied>u</supplied>rystheo occiso peruigili dracone sustulit. <milestone unit="par" n="2"/> Reuera autem nobiles fuerunt puellae, quarum greges abegit Hercules occiso eorum custode. <milestone unit="par" n="3"/> Vnde mala fingitur sustulisse, hoc est oues; nam mala dicuntur oues et melonomos dicitur pastor ouium. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hesperides, Atlantis filiae, nymph<del>e</del>ae,
+                  secundum fabulam hortum habuerunt, in quo erant mala aurea Veneri consecrata; quae
+                  Hercules missus ab E<supplied>u</supplied>rystheo occiso peruigili dracone
+                  sustulit. <milestone unit="par" n="2"/> Reuera autem nobiles fuerunt puellae,
+                  quarum greges abegit Hercules occiso eorum custode. <milestone unit="par" n="3"/>
+                  Vnde mala fingitur sustulisse, hoc est oues; nam mala dicuntur oues et melonomos
+                  dicitur pastor ouium. </p>
             </div>
 
             <div type="cap" n="39">
-               <head> Fabula At<supplied>a</supplied>lantes et Hippomene<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Schoenos ciuitas est; exinde uirgo fuit Atalante, praepotens cursu adeo, ut sponsos prouocatos ac uictos occideret. <milestone unit="par" n="2"/> Postea Hippomenes Venerem ut sibi adesset rogauit; a qua cum accepisset de horto Hesperidum tria mala aurea, prouocauit puellam et singula coepit iacere; tunc Atalante, cupiditate colligendorum malorum retenta, superata est. <milestone unit="par" n="3"/> Sed Hippomenes potitus uictoria in luco matris deum amoris impatientia cum ui<del>n</del>cta Atalante concubuit; unde irata dea in leones eos conuertit et suo currui subiugauit et praecepit ne umquam leones coirent. <milestone unit="par" n="4"/> Nam et Plinius in naturali historia dicit leonem cum parda et pardum cum leaena concumbere. <milestone unit="par" n="5"/> Ideo autem mater deum curru uehi dicitur, quia ipsa est terra, quae pendet in aere; ideo sustinetur rotis, quia mundus rotatur et reuolubilis est; ideo ei subiugantur leones, ut ostendatur maternam pietatem totum posse superare; ideo Corybantes eius ministri cum strictis gladiis esse finguntur, ut significetur omnes pro terra sua debere pugnare; quod autem turritam gestat coronam, ostendit superpositas terrae esse ciuitates, quas insignitas turribus constat. </p>
+               <head> Fabula At<supplied>a</supplied>lantes et
+                  Hippomene<supplied>s</supplied>.</head>
+               <p>
+                  <milestone unit="par" n="1"/> Schoenos ciuitas est; exinde uirgo fuit Atalante,
+                  praepotens cursu adeo, ut sponsos prouocatos ac uictos occideret. <milestone
+                     unit="par" n="2"/> Postea Hippomenes Venerem ut sibi adesset rogauit; a qua cum
+                  accepisset de horto Hesperidum tria mala aurea, prouocauit puellam et singula
+                  coepit iacere; tunc Atalante, cupiditate colligendorum malorum retenta, superata
+                  est. <milestone unit="par" n="3"/> Sed Hippomenes potitus uictoria in luco matris
+                  deum amoris impatientia cum ui<del>n</del>cta Atalante concubuit; unde irata dea
+                  in leones eos conuertit et suo currui subiugauit et praecepit ne umquam leones
+                  coirent. <milestone unit="par" n="4"/> Nam et Plinius in naturali historia dicit
+                  leonem cum parda et pardum cum leaena concumbere. <milestone unit="par" n="5"/>
+                  Ideo autem mater deum curru uehi dicitur, quia ipsa est terra, quae pendet in
+                  aere; ideo sustinetur rotis, quia mundus rotatur et reuolubilis est; ideo ei
+                  subiugantur leones, ut ostendatur maternam pietatem totum posse superare; ideo
+                  Corybantes eius ministri cum strictis gladiis esse finguntur, ut significetur
+                  omnes pro terra sua debere pugnare; quod autem turritam gestat coronam, ostendit
+                  superpositas terrae esse ciuitates, quas insignitas turribus constat. </p>
             </div>
 
             <div type="cap" n="40">
                <head> Fabula Heleni.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Helenus apud Arisbam captus a Graecis fuit et indicauit coactus fa<del>c</del>ta Troiana, in quibus et de Palladio; unde dicitur a Pyrrho meruisse regna, quamquam praestiterat Pyrrho ut per terram rediret, dicens omnes Graecos — quod et contigit — naufragio esse perituros. <milestone unit="par" n="2"/> Tunc Diomedes et Vlixes — ut alii dicunt, cuniculis, ut alii, cloacis — ascenderunt arcem et occisis custodibus sustulere simulacrum; ideo autem hoc negotium his potissimum datur, quia cultores fuerunt Mineruae. <milestone unit="par" n="3"/> Hoc cum postea Diomedes haberet, credens sibi non esse aptum propter sua pericu<supplied>l</supplied>a transeunti<del>a</del> Aeneae offerre conatus est. <milestone unit="par" n="4"/> Sed cum se ille uelato capite sacrificans conuertisset, Nautes quidam accepit simulacrum; unde Mineruae sacra non Iulia gens habuit, sed Nautarum. <milestone unit="par" n="5"/> Quamquam alii dicant simulacrum hoc a Troianis absconditum fuisse intra extructum parietem, postquam agnouerant Troiam esse perituram. <milestone unit="par" n="6"/> Quod postea bello Mithridatico dicitur Fimbria quidam Romanus inuentum indicasse, quod Romam constat aduectum; et cum responsum fuisset illic imperium fore ubi et Palladium, adhibito Mamurio fabro multa similia facta sunt. <milestone unit="par" n="7"/> Verum tamen agnoscitur hastae oculorumque mobilitate, sed ab una tantum sacerdote. <milestone unit="par" n="8"/> Dicunt sane alii unum simulacrum caelo lapsum apud Athenas tantum fuisse; alii duo uolunt, hoc de quo diximus et illud Atheniense. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Helenus apud Arisbam captus a Graecis fuit et
+                  indicauit coactus fa<del>c</del>ta Troiana, in quibus et de Palladio; unde dicitur
+                  a Pyrrho meruisse regna, quamquam praestiterat Pyrrho ut per terram rediret,
+                  dicens omnes Graecos — quod et contigit — naufragio esse perituros. <milestone
+                     unit="par" n="2"/> Tunc Diomedes et Vlixes — ut alii dicunt, cuniculis, ut
+                  alii, cloacis — ascenderunt arcem et occisis custodibus sustulere simulacrum; ideo
+                  autem hoc negotium his potissimum datur, quia cultores fuerunt Mineruae.
+                     <milestone unit="par" n="3"/> Hoc cum postea Diomedes haberet, credens sibi non
+                  esse aptum propter sua pericu<supplied>l</supplied>a transeunti<del>a</del> Aeneae
+                  offerre conatus est. <milestone unit="par" n="4"/> Sed cum se ille uelato capite
+                  sacrificans conuertisset, Nautes quidam accepit simulacrum; unde Mineruae sacra
+                  non Iulia gens habuit, sed Nautarum. <milestone unit="par" n="5"/> Quamquam alii
+                  dicant simulacrum hoc a Troianis absconditum fuisse intra extructum parietem,
+                  postquam agnouerant Troiam esse perituram. <milestone unit="par" n="6"/> Quod
+                  postea bello Mithridatico dicitur Fimbria quidam Romanus inuentum indicasse, quod
+                  Romam constat aduectum; et cum responsum fuisset illic imperium fore ubi et
+                  Palladium, adhibito Mamurio fabro multa similia facta sunt. <milestone unit="par"
+                     n="7"/> Verum tamen agnoscitur hastae oculorumque mobilitate, sed ab una tantum
+                  sacerdote. <milestone unit="par" n="8"/> Dicunt sane alii unum simulacrum caelo
+                  lapsum apud Athenas tantum fuisse; alii duo uolunt, hoc de quo diximus et illud
+                  Atheniense. </p>
             </div>
 
             <div type="cap" n="41">
                <head> Fabula Andromachae et Molosi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Consuetudinis regiae fuit ut legitimam uxorem non habentes aliquam licet captiuam tamen pro legitima haberent, adeo ut liberi ex ipsa nati succederent. <milestone unit="par" n="2"/> Itaque Pirrhus captiuam Andromachen quasi legitimam habuit et ex ea filium Molosum suscepit. <milestone unit="par" n="3"/> Postea cum uellet Hermionem, Menelai et Helenae filiam, Oresti iam ante desponsatam, ducere uxorem, Orestis insidiis in templo Delphici Apollinis occisus est. <milestone unit="par" n="4"/> Verum moriens praecepit ut Andromachae, quae apud eum coniugis locum tenuerat, Heleno daretur propter beneficium, quo eum a nauigatione prohibuerat. <milestone unit="par" n="5"/> Inde factum est ut teneret regnum priuigni, qui successerat patri. <milestone unit="par" n="6"/> A quo Molosia dicta est pars Epiri, quam Helenus postea a fratre Chaone, quem in uenatu per ignorantiam dicitur occidisse, Chaoniam nominauit, quasi ad solacium fratris extincti. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Consuetudinis regiae fuit ut legitimam uxorem non
+                  habentes aliquam licet captiuam tamen pro legitima haberent, adeo ut liberi ex
+                  ipsa nati succederent. <milestone unit="par" n="2"/> Itaque Pirrhus captiuam
+                  Andromachen quasi legitimam habuit et ex ea filium Molosum suscepit. <milestone
+                     unit="par" n="3"/> Postea cum uellet Hermionem, Menelai et Helenae filiam,
+                  Oresti iam ante desponsatam, ducere uxorem, Orestis insidiis in templo Delphici
+                  Apollinis occisus est. <milestone unit="par" n="4"/> Verum moriens praecepit ut
+                  Andromachae, quae apud eum coniugis locum tenuerat, Heleno daretur propter
+                  beneficium, quo eum a nauigatione prohibuerat. <milestone unit="par" n="5"/> Inde
+                  factum est ut teneret regnum priuigni, qui successerat patri. <milestone
+                     unit="par" n="6"/> A quo Molosia dicta est pars Epiri, quam Helenus postea a
+                  fratre Chaone, quem in uenatu per ignorantiam dicitur occidisse, Chaoniam
+                  nominauit, quasi ad solacium fratris extincti. </p>
             </div>
 
             <div type="cap" n="42">
                <head> Fabula Sirenum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sirenes secundum fabulam tres parte uirgines fuerunt, parte uolucres, Acheloi fluminis et Calliopes Musae filiae; harum una uoce, altera tibiis, alia lyra canebant; et primo iuxta Pelorum, post in Capreis habitauerunt. <milestone unit="par" n="2"/> Quae illectos suo cantu in naufragia deducebant. <milestone unit="par" n="3"/> Secundum ueritatem meretrices fuerunt, quae transeuntes quoniam deducebant ad egestatem, his fictae sunt inferre naufragia. <milestone unit="par" n="4"/> Has Vlixes contemnendo deduxit ad mortem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sirenes secundum fabulam tres parte uirgines
+                  fuerunt, parte uolucres, Acheloi fluminis et Calliopes Musae filiae; harum una
+                  uoce, altera tibiis, alia lyra canebant; et primo iuxta Pelorum, post in Capreis
+                  habitauerunt. <milestone unit="par" n="2"/> Quae illectos suo cantu in naufragia
+                  deducebant. <milestone unit="par" n="3"/> Secundum ueritatem meretrices fuerunt,
+                  quae transeuntes quoniam deducebant ad egestatem, his fictae sunt inferre
+                  naufragia. <milestone unit="par" n="4"/> Has Vlixes contemnendo deduxit ad mortem.
+               </p>
             </div>
 
             <div type="cap" n="43">
                <head> Fabula Veneris et Pasiph<supplied>a</supplied>e<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Indicato a Sole adulterio Martis et Veneris, Vulcanus mi<supplied>nu</supplied>tissimis catenis lectulum cinxit, quibus Mars et Venus ignorantes implicati sunt et cum ingenti turpitudine resoluti sub testimonio cunctorum deorum. <milestone unit="par" n="2"/> Quod factum Venus uehementer dolens stirpem omnem Solis persequi infandis amoribus coepit. <milestone unit="par" n="3"/> Igitur Pasiph<supplied>a</supplied>e, Solis filia, Minois regis Cretae uxor, tauri amore flagrabat et arte Daedali inclusa intra uaccam ligneam saeptam corio iuuencae pulcherrimae cum tauro concubuit; unde natus est Minotaurus, qui intra laborinthum inclusus humanis carnibus uescebatur. <milestone unit="par" n="4"/> Sed Minos de Pasyph<supplied>a</supplied>e habuit liberos plurimos: Androgeum, A<del>d</del>riadnen, Phaedram. <milestone unit="par" n="5"/> Sed Androgeus cum esset athleta fortissimus et superaret in agonibus cunctos apud Athenas, ab Atheniensibus et uicinis Megarensibus coniuratis occisus est. <milestone unit="par" n="6"/> Quod Minos dolens collectis nauibus bella commouit et uictis Atheniensibus poenam hanc statuit, ut singulis quibusque annis septem de filiis et septem de filiabus suis edendos Minotauro mitterent. <milestone unit="par" n="7"/> Sed tertio anno Aegei filius Theseus missus est, potens <supplied>tam</supplied> uirtute quam forma; qui cum ab A<del>d</del>riadne, regis filia, amatus fuisset, Daedali consilio filo iter direxit et necato Minotauro cum rapta A<del>d</del>riadne uictor aufugit. <milestone unit="par" n="8"/> Quae cum omnia factione Daedali Minos deprehendisset effecta, eum cum Icaro filio seruandum in laborinthum trusit. <milestone unit="par" n="9"/> Sed Daedalus corruptis custodibus sub faciendi muneris specie, quo simulabat posse regem placari, ceram accepit et pennas; et inde tam sibi quam filio alis impositis euolauit. <milestone unit="par" n="10"/> Icarus altiora petens pennis solis calore resolutis mari, in quo cecidit, nomen imposuit. <milestone unit="par" n="11"/> Daedalus uero primo Sardiniam, post delatus est Cumas et in templo Apollini condito filii sui casum depinxit. <milestone unit="par" n="12"/> Veritas autem haec est: nam Taurus notarius Minois fuit, quem Pasiph<supplied>a</supplied>e adamauit, cum quo in domo Daedali concubuit; et quia geminos peperit, unum de Minoe et alium de Tauro enixa esse Minotaurum dicitur; sed inclusum Daedalum regina corruptis relaxauit custodibus, qui amisso in mari filio naui delatus est Cumas. <milestone unit="par" n="13"/> Quod Virgilius tangit dicens <hi rend="italic">remigio alarum</hi>; alae enim et uolucrum sunt, et nauium (ut <hi rend="italic">uelorum pandimus alas</hi>). </p>
+               <p>
+                  <milestone unit="par" n="1"/> Indicato a Sole adulterio Martis et Veneris,
+                  Vulcanus mi<supplied>nu</supplied>tissimis catenis lectulum cinxit, quibus Mars et
+                  Venus ignorantes implicati sunt et cum ingenti turpitudine resoluti sub testimonio
+                  cunctorum deorum. <milestone unit="par" n="2"/> Quod factum Venus uehementer
+                  dolens stirpem omnem Solis persequi infandis amoribus coepit. <milestone
+                     unit="par" n="3"/> Igitur Pasiph<supplied>a</supplied>e, Solis filia, Minois
+                  regis Cretae uxor, tauri amore flagrabat et arte Daedali inclusa intra uaccam
+                  ligneam saeptam corio iuuencae pulcherrimae cum tauro concubuit; unde natus est
+                  Minotaurus, qui intra laborinthum inclusus humanis carnibus uescebatur. <milestone
+                     unit="par" n="4"/> Sed Minos de Pasyph<supplied>a</supplied>e habuit liberos
+                  plurimos: Androgeum, A<del>d</del>riadnen, Phaedram. <milestone unit="par" n="5"/>
+                  Sed Androgeus cum esset athleta fortissimus et superaret in agonibus cunctos apud
+                  Athenas, ab Atheniensibus et uicinis Megarensibus coniuratis occisus est.
+                     <milestone unit="par" n="6"/> Quod Minos dolens collectis nauibus bella
+                  commouit et uictis Atheniensibus poenam hanc statuit, ut singulis quibusque annis
+                  septem de filiis et septem de filiabus suis edendos Minotauro mitterent.
+                     <milestone unit="par" n="7"/> Sed tertio anno Aegei filius Theseus missus est,
+                  potens <supplied>tam</supplied> uirtute quam forma; qui cum ab
+                  A<del>d</del>riadne, regis filia, amatus fuisset, Daedali consilio filo iter
+                  direxit et necato Minotauro cum rapta A<del>d</del>riadne uictor aufugit.
+                     <milestone unit="par" n="8"/> Quae cum omnia factione Daedali Minos
+                  deprehendisset effecta, eum cum Icaro filio seruandum in laborinthum trusit.
+                     <milestone unit="par" n="9"/> Sed Daedalus corruptis custodibus sub faciendi
+                  muneris specie, quo simulabat posse regem placari, ceram accepit et pennas; et
+                  inde tam sibi quam filio alis impositis euolauit. <milestone unit="par" n="10"/>
+                  Icarus altiora petens pennis solis calore resolutis mari, in quo cecidit, nomen
+                  imposuit. <milestone unit="par" n="11"/> Daedalus uero primo Sardiniam, post
+                  delatus est Cumas et in templo Apollini condito filii sui casum depinxit.
+                     <milestone unit="par" n="12"/> Veritas autem haec est: nam Taurus notarius
+                  Minois fuit, quem Pasiph<supplied>a</supplied>e adamauit, cum quo in domo Daedali
+                  concubuit; et quia geminos peperit, unum de Minoe et alium de Tauro enixa esse
+                  Minotaurum dicitur; sed inclusum Daedalum regina corruptis relaxauit custodibus,
+                  qui amisso in mari filio naui delatus est Cumas. <milestone unit="par" n="13"/>
+                  Quod Virgilius tangit dicens <hi rend="italic">remigio alarum</hi>; alae enim et
+                  uolucrum sunt, et nauium (ut <hi rend="italic">uelorum pandimus alas</hi>). </p>
             </div>
 
             <div type="cap" n="44">
                <head> Fabula Procridis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Procrin <supplied>filia</supplied> Iphili et uxor Cephali fuit, qui cum uenandi studio teneretur, labore fessus ad locum quendam ire consueuerat et illic ad se recreandum auram uocare. <milestone unit="par" n="2"/> Quod cum saepe faceret, amorem in se mouit Aurorae, quae ei canem uelocissimum Lelepam nomine donauit et duo hastilia ineuitabilia eumque in amplexibus rogauit, ut spreta uxore sua eam amet. <milestone unit="par" n="3"/> Ille ait iusiurandum se habere cum coniuge mutuae castitatis; quo audito respondit Aurora: «Vt probes coniugis castitatem, muta te in mercatorem!». <milestone unit="par" n="4"/> Quo facto ille iuit ad Procrin et oblatis muneribus impetratoque coitu confessus est se esse maritum. <milestone unit="par" n="5"/> Quod dolens illa, cum audisset a rustico amare eum Auroram quam inuocare consueuerat, ad siluas profecta est et in frutectis latuit ad deprehendendum maritum. <milestone unit="par" n="6"/> Qui cum more solito Auroram uocaret, Procris egredi cupiens frutecta commouit; sperans Cephalus feram, hastam ineuitabilem iecit et interfecit uxorem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Procrin <supplied>filia</supplied> Iphili et uxor
+                  Cephali fuit, qui cum uenandi studio teneretur, labore fessus ad locum quendam ire
+                  consueuerat et illic ad se recreandum auram uocare. <milestone unit="par" n="2"/>
+                  Quod cum saepe faceret, amorem in se mouit Aurorae, quae ei canem uelocissimum
+                  Lelepam nomine donauit et duo hastilia ineuitabilia eumque in amplexibus rogauit,
+                  ut spreta uxore sua eam amet. <milestone unit="par" n="3"/> Ille ait iusiurandum
+                  se habere cum coniuge mutuae castitatis; quo audito respondit Aurora: «Vt probes
+                  coniugis castitatem, muta te in mercatorem!». <milestone unit="par" n="4"/> Quo
+                  facto ille iuit ad Procrin et oblatis muneribus impetratoque coitu confessus est
+                  se esse maritum. <milestone unit="par" n="5"/> Quod dolens illa, cum audisset a
+                  rustico amare eum Auroram quam inuocare consueuerat, ad siluas profecta est et in
+                  frutectis latuit ad deprehendendum maritum. <milestone unit="par" n="6"/> Qui cum
+                  more solito Auroram uocaret, Procris egredi cupiens frutecta commouit; sperans
+                  Cephalus feram, hastam ineuitabilem iecit et interfecit uxorem. </p>
             </div>
 
             <div type="cap" n="45">
                <head> Fabula Amymone<supplied>s</supplied> et Palamedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Amymone, Danai filia, dum studiose in insula iaculo exerceretur, imprudens satyrum percussit et cum satyrus eam uiolare uellet, illa Neptuni auxilium implorauit. <milestone unit="par" n="2"/> Quod cum Neptunus uidisset, fugato satyro ipse eam compressit, ex quo coitu natus est Nauplius <supplied>pater</supplied> Palamedis; unde Virgilius: <hi rend="italic">Belidae nomen Palamedis</hi>. <milestone unit="par" n="3"/> Neptunus uero dicitur cuspide locum, in quo Amymonem compresserat, percussisse; unde cum aqua flueret, Lernaeus est fons dictus et Amymone fluuius. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Amymone, Danai filia, dum studiose in insula iaculo
+                  exerceretur, imprudens satyrum percussit et cum satyrus eam uiolare uellet, illa
+                  Neptuni auxilium implorauit. <milestone unit="par" n="2"/> Quod cum Neptunus
+                  uidisset, fugato satyro ipse eam compressit, ex quo coitu natus est Nauplius
+                     <supplied>pater</supplied> Palamedis; unde Virgilius: <hi rend="italic">Belidae
+                     nomen Palamedis</hi>. <milestone unit="par" n="3"/> Neptunus uero dicitur
+                  cuspide locum, in quo Amymonem compresserat, percussisse; unde cum aqua flueret,
+                  Lernaeus est fons dictus et Amymone fluuius. </p>
             </div>
 
             <div type="cap" n="46">
                <head> Fabula Thesei et Hippolyti.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Theseus mortua Hippole Phaedram, Minois et Pasyph<supplied>a</supplied>ae filium, superduxit <supplied>nouercam</supplied> Hippolyto. <milestone unit="par" n="2"/> Qui cum de stupro illam interpellantem contempsisset, falso delatus ad patrem est, quod ei uim uellet inferre. <milestone unit="par" n="3"/> Theseus Aegeum patrem <supplied>rogauit</supplied> ut se ulcisceretur; qui agitanti curru<supplied>s</supplied> Hippolyto inmisit phocam in litore, qua equi territi eum distraxerunt. <milestone unit="par" n="4"/> Tunc Diana, eius castitate commota, reuocauit eum in uitam per Aesculapium, filium Apollinis et Coron<supplied>i</supplied>dis. <milestone unit="par" n="5"/> Qui natus erat exsecto matris uentre, ideo quia, cum Apollo audisset a coruo eius custode eam adulterium committere, iratus Coronidem maturo iam partu confixit sagittis — coruum uero nigrum fecit ex albo — et exsecto uentre Coronidis produxit Aesculapium, qui factus est medicinae peritus. <milestone unit="par" n="6"/> Hunc postea Iuppiter propter reuocatum Hippolytum interemit; unde Apollo iratus Cyclopas fabri<supplied>ca</supplied>tores fulminum confixit sagittis, ob quam rem a Ioue iussus est Admeti regis nouem annis armenta pascere diuinitate deposita. <milestone unit="par" n="7"/> Sed Diana Hippolytum reuocatum ab inferis nymphae commendauit Egeriae et eum Virbium, quasi bis uir<del>i</del>um, iussit uocari. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Theseus mortua Hippole Phaedram, Minois et
+                     Pasyph<supplied>a</supplied>ae filium, superduxit <supplied>nouercam</supplied>
+                  Hippolyto. <milestone unit="par" n="2"/> Qui cum de stupro illam interpellantem
+                  contempsisset, falso delatus ad patrem est, quod ei uim uellet inferre. <milestone
+                     unit="par" n="3"/> Theseus Aegeum patrem <supplied>rogauit</supplied> ut se
+                  ulcisceretur; qui agitanti curru<supplied>s</supplied> Hippolyto inmisit phocam in
+                  litore, qua equi territi eum distraxerunt. <milestone unit="par" n="4"/> Tunc
+                  Diana, eius castitate commota, reuocauit eum in uitam per Aesculapium, filium
+                  Apollinis et Coron<supplied>i</supplied>dis. <milestone unit="par" n="5"/> Qui
+                  natus erat exsecto matris uentre, ideo quia, cum Apollo audisset a coruo eius
+                  custode eam adulterium committere, iratus Coronidem maturo iam partu confixit
+                  sagittis — coruum uero nigrum fecit ex albo — et exsecto uentre Coronidis produxit
+                  Aesculapium, qui factus est medicinae peritus. <milestone unit="par" n="6"/> Hunc
+                  postea Iuppiter propter reuocatum Hippolytum interemit; unde Apollo iratus
+                  Cyclopas fabri<supplied>ca</supplied>tores fulminum confixit sagittis, ob quam rem
+                  a Ioue iussus est Admeti regis nouem annis armenta pascere diuinitate deposita.
+                     <milestone unit="par" n="7"/> Sed Diana Hippolytum reuocatum ab inferis nymphae
+                  commendauit Egeriae et eum Virbium, quasi bis uir<del>i</del>um, iussit uocari.
+               </p>
             </div>
 
             <div type="cap" n="47">
                <head> Fabula Minois et Tauri et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Minos, Iouis filius et Europae, cum patri sacrificaturus accederet ad aras, orauit potentiam numinis ut dignam aris suis hostiam praeberet. <milestone unit="par" n="2"/> Itaque subito taurus apparuit nimio candore perfusus, quem admiratus Minos, religionis oblitus, armenti sui maluit esse ductorem; cuius etiam amore Pasiph<supplied>a</supplied>ae fertur arsisse. <milestone unit="par" n="3"/> Igitur contemptus a filio Iuppiter indignatus furorem tauro subiecit et Cretensium non solum agros, sed etiam uniuersa moenia uastauit. <milestone unit="par" n="4"/> Hunc Hercules, missus ab Eurystheo, superauit uictumque Argos perduxit; ibique consecratus ab Eurystheo est Iunoni. <milestone unit="par" n="5"/> Sed Iuno exosa munus, quod ad Herculis gloriam pertinebat, taurum in Atticam regionem expulit, ubi et Marathonius appellatus est; quem postea Theseus <supplied>Aegei</supplied> filius interemit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Minos, Iouis filius et Europae, cum patri
+                  sacrificaturus accederet ad aras, orauit potentiam numinis ut dignam aris suis
+                  hostiam praeberet. <milestone unit="par" n="2"/> Itaque subito taurus apparuit
+                  nimio candore perfusus, quem admiratus Minos, religionis oblitus, armenti sui
+                  maluit esse ductorem; cuius etiam amore Pasiph<supplied>a</supplied>ae fertur
+                  arsisse. <milestone unit="par" n="3"/> Igitur contemptus a filio Iuppiter
+                  indignatus furorem tauro subiecit et Cretensium non solum agros, sed etiam
+                  uniuersa moenia uastauit. <milestone unit="par" n="4"/> Hunc Hercules, missus ab
+                  Eurystheo, superauit uictumque Argos perduxit; ibique consecratus ab Eurystheo est
+                  Iunoni. <milestone unit="par" n="5"/> Sed Iuno exosa munus, quod ad Herculis
+                  gloriam pertinebat, taurum in Atticam regionem expulit, ubi et Marathonius
+                  appellatus est; quem postea Theseus <supplied>Aegei</supplied> filius interemit.
+               </p>
             </div>
 
             <div type="cap" n="48">
                <head> Fabula Thesei et Pirithoi et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Theseus, Aegei filius et Aethnae, cum <supplied>a</supplied> matre sua educatus esset et ad puerilem uenisset aetatem, petiit Atticam regionem ad cognoscendum patrem. <milestone unit="par" n="2"/> Et sine laude ne ad eum peruenisset, latrociniis Graeciam liberauit. <milestone unit="par" n="3"/> Medea autem, repudiata ab Iasone, Aegeo nupta, persuasit aduenientem iuuenem tauro obponere, qui uastabat Atticam regionem, dicens futurum ut ab eo privaretur regno. <milestone unit="par" n="4"/> Theseus uero tauro interfecto duplicauit regi timorem; dein inuitatum ad epulas eum perdere uoluit. <milestone unit="par" n="5"/> Tandem agnito gladio, quem apud Aethnam olim reliquerat, libens agnouit filium et Medeam, quae fuerat <supplied>in</supplied>sidiarum causa, profugere coegit. <milestone unit="par" n="6"/> Post mortem uero patris ipse Athenis regnum obtinuit; consensitque Pirith<supplied>o</supplied>o, Ixionis filio, faciente uirtute fiduciam, ut Proserpinam raperent. <milestone unit="par" n="7"/> Qui cum descendissent ad inferos, ad saxum religatus est Pirithous nexibus trecentis; quas in perpetuum patitur po<supplied>e</supplied>nas. <milestone unit="par" n="8"/> Hercules uero pro Cerbero ad infernum descendens, cum comperisset Theseum carissimum sibi iuuenem haerentem in saxo poenas luere, ut quidam dicunt, exorato Dite ei ueniam impetrauit, ut alii uero, tam ualde euellit eum a saxo, ut pars nat<supplied>i</supplied>um eius haereret in saxo. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Theseus, Aegei filius et Aethnae, cum
+                     <supplied>a</supplied> matre sua educatus esset et ad puerilem uenisset
+                  aetatem, petiit Atticam regionem ad cognoscendum patrem. <milestone unit="par"
+                     n="2"/> Et sine laude ne ad eum peruenisset, latrociniis Graeciam liberauit.
+                     <milestone unit="par" n="3"/> Medea autem, repudiata ab Iasone, Aegeo nupta,
+                  persuasit aduenientem iuuenem tauro obponere, qui uastabat Atticam regionem,
+                  dicens futurum ut ab eo privaretur regno. <milestone unit="par" n="4"/> Theseus
+                  uero tauro interfecto duplicauit regi timorem; dein inuitatum ad epulas eum
+                  perdere uoluit. <milestone unit="par" n="5"/> Tandem agnito gladio, quem apud
+                  Aethnam olim reliquerat, libens agnouit filium et Medeam, quae fuerat
+                     <supplied>in</supplied>sidiarum causa, profugere coegit. <milestone unit="par"
+                     n="6"/> Post mortem uero patris ipse Athenis regnum obtinuit; consensitque
+                     Pirith<supplied>o</supplied>o, Ixionis filio, faciente uirtute fiduciam, ut
+                  Proserpinam raperent. <milestone unit="par" n="7"/> Qui cum descendissent ad
+                  inferos, ad saxum religatus est Pirithous nexibus trecentis; quas in perpetuum
+                  patitur po<supplied>e</supplied>nas. <milestone unit="par" n="8"/> Hercules uero
+                  pro Cerbero ad infernum descendens, cum comperisset Theseum carissimum sibi
+                  iuuenem haerentem in saxo poenas luere, ut quidam dicunt, exorato Dite ei ueniam
+                  impetrauit, ut alii uero, tam ualde euellit eum a saxo, ut pars
+                     nat<supplied>i</supplied>um eius haereret in saxo. </p>
             </div>
 
             <div type="cap" n="49">
                <head> Fabula Herculis et Hylae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules cum accessisset comes Argonautis, Hylan Thiodamantis filium secum duxit armigerum, admirandae pulchritudinis iuuenem. <milestone unit="par" n="2"/> Ipse uero fregerat remum in mari, dum pro suis remigat uiribus, cuius reparandi gratia Mysiam petens siluam fertur ingressus. <milestone unit="par" n="3"/> Hylas uero cum aquatum perrexisset, conspectus a Nymphis receptus est; quem dum Hercules quaerit, relictus ab Argonautis est in Mysia. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules cum accessisset comes Argonautis, Hylan
+                  Thiodamantis filium secum duxit armigerum, admirandae pulchritudinis iuuenem.
+                     <milestone unit="par" n="2"/> Ipse uero fregerat remum in mari, dum pro suis
+                  remigat uiribus, cuius reparandi gratia Mysiam petens siluam fertur ingressus.
+                     <milestone unit="par" n="3"/> Hylas uero cum aquatum perrexisset, conspectus a
+                  Nymphis receptus est; quem dum Hercules quaerit, relictus ab Argonautis est in
+                  Mysia. </p>
             </div>
 
             <div type="cap" n="50">
                <head> Fabula Herculis et Alcmenae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Herculis ortus fuit talis: Iuppiter cum Alcmena uxore Amphitryonis in specie eius concubuit; ex qua natus est Hercules. <milestone unit="par" n="2"/> Cuius ut ortus Iunoni celatus esset, quae natos de pellicibus odio habuit, geminata est nox. <milestone unit="par" n="3"/> Sed cum non latuisset Iunonem, immisit duos serpentes, qui Herculem deuorarent in cunis iacentem. <milestone unit="par" n="4"/> Erant duo pueri, Iphiclus de Amphitryone, Hercules de Ioue; Iphiclus, ab aduentu serpentium territus de cunis cecidit et uagitu suo parentes dormientes excitauit, qui surgentes uiderunt Herculem angues elidentem et eorum guttura praefocantem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Herculis ortus fuit talis: Iuppiter cum Alcmena
+                  uxore Amphitryonis in specie eius concubuit; ex qua natus est Hercules. <milestone
+                     unit="par" n="2"/> Cuius ut ortus Iunoni celatus esset, quae natos de
+                  pellicibus odio habuit, geminata est nox. <milestone unit="par" n="3"/> Sed cum
+                  non latuisset Iunonem, immisit duos serpentes, qui Herculem deuorarent in cunis
+                  iacentem. <milestone unit="par" n="4"/> Erant duo pueri, Iphiclus de Amphitryone,
+                  Hercules de Ioue; Iphiclus, ab aduentu serpentium territus de cunis cecidit et
+                  uagitu suo parentes dormientes excitauit, qui surgentes uiderunt Herculem angues
+                  elidentem et eorum guttura praefocantem. </p>
             </div>
 
             <div type="cap" n="51">
                <head> Fabula Herculis et Nemei leonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules missus ab Eurystheo, Thebanorum rege, Nemeum leonem interfecit. <milestone unit="par" n="2"/> Cuius pelle<del>m</del> cum unguibus pro spoliis utebatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules missus ab Eurystheo, Thebanorum rege,
+                  Nemeum leonem interfecit. <milestone unit="par" n="2"/> Cuius pelle<del>m</del>
+                  cum unguibus pro spoliis utebatur. </p>
             </div>
 
             <div type="cap" n="52">
                <head> Fabula Molorchi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Molorchus quidam pastor fuit. <milestone unit="par" n="2"/> Qui Herculem uenientem ad Nemeum leonem occidendum liberaliter suscepit hospitio. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Molorchus quidam pastor fuit. <milestone unit="par"
+                     n="2"/> Qui Herculem uenientem ad Nemeum leonem occidendum liberaliter suscepit
+                  hospitio. </p>
             </div>
 
             <div type="cap" n="53">
                <head> Fabula Erycis et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Eryx Veneris et Butae filius fuit, qui occisus ab Hercule ex sepultura sua monti nomen imposuit, in quo matri fecerat templum. <milestone unit="par" n="2"/> Quod Aeneae adscribit poeta dicens: <hi rend="italic">tum uicina astris Erycino in uertice sedes</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Eryx Veneris et Butae filius fuit, qui occisus ab
+                  Hercule ex sepultura sua monti nomen imposuit, in quo matri fecerat templum.
+                     <milestone unit="par" n="2"/> Quod Aeneae adscribit poeta dicens: <hi
+                     rend="italic">tum uicina astris Erycino in uertice sedes</hi>. </p>
             </div>
 
             <div type="cap" n="54">
                <head> Fabula Herculis et Cimini lacus.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules aliquando uenit ad populos, qui dicebantur Cimini uel a monte uel a lacu, et, cum a singulis prouocaretur ad ostendendam uirtutem, defixisse dicitur uectem ferreum, quo exercebatur. <milestone unit="par" n="2"/> Qui cum terrae esset affixus et a nullo posset auferri, eum rogatus sustulit; unde immensa uis aquae secuta est, quae Ciminum lacum fecit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules aliquando uenit ad populos, qui dicebantur
+                  Cimini uel a monte uel a lacu, et, cum a singulis prouocaretur ad ostendendam
+                  uirtutem, defixisse dicitur uectem ferreum, quo exercebatur. <milestone unit="par"
+                     n="2"/> Qui cum terrae esset affixus et a nullo posset auferri, eum rogatus
+                  sustulit; unde immensa uis aquae secuta est, quae Ciminum lacum fecit. </p>
             </div>
 
             <div type="cap" n="55">
                <head> Fabula Antaei et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Antaeus fuit rex Libyae, filius Terrae. <milestone unit="par" n="2"/> Ad quem cum uenisset Hercules, coepit cum eo luctari, sed non poterat eum superare; fingebat enim se cadere et ex matre Terra uires sumebat et forti<del>ci</del>or surgebat. <milestone unit="par" n="3"/> Hoc cognoscens Hercules suspensum i<supplied>n</supplied> aere<del>m</del> eliso gutture suffocauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Antaeus fuit rex Libyae, filius Terrae. <milestone
+                     unit="par" n="2"/> Ad quem cum uenisset Hercules, coepit cum eo luctari, sed
+                  non poterat eum superare; fingebat enim se cadere et ex matre Terra uires sumebat
+                  et forti<del>ci</del>or surgebat. <milestone unit="par" n="3"/> Hoc cognoscens
+                  Hercules suspensum i<supplied>n</supplied> aere<del>m</del> eliso gutture
+                  suffocauit. </p>
             </div>
 
             <div type="cap" n="56">
                <head> Fabula Herculis et Alcinoi et Harpyiarum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Alcinous, Phaeacum rex, laborabat <del>ab</del> Harpyiis. <milestone unit="par" n="2"/> Ad quem Hercules ueniens, cum hoc agnouisset, praestolatus est earum aduentum ad mensam solito more uenientium; quas uulneratas reppulit a regno. <milestone unit="par" n="3"/> Has Ouidius Stymphalidas uocat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Alcinous, Phaeacum rex, laborabat <del>ab</del>
+                  Harpyiis. <milestone unit="par" n="2"/> Ad quem Hercules ueniens, cum hoc
+                  agnouisset, praestolatus est earum aduentum ad mensam solito more uenientium; quas
+                  uulneratas reppulit a regno. <milestone unit="par" n="3"/> Has Ouidius
+                  Stymphalidas uocat. </p>
             </div>
 
             <div type="cap" n="57">
                <head> Fabula Herculis et Tricerberi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules ad inferos descendens rapturus Theseum timuit ne Tricerberus in illum transiens laceraret illum; qua<del>m</del>propter insiliens in Cerberum traxit eum ab inferis. <milestone unit="par" n="2"/> Cumque insolitam lucem uidisset superorum, spumam a<del>r</del>b ore eiecit; e qua spuma dicitur nata fuisse herba uenenifera nomine acon<supplied>i</supplied>ta. <milestone unit="par" n="3"/> Nam Cerberus terra est, quae omnium corporum consumptrix est; unde Cerberus dicìtur, quasi creoboros, id est carnem uorans. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules ad inferos descendens rapturus Theseum
+                  timuit ne Tricerberus in illum transiens laceraret illum; qua<del>m</del>propter
+                  insiliens in Cerberum traxit eum ab inferis. <milestone unit="par" n="2"/> Cumque
+                  insolitam lucem uidisset superorum, spumam a<del>r</del>b ore eiecit; e qua spuma
+                  dicitur nata fuisse herba uenenifera nomine acon<supplied>i</supplied>ta.
+                     <milestone unit="par" n="3"/> Nam Cerberus terra est, quae omnium corporum
+                  consumptrix est; unde Cerberus dicìtur, quasi creoboros, id est carnem uorans.
+               </p>
             </div>
 
             <div type="cap" n="58">
                <head> Fabula Herculis et D<supplied>e</supplied>ianirae et Oenei et Centauri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Oeneus, Parthaonis filius, rex Aetoliae reg<supplied>n</supplied>ique sedem habens in Calydone, D<supplied>e</supplied>ianiram filiam habuit. <milestone unit="par" n="2"/> Quam Hercules et Alpheus — qui et Achelous — dum peterent in coniugium, pater opposuit illis hanc legem, ut inuicem conluctantes, qui in certamine alterum uinceret, ille D<supplied>e</supplied>ianiram uxorem duceret. <milestone unit="par" n="3"/> Qui cum certamen inirent, Achelous, magicae. artis potens, in uarias se ferarum formas mutauit et tandem in tauri speciem mutatus ab Hercule est uictus et dextro cornu absciso est turpatus; quod Nymphae accipientes Fortunae pro dono obtulerunt. <milestone unit="par" n="4"/> Quod Fortuna omnibus bonis implens Copiae, ministrae suae, tradidit, ut quos Fortuna fouere uellet, copia illis exinde ad plenum manaret; unde Horatius: <hi rend="italic">Hinc tibi copia ad p<supplied>l</supplied>enum benigno cornu manabit bonorum opulenta ruris</hi>. <milestone unit="par" n="5"/> Alpheus — seu Achelous — confusus Alcidis uirtute, mutatus est in amnem; elapsus hostilibus palmis et timens semper ne usquam appareat inimici praesentia, per concaua terrarum undis Siciliae affluit. <milestone unit="par" n="6"/> Hercules postea D<supplied>e</supplied>ianiram in suam potestatem accipiens ad quendam fluuium peruenit nimiae profunditatis, quem cum transire non posset, eam deposuit clauamque cum reliquis armis secum transuexit, ut post exoneratus eam expedite ferret, et interim eam Nesso centauro commendauit. <milestone unit="par" n="7"/> Cum ergo ad illam transportandam uellet reuerti, uidit eundem Nessum centaurum cum ea concumbere; feruens igitur ira, emissa sagitta toxicata uulnerauit eum, cuius cruor in uenenum conuersus est. <milestone unit="par" n="8"/> Moriens autem Nessus dixit D<supplied>e</supplied>ianirae: «Collige tibi cruorem istum eritque tibi pro munere a me datum; nam, si quando Herculis animus a te declinauerit, uestem — hoc cruore infectam — uiro tribuens eius amorem reuocabis tibi!». <milestone unit="par" n="9"/> Cum igitur Hercules quandam meretricem amaret, exosa D<supplied>e</supplied>ianira misit ei uestem illo ueneno infectam mandans per Licham famulum eius, ut hora sacrificii illam indueret; qua indutus, adhaesit cuti illius cepitque uenenum artus illius infundere et incendere. <milestone unit="par" n="10"/> Tunc Licham, qui ei uestem detulerat, in E<supplied>u</supplied>boicas proiecit undas. <milestone unit="par" n="11"/> Se ipsum in <supplied>O</supplied>et<del>hn</del>ae montis incendium misit et sic inter deos translatus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Oeneus, Parthaonis filius, rex Aetoliae
+                     reg<supplied>n</supplied>ique sedem habens in Calydone,
+                  D<supplied>e</supplied>ianiram filiam habuit. <milestone unit="par" n="2"/> Quam
+                  Hercules et Alpheus — qui et Achelous — dum peterent in coniugium, pater opposuit
+                  illis hanc legem, ut inuicem conluctantes, qui in certamine alterum uinceret, ille
+                     D<supplied>e</supplied>ianiram uxorem duceret. <milestone unit="par" n="3"/>
+                  Qui cum certamen inirent, Achelous, magicae. artis potens, in uarias se ferarum
+                  formas mutauit et tandem in tauri speciem mutatus ab Hercule est uictus et dextro
+                  cornu absciso est turpatus; quod Nymphae accipientes Fortunae pro dono obtulerunt.
+                     <milestone unit="par" n="4"/> Quod Fortuna omnibus bonis implens Copiae,
+                  ministrae suae, tradidit, ut quos Fortuna fouere uellet, copia illis exinde ad
+                  plenum manaret; unde Horatius: <hi rend="italic">Hinc tibi copia ad
+                        p<supplied>l</supplied>enum benigno cornu manabit bonorum opulenta
+                     ruris</hi>. <milestone unit="par" n="5"/> Alpheus — seu Achelous — confusus
+                  Alcidis uirtute, mutatus est in amnem; elapsus hostilibus palmis et timens semper
+                  ne usquam appareat inimici praesentia, per concaua terrarum undis Siciliae
+                  affluit. <milestone unit="par" n="6"/> Hercules postea
+                  D<supplied>e</supplied>ianiram in suam potestatem accipiens ad quendam fluuium
+                  peruenit nimiae profunditatis, quem cum transire non posset, eam deposuit
+                  clauamque cum reliquis armis secum transuexit, ut post exoneratus eam expedite
+                  ferret, et interim eam Nesso centauro commendauit. <milestone unit="par" n="7"/>
+                  Cum ergo ad illam transportandam uellet reuerti, uidit eundem Nessum centaurum cum
+                  ea concumbere; feruens igitur ira, emissa sagitta toxicata uulnerauit eum, cuius
+                  cruor in uenenum conuersus est. <milestone unit="par" n="8"/> Moriens autem Nessus
+                  dixit D<supplied>e</supplied>ianirae: «Collige tibi cruorem istum eritque tibi pro
+                  munere a me datum; nam, si quando Herculis animus a te declinauerit, uestem — hoc
+                  cruore infectam — uiro tribuens eius amorem reuocabis tibi!». <milestone
+                     unit="par" n="9"/> Cum igitur Hercules quandam meretricem amaret, exosa
+                     D<supplied>e</supplied>ianira misit ei uestem illo ueneno infectam mandans per
+                  Licham famulum eius, ut hora sacrificii illam indueret; qua indutus, adhaesit cuti
+                  illius cepitque uenenum artus illius infundere et incendere. <milestone unit="par"
+                     n="10"/> Tunc Licham, qui ei uestem detulerat, in E<supplied>u</supplied>boicas
+                  proiecit undas. <milestone unit="par" n="11"/> Se ipsum in
+                     <supplied>O</supplied>et<del>hn</del>ae montis incendium misit et sic inter
+                  deos translatus est. </p>
             </div>
 
             <div type="cap" n="59">
                <head> Fabula Philoctetis et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Philoctetes fuit Phiantis filius, Herculis comes; quem Hercules, cum hominem in <supplied>O</supplied>et<del>hn</del>a monte deponeret, petiit, ne alicui sui corporis reliquias indicaret; de qua re eum iurare compulit et ei pro munere dedit sagittas, Hydrae felle tinctas. <milestone unit="par" n="2"/> Postea Troiano bello responsum est sagittis Herculis opus esse ad Troiae — seu Ilii — expugnationem. <milestone unit="par" n="3"/> Inuentus itaque Philoctetes, cum ab eo Hercules quaere<supplied>re</supplied>tur, et negaret primo se <del>se</del> scire ubi esset Hercules, tandem confessus est mortuum esse; inde cum acriter ad indicandum sepulcrum eius cogeretur, pede locum percussit, cum nollet dicere. <milestone unit="par" n="4"/> Postea pergens ad bellum, cum exerceretur, sagittae unius casu uulneratus est in pede, quo percusserat tumulum. <milestone unit="par" n="5"/> Ergo cum foetorem insanabilis uulneris Graeci ferre non possent, diu equidem pro oraculi ne<del>s</del>cessitate ductum tandem apud Lemnum sublatis reliquerunt sagittis. <milestone unit="par" n="6"/> Hic postea horrore sui uulneris ad patriam redire neglexit, sed sibi paruam Petiliam in Calabriae partibus fecit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Philoctetes fuit Phiantis filius, Herculis comes;
+                  quem Hercules, cum hominem in <supplied>O</supplied>et<del>hn</del>a monte
+                  deponeret, petiit, ne alicui sui corporis reliquias indicaret; de qua re eum
+                  iurare compulit et ei pro munere dedit sagittas, Hydrae felle tinctas. <milestone
+                     unit="par" n="2"/> Postea Troiano bello responsum est sagittis Herculis opus
+                  esse ad Troiae — seu Ilii — expugnationem. <milestone unit="par" n="3"/> Inuentus
+                  itaque Philoctetes, cum ab eo Hercules quaere<supplied>re</supplied>tur, et
+                  negaret primo se <del>se</del> scire ubi esset Hercules, tandem confessus est
+                  mortuum esse; inde cum acriter ad indicandum sepulcrum eius cogeretur, pede locum
+                  percussit, cum nollet dicere. <milestone unit="par" n="4"/> Postea pergens ad
+                  bellum, cum exerceretur, sagittae unius casu uulneratus est in pede, quo
+                  percusserat tumulum. <milestone unit="par" n="5"/> Ergo cum foetorem insanabilis
+                  uulneris Graeci ferre non possent, diu equidem pro oraculi ne<del>s</del>cessitate
+                  ductum tandem apud Lemnum sublatis reliquerunt sagittis. <milestone unit="par"
+                     n="6"/> Hic postea horrore sui uulneris ad patriam redire neglexit, sed sibi
+                  paruam Petiliam in Calabriae partibus fecit. </p>
             </div>
 
             <div type="cap" n="60">
                <head> Fabula nepotum Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Postquam Hercules migrauit e terris, nepotes eius, timentes insidias eorum, quos auus Hercules afflixerat multipliciter, Athenis sibi primi asylum, hoc est templum Mineruae, collocarunt, unde nullus posset abduci. <milestone unit="par" n="2"/> Quod et Statius dicit, ut <hi rend="italic">Herculeos fama est fundasse nepotes</hi>; ideo ergo ait: <hi rend="italic">Quod Romulus acer asylum retulit</hi>, hoc est templum fecit ad imitationem Atheniensis asyli. <milestone unit="par" n="3"/> Quod ideo Romulus fecit, ut haberet aduenas plures, cum quibus conderet Romam; unde Iuuenalis: <hi rend="italic">Et tamen ut longe repetas longeque reuoluas nomen, ab infami gente<supplied>m</supplied> deducis asylo</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Postquam Hercules migrauit e terris, nepotes eius,
+                  timentes insidias eorum, quos auus Hercules afflixerat multipliciter, Athenis sibi
+                  primi asylum, hoc est templum Mineruae, collocarunt, unde nullus posset abduci.
+                     <milestone unit="par" n="2"/> Quod et Statius dicit, ut <hi rend="italic"
+                     >Herculeos fama est fundasse nepotes</hi>; ideo ergo ait: <hi rend="italic"
+                     >Quod Romulus acer asylum retulit</hi>, hoc est templum fecit ad imitationem
+                  Atheniensis asyli. <milestone unit="par" n="3"/> Quod ideo Romulus fecit, ut
+                  haberet aduenas plures, cum quibus conderet Romam; unde Iuuenalis: <hi
+                     rend="italic">Et tamen ut longe repetas longeque reuoluas nomen, ab infami
+                        gente<supplied>m</supplied> deducis asylo</hi>. </p>
             </div>
 
             <div type="cap" n="61">
                <head> Fabula Pholi et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pholoe, silua Thessaliae, dicta a Pholo centauro qui eam incolebat, quia Pholus tempore, quo ab Eurystheo rege missus est Hercules <supplied>in</supplied> Thraciam, ut Diomedis equos adduceret, qui humanis carnibus uescebantur, eum hospitio recepit. <milestone unit="par" n="2"/> Alii, qui dicunt quod Hercules eum occidit, susceptus ab eo hospitio, errant; sed uerius Asper Longus Pholum tradit aduersum Centauros ab Hercule adductum, cum Herculem hospitio recepisset. <milestone unit="par" n="3"/> Asper et Pholum tradit, dum sagittas Herculis stupet, qui tot Centauros occiderat, unam ex illis in pedem cecidisse, cuius uulnere sanari non potuit; ideo credunt nonnulli ab Hercule occisum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pholoe, silua Thessaliae, dicta a Pholo centauro qui
+                  eam incolebat, quia Pholus tempore, quo ab Eurystheo rege missus est Hercules
+                     <supplied>in</supplied> Thraciam, ut Diomedis equos adduceret, qui humanis
+                  carnibus uescebantur, eum hospitio recepit. <milestone unit="par" n="2"/> Alii,
+                  qui dicunt quod Hercules eum occidit, susceptus ab eo hospitio, errant; sed uerius
+                  Asper Longus Pholum tradit aduersum Centauros ab Hercule adductum, cum Herculem
+                  hospitio recepisset. <milestone unit="par" n="3"/> Asper et Pholum tradit, dum
+                  sagittas Herculis stupet, qui tot Centauros occiderat, unam ex illis in pedem
+                  cecidisse, cuius uulnere sanari non potuit; ideo credunt nonnulli ab Hercule
+                  occisum. </p>
             </div>
 
             <div type="cap" n="62">
                <head> Fabula Hydrae et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hydra fuit in Lerna, Argiuorum palude, serpens quinquaginta habens capita, uel, ut quidam dicunt, septem, qui omnem regionem deuorabat. <milestone unit="par" n="2"/> Quod cum audisset Hercules, adiens eum expugnabat. <milestone unit="par" n="3"/> Et uno caeso tria capita crescebant, unde et latine excetra est dicta. <milestone unit="par" n="4"/> Quam postea Hydram Hercules deuicit. <milestone unit="par" n="5"/> Sed constat Hydram locum fuisse euomentem aquas uastante<del>n</del>s uicinam ciuitatem, in quo meatu uno clauso multi erumpebant; quod Hercules uidens, ipsa loca exussit et sic meatum aquae clausit; nam Hydra ab aqua est dicta. <milestone unit="par" n="6"/> Potuisse autem haec fieri, ille indicat locus ubi dicit: <hi rend="italic">Excoquitur uitium atque exu<del>n</del>dat inutilis humor</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hydra fuit in Lerna, Argiuorum palude, serpens
+                  quinquaginta habens capita, uel, ut quidam dicunt, septem, qui omnem regionem
+                  deuorabat. <milestone unit="par" n="2"/> Quod cum audisset Hercules, adiens eum
+                  expugnabat. <milestone unit="par" n="3"/> Et uno caeso tria capita crescebant,
+                  unde et latine excetra est dicta. <milestone unit="par" n="4"/> Quam postea Hydram
+                  Hercules deuicit. <milestone unit="par" n="5"/> Sed constat Hydram locum fuisse
+                  euomentem aquas uastante<del>n</del>s uicinam ciuitatem, in quo meatu uno clauso
+                  multi erumpebant; quod Hercules uidens, ipsa loca exussit et sic meatum aquae
+                  clausit; nam Hydra ab aqua est dicta. <milestone unit="par" n="6"/> Potuisse autem
+                  haec fieri, ille indicat locus ubi dicit: <hi rend="italic">Excoquitur uitium
+                     atque exu<del>n</del>dat inutilis humor</hi>. </p>
             </div>
 
             <div type="cap" n="63">
                <head> Fabula erumnarum Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Aliae quaedam, praeter has quae hic continentur, fabulae de Hercule finguntur. <milestone unit="par" n="2"/> Nam fertur et Eryma<supplied>n</supplied>theum quendam aprum occidisse, et ceruo cuidam aurea cornua abstulisse, et Amazonam balteo <supplied>spoliasse</supplied>, et de equis Diomedis uictoriam rapuisse, et — Lucano attestante — Ossam monte<supplied>m</supplied> superpositum a gigantibus Olympo deiecisse. <milestone unit="par" n="3"/> Sub uno anhelitu CXXV passus cursu pedum percurrebat. <milestone unit="par" n="4"/> Quae tamen praedictae fabulae ideo hic non plene scribuntur, quia raro inueniuntur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Aliae quaedam, praeter has quae hic continentur,
+                  fabulae de Hercule finguntur. <milestone unit="par" n="2"/> Nam fertur et
+                     Eryma<supplied>n</supplied>theum quendam aprum occidisse, et ceruo cuidam aurea
+                  cornua abstulisse, et Amazonam balteo <supplied>spoliasse</supplied>, et de equis
+                  Diomedis uictoriam rapuisse, et — Lucano attestante — Ossam
+                     monte<supplied>m</supplied> superpositum a gigantibus Olympo deiecisse.
+                     <milestone unit="par" n="3"/> Sub uno anhelitu CXXV passus cursu pedum
+                  percurrebat. <milestone unit="par" n="4"/> Quae tamen praedictae fabulae ideo hic
+                  non plene scribuntur, quia raro inueniuntur. </p>
             </div>
 
             <div type="cap" n="64">
-               <head> Fabula Eurysthei et Herculis.</head> 
-               <p>Eurystheus rex fuit Graeciae, Persei genus, qui Iunonis instinctu imperabat Herculi ut uaria monstra superaret, quibus posset perire; unde eum durum appellauit, qui potuit ad complendum odium nouercale sufficere. </p>
+               <head> Fabula Eurysthei et Herculis.</head>
+               <p>Eurystheus rex fuit Graeciae, Persei genus, qui Iunonis instinctu imperabat
+                  Herculi ut uaria monstra superaret, quibus posset perire; unde eum durum
+                  appellauit, qui potuit ad complendum odium nouercale sufficere. </p>
             </div>
 
             <div type="cap" n="65">
-               <head> Fabula Busiridis et Herculis.</head> 
-               <p>Busiris rex fuit Aegypti, qui cum susceptos hospites immolaret, ab Hercule interemptus est, cum etiam eum uoluisset occidere. </p>
+               <head> Fabula Busiridis et Herculis.</head>
+               <p>Busiris rex fuit Aegypti, qui cum susceptos hospites immolaret, ab Hercule
+                  interemptus est, cum etiam eum uoluisset occidere. </p>
             </div>
 
             <div type="cap" n="66">
                <head> Fabula Caci et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cacus filius Vulcani fuit, ignem ore uomens, qui uicina omnia populabat<supplied>ur</supplied>; quem Hercules occidit. <milestone unit="par" n="2"/> Secundum ueritatem fuit Euandri seruus pessimus et fur et ideo cacus dicitur, quod graece malum sonat; ignem ore uomere dicitur, quia agros igne uastabat. </p>
                <p>
-                  <milestone unit="par" n="3"/> Cacus Iouis, cum in arbore fici formicas — id est myrmicas — uidisset, optauit tot sibi socios euenire et statim formicae in homines uersae sunt. <milestone unit="par" n="4"/> Sed hoc fabula est; nam, ut <supplied>Erat</supplied>osthenes dicit, Myrmidonae dicti sunt a rege Myrmidono. </p>
+                  <milestone unit="par" n="1"/> Cacus filius Vulcani fuit, ignem ore uomens, qui
+                  uicina omnia populabat<supplied>ur</supplied>; quem Hercules occidit. <milestone
+                     unit="par" n="2"/> Secundum ueritatem fuit Euandri seruus pessimus et fur et
+                  ideo cacus dicitur, quod graece malum sonat; ignem ore uomere dicitur, quia agros
+                  igne uastabat. </p>
+               <p>
+                  <milestone unit="par" n="3"/> Cacus Iouis, cum in arbore fici formicas — id est
+                  myrmicas — uidisset, optauit tot sibi socios euenire et statim formicae in homines
+                  uersae sunt. <milestone unit="par" n="4"/> Sed hoc fabula est; nam, ut
+                     <supplied>Erat</supplied>osthenes dicit, Myrmidonae dicti sunt a rege
+                  Myrmidono. </p>
             </div>
 
             <div type="cap" n="67">
                <head> Fabula Geryonis et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Geryon rex insulae Eryth<del>im</del>iae — uel Hispaniae — fuit. <milestone unit="par" n="2"/> Et ideo tergeminus — uel tricorpor — dicitur, quia tria capita habuit uel, secundum alios, quinquaginta: tria capita, uel quia tribus insulis imperauit, uel quia tres fratres concordissimi fuerunt. <milestone unit="par" n="3"/> Ad quem interficiendum Eurystheus Iunonis instinctu Herculem misit, sperans eum ibidem interiturum. <milestone unit="par" n="4"/> Illuc pergens Hercules cum aerea olla et bicipiti cane — aerea olla ob aeratas naues, bicipiti cane, quia nauali et terrestri proelio plurimum ualuit — uenit ad oceanum et nulla naue inuenta alnum conscendit et in insulam Erith<del>im</del>iam peruenit. <milestone unit="par" n="5"/> Vbi primum canem Othrum interfecit et <supplied>Er</supplied>ythi<del>mi</del>am filiam eius, deinde Erytionem pastorem, filium Martis, nouissime ipsum Geryonem interfecit et sic uictor armenta eius in Graeciam adduxit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Geryon rex insulae Eryth<del>im</del>iae — uel
+                  Hispaniae — fuit. <milestone unit="par" n="2"/> Et ideo tergeminus — uel tricorpor
+                  — dicitur, quia tria capita habuit uel, secundum alios, quinquaginta: tria capita,
+                  uel quia tribus insulis imperauit, uel quia tres fratres concordissimi fuerunt.
+                     <milestone unit="par" n="3"/> Ad quem interficiendum Eurystheus Iunonis
+                  instinctu Herculem misit, sperans eum ibidem interiturum. <milestone unit="par"
+                     n="4"/> Illuc pergens Hercules cum aerea olla et bicipiti cane — aerea olla ob
+                  aeratas naues, bicipiti cane, quia nauali et terrestri proelio plurimum ualuit —
+                  uenit ad oceanum et nulla naue inuenta alnum conscendit et in insulam
+                     Erith<del>im</del>iam peruenit. <milestone unit="par" n="5"/> Vbi primum canem
+                  Othrum interfecit et <supplied>Er</supplied>ythi<del>mi</del>am filiam eius,
+                  deinde Erytionem pastorem, filium Martis, nouissime ipsum Geryonem interfecit et
+                  sic uictor armenta eius in Graeciam adduxit. </p>
             </div>
 
             <div type="cap" n="68">
                <head> Fabula Euandri et Herculis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules primum ab Euandro non est susceptus, postea cum filium Iouis <supplied>se</supplied> diceret et morte Caci uirtutem probaret, susceptus et pro numine habitus est; denique Aram Maximam ei constituit. <milestone unit="par" n="2"/> Cum ergo Hercules quaedam capita de armentis Geryonis patri suo immolare statuisset, inuenti sunt duo senes, Pinarius et Potitius; quibus Hercules ostendit, quali ritu se coli uellet, scilicet ut mane et uespere ei sacrificaretur. <milestone unit="par" n="3"/> Itaque perfecto matutino sacrificio, cum ad sacrificium uespertinum prior Potitius perueniret, iratus Hercules iussit ut Pinarii domus ministra esset epulantibus Potitiis <del>ministraret</del>.</p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules primum ab Euandro non est susceptus, postea
+                  cum filium Iouis <supplied>se</supplied> diceret et morte Caci uirtutem probaret,
+                  susceptus et pro numine habitus est; denique Aram Maximam ei constituit.
+                     <milestone unit="par" n="2"/> Cum ergo Hercules quaedam capita de armentis
+                  Geryonis patri suo immolare statuisset, inuenti sunt duo senes, Pinarius et
+                  Potitius; quibus Hercules ostendit, quali ritu se coli uellet, scilicet ut mane et
+                  uespere ei sacrificaretur. <milestone unit="par" n="3"/> Itaque perfecto matutino
+                  sacrificio, cum ad sacrificium uespertinum prior Potitius perueniret, iratus
+                  Hercules iussit ut Pinarii domus ministra esset epulantibus Potitiis
+                     <del>ministraret</del>.</p>
             </div>
 
             <div type="cap" n="69">
                <head> Fabula Euandri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Euander nepos Pallantis, regis Arcadiae, fuit. <milestone unit="par" n="2"/> Hic patrem suum occidit et matre suadente Nicostrata, quae postea Carmentis dicta est, expulsis ueteribus colonis loca obtinuit, ubi postea Roma constructa est, et modicum oppidum fundauit in monte Palanteo, qui nomen habuit de Pallante proauo Euandri. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Euander nepos Pallantis, regis Arcadiae, fuit.
+                     <milestone unit="par" n="2"/> Hic patrem suum occidit et matre suadente
+                  Nicostrata, quae postea Carmentis dicta est, expulsis ueteribus colonis loca
+                  obtinuit, ubi postea Roma constructa est, et modicum oppidum fundauit in monte
+                  Palanteo, qui nomen habuit de Pallante proauo Euandri. </p>
             </div>
 
             <div type="cap" n="70">
                <head> Fabula Bellerophontis, qui et Perseus.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Bellerophons, qui et Perseus, Glauci filius, cum ignarus ad Proetum in hospitium uenisset et uxor Proeti Sthenoboea — siue Antia — illum amaret, nec ab eo impetrare potuisset, ut secum concumberet, mentita est apud uirum ab eo se compellatam pro stupro fuisse. <milestone unit="par" n="2"/> Proetus uero ad Iuuatem socerum suum misit eum et de eadem re Bellerophonti dedit tabulas perferendas socero; quibus ille lectis, interficere talem uolebat uirum. <milestone unit="par" n="3"/> Sed cum ille prudentia sua et castitatis auxilio se ab instanti periculo liberasset, tamen, ut pudicitiam periculi probaret inmanitas, ad interficiendum Ch<supplied>i</supplied>maeram missus est: quam Pegas<del>g</del>o iuuante prostrauit. <milestone unit="par" n="4"/> Denuo eum misit, ut Calydonas uinceret. <milestone unit="par" n="5"/> Etiam illos cum uicisset, nouissime Iuuates agnouit, quae sibi fuisset causa tanta mala patiendi criminaque, quae in eum conficta erant, aboleuit. <milestone unit="par" n="6"/> Virtute quoque magnifice collaudata filiam suam Alcimenen dedit ei uxorem. <milestone unit="par" n="7"/> At Sthenoboea — quae et Antia — re cognita propria manu interiit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Bellerophons, qui et Perseus, Glauci filius, cum
+                  ignarus ad Proetum in hospitium uenisset et uxor Proeti Sthenoboea — siue Antia —
+                  illum amaret, nec ab eo impetrare potuisset, ut secum concumberet, mentita est
+                  apud uirum ab eo se compellatam pro stupro fuisse. <milestone unit="par" n="2"/>
+                  Proetus uero ad Iuuatem socerum suum misit eum et de eadem re Bellerophonti dedit
+                  tabulas perferendas socero; quibus ille lectis, interficere talem uolebat uirum.
+                     <milestone unit="par" n="3"/> Sed cum ille prudentia sua et castitatis auxilio
+                  se ab instanti periculo liberasset, tamen, ut pudicitiam periculi probaret
+                  inmanitas, ad interficiendum Ch<supplied>i</supplied>maeram missus est: quam
+                     Pegas<del>g</del>o iuuante prostrauit. <milestone unit="par" n="4"/> Denuo eum
+                  misit, ut Calydonas uinceret. <milestone unit="par" n="5"/> Etiam illos cum
+                  uicisset, nouissime Iuuates agnouit, quae sibi fuisset causa tanta mala patiendi
+                  criminaque, quae in eum conficta erant, aboleuit. <milestone unit="par" n="6"/>
+                  Virtute quoque magnifice collaudata filiam suam Alcimenen dedit ei uxorem.
+                     <milestone unit="par" n="7"/> At Sthenoboea — quae et Antia — re cognita
+                  propria manu interiit. </p>
             </div>
 
             <div type="cap" n="71">
                <head> Fabula Chimerae et Bellerophontis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Chimaera, monstrum, Tyronis et Achemenidae filia fuit. <milestone unit="par" n="2"/> Cuius triplex dicitur forma: prima namque leonis horrebat facie, media caprae, cauda imitabatur draconem. <milestone unit="par" n="3"/> Haec cum in Lycia iuxta Gargarum montem popularetur terras, a Bellerophonte interfecta est. <milestone unit="par" n="4"/> Quidam Chimaeram dicunt non animal, sed montem Lyciae, quibusdam locis leones et capras nutrientem, quibusdam ard<del>er</del>entem, quibusdam plenum serpentibus. <milestone unit="par" n="5"/> Hunc Bellerophons habita<supplied>bi</supplied>lem reddidit, unde et Chimaeram occidisse dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Chimaera, monstrum, Tyronis et Achemenidae filia
+                  fuit. <milestone unit="par" n="2"/> Cuius triplex dicitur forma: prima namque
+                  leonis horrebat facie, media caprae, cauda imitabatur draconem. <milestone
+                     unit="par" n="3"/> Haec cum in Lycia iuxta Gargarum montem popularetur terras,
+                  a Bellerophonte interfecta est. <milestone unit="par" n="4"/> Quidam Chimaeram
+                  dicunt non animal, sed montem Lyciae, quibusdam locis leones et capras nutrientem,
+                  quibusdam ard<del>er</del>entem, quibusdam plenum serpentibus. <milestone
+                     unit="par" n="5"/> Hunc Bellerophons habita<supplied>bi</supplied>lem reddidit,
+                  unde et Chimaeram occidisse dicitur. </p>
             </div>
 
             <div type="cap" n="72">
                <head> Fabula Persei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Perseus, per Aethiopiam iter faciens, postquam Andromeden propter superbiam matris, quae se nympharum pulchritudini praetulerat, saxo illigatam ac marinae beluae obiectam uidit, captus specie eius exarsit. <milestone unit="par" n="2"/> Pactusque est a Cepheo et Cassiopia, parentibus uirginis, ut sibi matrimonio iungerent, si beluam interemisset. <milestone unit="par" n="3"/> Perfecto igitur <supplied>a</supplied> Perseo pollicito, cum fides promissa a Cepheo esset praestita et nuptiarum coniugalium epulis principes interessent, Phineus, cui Andromeda ante fuerat desponsata, contumeliam sibi existimans grauiss<supplied>im</supplied>am iniunctam, quod aduenae consanguineus postpositus esset, uescentium animos pugna confu<del>n</del>dit. <milestone unit="par" n="4"/> Et cum res miserabilis dimicantium ageretur in regia ac multi ex utraque parte armis, quae casus obtulisset, cecidissent, nouissime Perseus, pertimescens multitudinem aduersariorum, caput Gorgonis extulit; quo uiso Phineus cum auxiliantibus diriguit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Perseus, per Aethiopiam iter faciens, postquam
+                  Andromeden propter superbiam matris, quae se nympharum pulchritudini praetulerat,
+                  saxo illigatam ac marinae beluae obiectam uidit, captus specie eius exarsit.
+                     <milestone unit="par" n="2"/> Pactusque est a Cepheo et Cassiopia, parentibus
+                  uirginis, ut sibi matrimonio iungerent, si beluam interemisset. <milestone
+                     unit="par" n="3"/> Perfecto igitur <supplied>a</supplied> Perseo pollicito, cum
+                  fides promissa a Cepheo esset praestita et nuptiarum coniugalium epulis principes
+                  interessent, Phineus, cui Andromeda ante fuerat desponsata, contumeliam sibi
+                  existimans grauiss<supplied>im</supplied>am iniunctam, quod aduenae consanguineus
+                  postpositus esset, uescentium animos pugna confu<del>n</del>dit. <milestone
+                     unit="par" n="4"/> Et cum res miserabilis dimicantium ageretur in regia ac
+                  multi ex utraque parte armis, quae casus obtulisset, cecidissent, nouissime
+                  Perseus, pertimescens multitudinem aduersariorum, caput Gorgonis extulit; quo uiso
+                  Phineus cum auxiliantibus diriguit. </p>
             </div>
 
             <div type="cap" n="73">
                <head> Fabula Tarquinii et Lucretiae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tarquinius Superbus habuit perditos filios, inter quos Arruntem. <milestone unit="par" n="2"/> Qui dum in castris esset patre suo Ardeam obsidente et ortus esset inter eum et Collatinum, maritum Lucretiae, de uxoribus sermo, eousque processit contentio, ut ad probandos earum mores arreptis equis statim in domos suas simul proficiscerentur. <milestone unit="par" n="3"/> Ingressi itaque ciuitatem Collatiam, ubi fuit Lucretiae domus, inuenerunt eam lanificio dare operam et tristem propter mariti absentiam. <milestone unit="par" n="4"/> Inde ad Arruntis domum profecti, cum uxorem eius inuenissent cantilenis et saltationibus indulgentem, reuersi ad castra sunt. <milestone unit="par" n="5"/> Quod Arruns dolens, cum de expugnabili Lucretiae castitate cogitaret, mariti eius nomine epistolam finxit et dedit Lucretiae; in qua hoc continebatur ut Arruns susciperetur hospitio. <milestone unit="par" n="6"/> Quo facto per noctem stricto gladio eius ingressus cubiculum cum Aethiope hac arte egit, ut secum coiret, dicens: «Nisi mecum concubueris, Aethiopem tecum interimo, tamquam in adulterio deprehensam!» <milestone unit="par" n="7"/> Timens itaque Lucretia ne famam castitatis amore deperderet, quippe quam sine purgatione futuram esse cernebat, inuita turpibus imperiis paruit. <milestone unit="par" n="8"/> Et altero die conuocatis propinquis, marito Collatino, patre Tricipitino, Bruto auunculo, qui tribunus equitum celerum fuerat, rem indicans, petiit ne uiolatus pudor neue inultus eius <supplied>esset</supplied> interitus et eiecto gladio se interemit. <milestone unit="par" n="9"/> Quem Brutus de eius corpore extractum tenens, processit ad populum et multa conquestus de Tarquinii superbia et filiorum eius turpitudine egit, ne in urbem reciperentur, auctoritate qua plurimum poterat; nam, ut supra diximus, Brutus tribunus equitum fuerat. <milestone unit="par" n="10"/> Sed cum non susciperetur, Tarquinius contulit se ad regem Tusciae Porsennam; qui pro Tarquinio cum ingentibus copiis capto Ianiculo et illic castris positis Romam uehementer obsedit. <milestone unit="par" n="11"/> Et cum per Sublicium pontem — hoc est ligneum — transire conaretur, solus Cocles hostilem impetum sustinuit, donec a tergo pons solueretur a sociis. <milestone unit="par" n="12"/> Quo soluto se cum armis praecipitauit in Tiberim et licet laesus in coxa, tamen fluenta superauit; unde est illud ab eo dictum, cum ei in comitiis coxae uitium obiceretur: «Per singulos gradus admoneor triumphi mei!». <milestone unit="par" n="13"/> In tantam autem obsidionis necessitatem populus uenerat ut et obsides daret; ex quibus C<supplied>l</supplied>oelia inuenta occasione transnatauit fluuium et Romam reuersa est redditaque rursus est pacis lege, eam Porsenna repetente. <milestone unit="par" n="14"/> Qui admiratus uirtutem puellae, dedit ei optionem ut cum quibus uellet rediret; illa elegit uirg<supplied>i</supplied>nes. <milestone unit="par" n="15"/> Vnde Porsenna, hoc quoque miratus, concessit et rogauit per litteras populum Romanum ut ei aliquid uirile decerneretur; cui data est statua equestris, quam in sacra uia hodie conspicimus. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tarquinius Superbus habuit perditos filios, inter
+                  quos Arruntem. <milestone unit="par" n="2"/> Qui dum in castris esset patre suo
+                  Ardeam obsidente et ortus esset inter eum et Collatinum, maritum Lucretiae, de
+                  uxoribus sermo, eousque processit contentio, ut ad probandos earum mores arreptis
+                  equis statim in domos suas simul proficiscerentur. <milestone unit="par" n="3"/>
+                  Ingressi itaque ciuitatem Collatiam, ubi fuit Lucretiae domus, inuenerunt eam
+                  lanificio dare operam et tristem propter mariti absentiam. <milestone unit="par"
+                     n="4"/> Inde ad Arruntis domum profecti, cum uxorem eius inuenissent cantilenis
+                  et saltationibus indulgentem, reuersi ad castra sunt. <milestone unit="par" n="5"
+                  /> Quod Arruns dolens, cum de expugnabili Lucretiae castitate cogitaret, mariti
+                  eius nomine epistolam finxit et dedit Lucretiae; in qua hoc continebatur ut Arruns
+                  susciperetur hospitio. <milestone unit="par" n="6"/> Quo facto per noctem stricto
+                  gladio eius ingressus cubiculum cum Aethiope hac arte egit, ut secum coiret,
+                  dicens: «Nisi mecum concubueris, Aethiopem tecum interimo, tamquam in adulterio
+                  deprehensam!» <milestone unit="par" n="7"/> Timens itaque Lucretia ne famam
+                  castitatis amore deperderet, quippe quam sine purgatione futuram esse cernebat,
+                  inuita turpibus imperiis paruit. <milestone unit="par" n="8"/> Et altero die
+                  conuocatis propinquis, marito Collatino, patre Tricipitino, Bruto auunculo, qui
+                  tribunus equitum celerum fuerat, rem indicans, petiit ne uiolatus pudor neue
+                  inultus eius <supplied>esset</supplied> interitus et eiecto gladio se interemit.
+                     <milestone unit="par" n="9"/> Quem Brutus de eius corpore extractum tenens,
+                  processit ad populum et multa conquestus de Tarquinii superbia et filiorum eius
+                  turpitudine egit, ne in urbem reciperentur, auctoritate qua plurimum poterat; nam,
+                  ut supra diximus, Brutus tribunus equitum fuerat. <milestone unit="par" n="10"/>
+                  Sed cum non susciperetur, Tarquinius contulit se ad regem Tusciae Porsennam; qui
+                  pro Tarquinio cum ingentibus copiis capto Ianiculo et illic castris positis Romam
+                  uehementer obsedit. <milestone unit="par" n="11"/> Et cum per Sublicium pontem —
+                  hoc est ligneum — transire conaretur, solus Cocles hostilem impetum sustinuit,
+                  donec a tergo pons solueretur a sociis. <milestone unit="par" n="12"/> Quo soluto
+                  se cum armis praecipitauit in Tiberim et licet laesus in coxa, tamen fluenta
+                  superauit; unde est illud ab eo dictum, cum ei in comitiis coxae uitium
+                  obiceretur: «Per singulos gradus admoneor triumphi mei!». <milestone unit="par"
+                     n="13"/> In tantam autem obsidionis necessitatem populus uenerat ut et obsides
+                  daret; ex quibus C<supplied>l</supplied>oelia inuenta occasione transnatauit
+                  fluuium et Romam reuersa est redditaque rursus est pacis lege, eam Porsenna
+                  repetente. <milestone unit="par" n="14"/> Qui admiratus uirtutem puellae, dedit ei
+                  optionem ut cum quibus uellet rediret; illa elegit uirg<supplied>i</supplied>nes.
+                     <milestone unit="par" n="15"/> Vnde Porsenna, hoc quoque miratus, concessit et
+                  rogauit per litteras populum Romanum ut ei aliquid uirile decerneretur; cui data
+                  est statua equestris, quam in sacra uia hodie conspicimus. </p>
             </div>
 
             <div type="cap" n="74">
                <head> Fabula Hymenaei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hymenaeus, puer formosissimus, genere Atheniensis fuit. <milestone unit="par" n="2"/> Is cum annos puerilis ae<del>s</del>tatis excederet neque adhuc uirum implere posset, ea pulchritudine praeditus fuisse dicitur, ut feminam mentiretur. <milestone unit="par" n="3"/> Istum cum una ex ciuibus suis, uirgo nobilis, adamasset, ipse mediocribus ortus parentibus, quia nuptias desperabat, quod poterat tamen, puellam extrema amoris linea diligens, eius animo solo satisfaciebat aspectu. <milestone unit="par" n="4"/> Cumque nobiles feminae cum uirginibus sacra Cereris Eleu<del>i</del>sinae celebrarent, subito aduentu piratarum raptae sunt. <milestone unit="par" n="5"/> Inter quas et Hymen<supplied>ae</supplied>us, qui illo amatam subsecutus fuerat, cum puella abripitur. <milestone unit="par" n="6"/> Cum igitur per longinqua maria praedam piratae uexissent, ad quandam regionem tandem perueniunt, ubi et somno pressi ab insequentibus sunt perempti. <milestone unit="par" n="7"/> Hymenaeus relictis ibi uirginibus, reuersus Athenas, pactus est a ciuibus dilectae suae nuptias, si eis filias suas restitueret. <milestone unit="par" n="8"/> Quas ubi pro uoto restituit, exoptatam accepit uxorem. <milestone unit="par" n="9"/> Quod coniugium quia felix fuerat, placuit Atheniensibus nomen nuptiis Hymenaei miscere. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hymenaeus, puer formosissimus, genere Atheniensis
+                  fuit. <milestone unit="par" n="2"/> Is cum annos puerilis ae<del>s</del>tatis
+                  excederet neque adhuc uirum implere posset, ea pulchritudine praeditus fuisse
+                  dicitur, ut feminam mentiretur. <milestone unit="par" n="3"/> Istum cum una ex
+                  ciuibus suis, uirgo nobilis, adamasset, ipse mediocribus ortus parentibus, quia
+                  nuptias desperabat, quod poterat tamen, puellam extrema amoris linea diligens,
+                  eius animo solo satisfaciebat aspectu. <milestone unit="par" n="4"/> Cumque
+                  nobiles feminae cum uirginibus sacra Cereris Eleu<del>i</del>sinae celebrarent,
+                  subito aduentu piratarum raptae sunt. <milestone unit="par" n="5"/> Inter quas et
+                     Hymen<supplied>ae</supplied>us, qui illo amatam subsecutus fuerat, cum puella
+                  abripitur. <milestone unit="par" n="6"/> Cum igitur per longinqua maria praedam
+                  piratae uexissent, ad quandam regionem tandem perueniunt, ubi et somno pressi ab
+                  insequentibus sunt perempti. <milestone unit="par" n="7"/> Hymenaeus relictis ibi
+                  uirginibus, reuersus Athenas, pactus est a ciuibus dilectae suae nuptias, si eis
+                  filias suas restitueret. <milestone unit="par" n="8"/> Quas ubi pro uoto
+                  restituit, exoptatam accepit uxorem. <milestone unit="par" n="9"/> Quod coniugium
+                  quia felix fuerat, placuit Atheniensibus nomen nuptiis Hymenaei miscere. </p>
             </div>
 
             <div type="cap" n="75">
                <head> Fabula Orphei et Eurydices.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Orpheus, Oeagri et Caliopae Musae filius, ut quidam putant, Apollinis filia<supplied>m</supplied> habuit uxorem Eurydicen. <milestone unit="par" n="2"/> Quam dum Aristaeus, Cyrenis filius, pastor, cupidus persequitur uolens eam stuprare, illa fugiens concubitum serpentem non deuitauit et haec ei causa mortis fuit. <milestone unit="par" n="3"/> Orpheus coactus desiderio coniugis temptauit dulcedine cantus citharae lenire Ditem et Proserpinam, si posset Eurydicen ad superos reuocare. <milestone unit="par" n="4"/> Descendit igitur ad inferos et in miserationem eos cantu suo conpulit; acceptaque lege impetrauit Eurydicen ita demum, si non ante respexisset quam ad superos perueniret. <milestone unit="par" n="5"/> Vt deinde est dura amantium perseuerantia, Orpheus timens ne non inesset pollicitis Di<del>c</del>tis fides, respexit et irritum fecit suum laborem. <milestone unit="par" n="6"/> Reuersus deinde ad superos, qui parum prosperas expertus erat nuptias, perosus omne genus femineum solitudinibus se dedit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Orpheus, Oeagri et Caliopae Musae filius, ut quidam
+                  putant, Apollinis filia<supplied>m</supplied> habuit uxorem Eurydicen. <milestone
+                     unit="par" n="2"/> Quam dum Aristaeus, Cyrenis filius, pastor, cupidus
+                  persequitur uolens eam stuprare, illa fugiens concubitum serpentem non deuitauit
+                  et haec ei causa mortis fuit. <milestone unit="par" n="3"/> Orpheus coactus
+                  desiderio coniugis temptauit dulcedine cantus citharae lenire Ditem et
+                  Proserpinam, si posset Eurydicen ad superos reuocare. <milestone unit="par" n="4"
+                  /> Descendit igitur ad inferos et in miserationem eos cantu suo conpulit;
+                  acceptaque lege impetrauit Eurydicen ita demum, si non ante respexisset quam ad
+                  superos perueniret. <milestone unit="par" n="5"/> Vt deinde est dura amantium
+                  perseuerantia, Orpheus timens ne non inesset pollicitis Di<del>c</del>tis fides,
+                  respexit et irritum fecit suum laborem. <milestone unit="par" n="6"/> Reuersus
+                  deinde ad superos, qui parum prosperas expertus erat nuptias, perosus omne genus
+                  femineum solitudinibus se dedit. </p>
             </div>
 
             <div type="cap" n="76">
                <head> Fabula Castoris et Pollucis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Castor et Pollux Iouis et Ledae filii fuerunt; qui cum adamassent Phoeben et Dianisam, coniuges Linci et Idei, Aphar<supplied>e</supplied>i filiorum, et uellent eas rapere, Lincus — omnia cui uidendi potestas erat — Idam fratrem in uindictam concitauit. <milestone unit="par" n="2"/> Qui telum habebat, quod diuini teli similitudinem habebat ita ut nullus posset illud euadere; itaque eo misso interfecit Castorem; <supplied>ultor adest Pollux et Lincum perforat hasta . . .; ibat in hunc Idas</supplied>, cumque iam Pollucem uellet occidere, ab Ioue et fulmine percussus est. <milestone unit="par" n="3"/> Pollux uero uidens suum fratrem mortuum ad inferos descendit; inde cum fratre recepto ad superos euasit et Iouem orauit, ut caelestem honorem sibi traderet. <milestone unit="par" n="4"/> Inde inter astra collocati sunt et caelestem honorem habuerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Castor et Pollux Iouis et Ledae filii fuerunt; qui
+                  cum adamassent Phoeben et Dianisam, coniuges Linci et Idei,
+                     Aphar<supplied>e</supplied>i filiorum, et uellent eas rapere, Lincus — omnia
+                  cui uidendi potestas erat — Idam fratrem in uindictam concitauit. <milestone
+                     unit="par" n="2"/> Qui telum habebat, quod diuini teli similitudinem habebat
+                  ita ut nullus posset illud euadere; itaque eo misso interfecit Castorem;
+                     <supplied>ultor adest Pollux et Lincum perforat hasta . . .; ibat in hunc
+                     Idas</supplied>, cumque iam Pollucem uellet occidere, ab Ioue et fulmine
+                  percussus est. <milestone unit="par" n="3"/> Pollux uero uidens suum fratrem
+                  mortuum ad inferos descendit; inde cum fratre recepto ad superos euasit et Iouem
+                  orauit, ut caelestem honorem sibi traderet. <milestone unit="par" n="4"/> Inde
+                  inter astra collocati sunt et caelestem honorem habuerunt. </p>
             </div>
 
             <div type="cap" n="77">
                <head> Fabula cygni et Ledae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter, amorem Ledae uirginis affectans, conuersus in cygnum finxit se fugere aquilam; sed Mercurium in aquilam transmutauit. <milestone unit="par" n="2"/> Sic in gremio Ledae receptus, cum ea concubuit, quae peperit ouum, unde nati sunt tres: Castor, Pollux et Helena. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter, amorem Ledae uirginis affectans, conuersus
+                  in cygnum finxit se fugere aquilam; sed Mercurium in aquilam transmutauit.
+                     <milestone unit="par" n="2"/> Sic in gremio Ledae receptus, cum ea concubuit,
+                  quae peperit ouum, unde nati sunt tres: Castor, Pollux et Helena. </p>
             </div>
 
             <div type="cap" n="78">
                <head> Fabula Api<supplied>dis</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Refert Solinus quod inter omnia, quae Aegyptus <supplied>habet</supplied> digna memoratu, praecipue mirentur bouem, quem Apin uocant, insignem albae macula notae, quae dextro lateri eius ingenitam refert corniculatae lunae faciem. <milestone unit="par" n="2"/> Hunc Aegyptus ad instar numinis colit, eo quod de futuris det quaedam manifesta signa; apparet e<supplied>nim</supplied> in Memphis. <milestone unit="par" n="3"/> Cui statutum aeui spatium est; nam immersus profundo sacri fontis necatur, ne diem longius trahat quam licebit; mox alter sine publico luctu requiritur. <milestone unit="par" n="4"/> Hunc etenim centum antistites Memphim prosecuntur et repente, uelut lymphatici, praecinunt. <milestone unit="par" n="5"/> Dat omina manifestantia de futuris: illud maximum, si de c<supplied>onsu</supplied>l<del>i</del>entis manu cibum capiat. <milestone unit="par" n="6"/> Huius capitis imaginem sibi in heremo Iudaei fecerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Refert Solinus quod inter omnia, quae Aegyptus
+                     <supplied>habet</supplied> digna memoratu, praecipue mirentur bouem, quem Apin
+                  uocant, insignem albae macula notae, quae dextro lateri eius ingenitam refert
+                  corniculatae lunae faciem. <milestone unit="par" n="2"/> Hunc Aegyptus ad instar
+                  numinis colit, eo quod de futuris det quaedam manifesta signa; apparet
+                     e<supplied>nim</supplied> in Memphis. <milestone unit="par" n="3"/> Cui
+                  statutum aeui spatium est; nam immersus profundo sacri fontis necatur, ne diem
+                  longius trahat quam licebit; mox alter sine publico luctu requiritur. <milestone
+                     unit="par" n="4"/> Hunc etenim centum antistites Memphim prosecuntur et
+                  repente, uelut lymphatici, praecinunt. <milestone unit="par" n="5"/> Dat omina
+                  manifestantia de futuris: illud maximum, si de
+                     c<supplied>onsu</supplied>l<del>i</del>entis manu cibum capiat. <milestone
+                     unit="par" n="6"/> Huius capitis imaginem sibi in heremo Iudaei fecerunt. </p>
             </div>
 
             <div type="cap" n="79">
                <head> Fabula Tydei et Polynicis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tydeus, Oenei filius et Passiopae, Diomedis pater; is cum M<supplied>en</supplied>a<del>n</del>
-                  <supplied>l</supplied>ipp<del>l</del>um filium suum interfecisset, exul ad Argos peruenit et amicitia Adrasto regi iunctus est. <milestone unit="par" n="2"/> Ipso tempore Polynices regno expulsus est a fratre suo Eteocle, qui Thebis imperauit, et exul quoque ad Adrastum uenit. <milestone unit="par" n="3"/> Cum autem animaduertisset Adrastus responsum, quod ei Apollo dederat, futurum ut filias suas daret apro et leoni — nam Polyn<supplied>i</supplied>ces et Tydeus earum ferarum pellibus tecti erant —, existimauit rex eis debere filias suas in matrimonium dare. <milestone unit="par" n="4"/> Hinc Adrastus a<supplied>d</supplied>scitis ciuibus suis auxilium Polynici aduersum Eteoclem tulit; ibi Tydeus interfectus est, Polynices cum fratre mutuis uulneribus cecidit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tydeus, Oenei filius et Passiopae, Diomedis pater;
+                  is cum M<supplied>en</supplied>a<del>n</del>
+                  <supplied>l</supplied>ipp<del>l</del>um filium suum interfecisset, exul ad Argos
+                  peruenit et amicitia Adrasto regi iunctus est. <milestone unit="par" n="2"/> Ipso
+                  tempore Polynices regno expulsus est a fratre suo Eteocle, qui Thebis imperauit,
+                  et exul quoque ad Adrastum uenit. <milestone unit="par" n="3"/> Cum autem
+                  animaduertisset Adrastus responsum, quod ei Apollo dederat, futurum ut filias suas
+                  daret apro et leoni — nam Polyn<supplied>i</supplied>ces et Tydeus earum ferarum
+                  pellibus tecti erant —, existimauit rex eis debere filias suas in matrimonium
+                  dare. <milestone unit="par" n="4"/> Hinc Adrastus a<supplied>d</supplied>scitis
+                  ciuibus suis auxilium Polynici aduersum Eteoclem tulit; ibi Tydeus interfectus
+                  est, Polynices cum fratre mutuis uulneribus cecidit. </p>
             </div>
 
             <div type="cap" n="80">
                <head> Fabula Smicronis et Branchi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cius quidam rex cum in peregrinatione pranderet in litore ac deinde proficisceretur, oblitus est filium, nomine Smicronem; ille peruenit in saltum patroni cuiusdam et cum esset receptus coepit cum suis pueris capras pascere. <milestone unit="par" n="2"/> Aliquando prendiderunt cy<del>n</del>gnum et illum ueste cooperuerunt; dum ipsi pugnant ut illum patrono munus offer<supplied>r</supplied>ent et, cum iam essent fatigati certamine, reiecta ueste mulierem inuenerunt. <milestone unit="par" n="3"/> Et cum fugerent, reuocati ab ea moniti sunt ut patronus unice Smicronem diligeret puerum; illi quae audierunt patrono indicauerunt. <milestone unit="par" n="4"/> Tunc patronus Smicronem pro suo filio nimio dilexit affectu eique filiam suam ducendam locauit uxorem. <milestone unit="par" n="5"/> Illa cum praegnans ex eo esset, uidit in somnis per fauces suas introisse solem et exisse per uentrem; infans editus ideo Branchus uocatus est, quia mater eius per fauces sibi uiderat uterum penetrasse. <milestone unit="par" n="6"/> Hic cum in siluis Apollinem osculatus esset, comprehensus est ab eo et accepta corona uirgaque uaticinari coepit et subito nusquam comparuit. <milestone unit="par" n="7"/> Templum ei factum est, quod Branchiadon nominatur; et Apollini pariter Philesia consecrata sunt templa, quae ab osculo Branchi, siue certamine puerorum, Philesia nuncupa<supplied>n</supplied>tur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cius quidam rex cum in peregrinatione pranderet in
+                  litore ac deinde proficisceretur, oblitus est filium, nomine Smicronem; ille
+                  peruenit in saltum patroni cuiusdam et cum esset receptus coepit cum suis pueris
+                  capras pascere. <milestone unit="par" n="2"/> Aliquando prendiderunt
+                     cy<del>n</del>gnum et illum ueste cooperuerunt; dum ipsi pugnant ut illum
+                  patrono munus offer<supplied>r</supplied>ent et, cum iam essent fatigati
+                  certamine, reiecta ueste mulierem inuenerunt. <milestone unit="par" n="3"/> Et cum
+                  fugerent, reuocati ab ea moniti sunt ut patronus unice Smicronem diligeret puerum;
+                  illi quae audierunt patrono indicauerunt. <milestone unit="par" n="4"/> Tunc
+                  patronus Smicronem pro suo filio nimio dilexit affectu eique filiam suam ducendam
+                  locauit uxorem. <milestone unit="par" n="5"/> Illa cum praegnans ex eo esset,
+                  uidit in somnis per fauces suas introisse solem et exisse per uentrem; infans
+                  editus ideo Branchus uocatus est, quia mater eius per fauces sibi uiderat uterum
+                  penetrasse. <milestone unit="par" n="6"/> Hic cum in siluis Apollinem osculatus
+                  esset, comprehensus est ab eo et accepta corona uirgaque uaticinari coepit et
+                  subito nusquam comparuit. <milestone unit="par" n="7"/> Templum ei factum est,
+                  quod Branchiadon nominatur; et Apollini pariter Philesia consecrata sunt templa,
+                  quae ab osculo Branchi, siue certamine puerorum, Philesia
+                     nuncupa<supplied>n</supplied>tur. </p>
             </div>
 
             <div type="cap" n="81">
                <head> Fabula Salmonei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Salmoneus Elidorum rex fuit. <milestone unit="par" n="2"/> Qui, nimia felicitate elatus, suos ciues sacerdotes et sacra Iouis ad se transferre iussit sibique religiones illius et sacra impendi. <milestone unit="par" n="3"/> Hic uectus per aera curru imitabatur tonitrua et fa<del>s</del>ces <supplied>agitabat</supplied> in modum fulminis. <milestone unit="par" n="4"/> At Iouis uerum <supplied>f</supplied>ulmen torquens praecipitem in Tartara adegit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Salmoneus Elidorum rex fuit. <milestone unit="par"
+                     n="2"/> Qui, nimia felicitate elatus, suos ciues sacerdotes et sacra Iouis ad
+                  se transferre iussit sibique religiones illius et sacra impendi. <milestone
+                     unit="par" n="3"/> Hic uectus per aera curru imitabatur tonitrua et
+                     fa<del>s</del>ces <supplied>agitabat</supplied> in modum fulminis. <milestone
+                     unit="par" n="4"/> At Iouis uerum <supplied>f</supplied>ulmen torquens
+                  praecipitem in Tartara adegit. </p>
             </div>
 
             <div type="cap" n="82">
                <head> Fabula Aloei, Oti et Ephialtes.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Aloeus Iphimediam uxorem habuit; quae compressa a Neptuno duos peperit, Otum et Ephialtem, qui digitis nouem per singulos menses crescebant. <milestone unit="par" n="2"/> Freti namque altitudine, caelum uoluere subuertere, sed confixi sunt Dianae et Apollinis telis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Aloeus Iphimediam uxorem habuit; quae compressa a
+                  Neptuno duos peperit, Otum et Ephialtem, qui digitis nouem per singulos menses
+                  crescebant. <milestone unit="par" n="2"/> Freti namque altitudine, caelum uoluere
+                  subuertere, sed confixi sunt Dianae et Apollinis telis. </p>
             </div>
 
             <div type="cap" n="83">
                <head> Fabula Caeculi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Quidam enim infans, expositus a quodam famulo iuxta focum, in quo soliti erant pastores ignem accendere, calore ductus sese in calentes cineres misit inuentusque a pastoribus Vulcani filius creditus est et ab illis educatus; Caeculus est appellatus, quia paruulos ex igne habebat oculos. <milestone unit="par" n="2"/> Qui ad pubere<supplied>m</supplied> aetatem ueniens, ciuitatem in montibus construxit, quam Praeneste uocauit; uidensque illam frequentari, extruxit theatrum ligneum, ut finitimae gentes ad eam urbem concurrerent. <milestone unit="par" n="3"/> Prae<supplied>ne</supplied>ste oppidum eo tempore a Caeculo est constructum. <milestone unit="par" n="4"/> Cumque nullus eum filium crederet Vulcani, faces tradidit amicis suis et signo dato spectatores flamma circumseptos inuasit; rogatusque et probatus filius esse Vulcani, flammas exstinxit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Quidam enim infans, expositus a quodam famulo iuxta
+                  focum, in quo soliti erant pastores ignem accendere, calore ductus sese in
+                  calentes cineres misit inuentusque a pastoribus Vulcani filius creditus est et ab
+                  illis educatus; Caeculus est appellatus, quia paruulos ex igne habebat oculos.
+                     <milestone unit="par" n="2"/> Qui ad pubere<supplied>m</supplied> aetatem
+                  ueniens, ciuitatem in montibus construxit, quam Praeneste uocauit; uidensque illam
+                  frequentari, extruxit theatrum ligneum, ut finitimae gentes ad eam urbem
+                  concurrerent. <milestone unit="par" n="3"/> Prae<supplied>ne</supplied>ste oppidum
+                  eo tempore a Caeculo est constructum. <milestone unit="par" n="4"/> Cumque nullus
+                  eum filium crederet Vulcani, faces tradidit amicis suis et signo dato spectatores
+                  flamma circumseptos inuasit; rogatusque et probatus filius esse Vulcani, flammas
+                  exstinxit. </p>
             </div>
 
             <div type="cap" n="84">
                <head> Fabula trium Proetidum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Proetides Proeti, regis Argiuorum, de Sanabilia siue Sthenoboea uxore eius filiae natae fuerunt; quarum haec sunt nomina: Cresipe, E<del>t</del>finoe, Efianasa. <milestone unit="par" n="2"/> Quae insolentius gloriantes Iunoni suam formam praetulerunt et hoc sentiens Iuno in insaniam conuertit eas, quod putabant se uaccas esse et quaerebant in capitibus cornua et non inueniebant et dabant mugitus confusos usque dum a quodam Melampode sanatae sunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Proetides Proeti, regis Argiuorum, de Sanabilia siue
+                  Sthenoboea uxore eius filiae natae fuerunt; quarum haec sunt nomina: Cresipe,
+                     E<del>t</del>finoe, Efianasa. <milestone unit="par" n="2"/> Quae insolentius
+                  gloriantes Iunoni suam formam praetulerunt et hoc sentiens Iuno in insaniam
+                  conuertit eas, quod putabant se uaccas esse et quaerebant in capitibus cornua et
+                  non inueniebant et dabant mugitus confusos usque dum a quodam Melampode sanatae
+                  sunt. </p>
             </div>
 
             <div type="cap" n="85">
                <head> Fabula Pieridum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pieri, regis .Macedoniae, et Enipae nouem filiae insolentius dum gloriantur, Musas in certamina prouocauerunt cantus. <milestone unit="par" n="2"/> Quarum una carmen exorsa est, quod gigantes aduersus deos contenderint, ex quibus Typhoeus terrigena deformitate terruisset deos compulsos in Aegyptum. <milestone unit="par" n="3"/> Ibi Iuppiter ob metum in arietem uersus est, Apollo in coruum, Liber in caprum, Diana in felem, Iuno in uaccam, Venus in pis<supplied>c</supplied>em. <milestone unit="par" n="4"/> Inuicem autem Musae cum Cereris laudem cecinissent et qualiter Typhoeus Aetnae, monti<del>s</del> Siciliae, subiectus esset, Pierides uictae in picas sunt transfiguratae. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pieri, regis .Macedoniae, et Enipae nouem filiae
+                  insolentius dum gloriantur, Musas in certamina prouocauerunt cantus. <milestone
+                     unit="par" n="2"/> Quarum una carmen exorsa est, quod gigantes aduersus deos
+                  contenderint, ex quibus Typhoeus terrigena deformitate terruisset deos compulsos
+                  in Aegyptum. <milestone unit="par" n="3"/> Ibi Iuppiter ob metum in arietem uersus
+                  est, Apollo in coruum, Liber in caprum, Diana in felem, Iuno in uaccam, Venus in
+                     pis<supplied>c</supplied>em. <milestone unit="par" n="4"/> Inuicem autem Musae
+                  cum Cereris laudem cecinissent et qualiter Typhoeus Aetnae, monti<del>s</del>
+                  Siciliae, subiectus esset, Pierides uictae in picas sunt transfiguratae. </p>
             </div>
 
             <div type="cap" n="86">
                <head> Fabula Ouistae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ouista, pastor, filius Ynen regis, cum uideret caprum, a <supplied>g</supplied>rege saepius discedentem, eum secutus uuam depascentem inuenit in ripa Acheloi fluminis. <milestone unit="par" n="2"/> Quam statim expressit ac de aqua Acheloi fluminis, iuxta quam fuerat inuenta, commiscuit obtulitque regi; qui suo nomine graeco sermone ynen, id est uinum, appellauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Ouista, pastor, filius Ynen regis, cum uideret
+                  caprum, a <supplied>g</supplied>rege saepius discedentem, eum secutus uuam
+                  depascentem inuenit in ripa Acheloi fluminis. <milestone unit="par" n="2"/> Quam
+                  statim expressit ac de aqua Acheloi fluminis, iuxta quam fuerat inuenta,
+                  commiscuit obtulitque regi; qui suo nomine graeco sermone ynen, id est uinum,
+                  appellauit. </p>
             </div>
 
             <div type="cap" n="87">
                <head> Fabula Liberi, Sileni et Midae regis et Pactoli fluuii.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Liber Thracia digressus, cum in Tmolo monte iter ageret, Silenus nutritor eius a Phrygibus captus ad Midam regem ductus est. <milestone unit="par" n="2"/> Silenus autem, agnitus ab eo, acceptus est et Libero aduenienti redditus; et ob beneficium optandi deus arbitrium ei dedit, si quid uellet, a se petere. <milestone unit="par" n="3"/> Ille uero petit ut quae contigisset aurum fierent, quod inutile fuit. <milestone unit="par" n="4"/> Nam coepit sui uoti effectu torqueri, quia quicquid tetigerat, aurum statim efficiebatur. <milestone unit="par" n="5"/> Cui petenti, ut restitueretur sibi, fecit; iussit enim ut ad flumen Pactolum perueniret ibique <supplied>se</supplied> subponeret et sic rediret in pristinum statum. <milestone unit="par" n="6"/> Quo facto Pactolus deinceps arenas aureas trahere dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Liber Thracia digressus, cum in Tmolo monte iter
+                  ageret, Silenus nutritor eius a Phrygibus captus ad Midam regem ductus est.
+                     <milestone unit="par" n="2"/> Silenus autem, agnitus ab eo, acceptus est et
+                  Libero aduenienti redditus; et ob beneficium optandi deus arbitrium ei dedit, si
+                  quid uellet, a se petere. <milestone unit="par" n="3"/> Ille uero petit ut quae
+                  contigisset aurum fierent, quod inutile fuit. <milestone unit="par" n="4"/> Nam
+                  coepit sui uoti effectu torqueri, quia quicquid tetigerat, aurum statim
+                  efficiebatur. <milestone unit="par" n="5"/> Cui petenti, ut restitueretur sibi,
+                  fecit; iussit enim ut ad flumen Pactolum perueniret ibique <supplied>se</supplied>
+                  subponeret et sic rediret in pristinum statum. <milestone unit="par" n="6"/> Quo
+                  facto Pactolus deinceps arenas aureas trahere dicitur. </p>
             </div>
 
             <div type="cap" n="88">
                <head> De ortu Pan<supplied>is</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Post mortem Vlixis Mercurius cum uxore eius Penelope concubuit, quae sibi iuxta oppidum Tegeum peperit filium, Pan nomine. <milestone unit="par" n="2"/> Vnde et Tegeus dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Post mortem Vlixis Mercurius cum uxore eius Penelope
+                  concubuit, quae sibi iuxta oppidum Tegeum peperit filium, Pan nomine. <milestone
+                     unit="par" n="2"/> Vnde et Tegeus dicitur. </p>
             </div>
 
             <div type="cap" n="89">
                <head> Fabula Pan<supplied>is</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pan cum Tmolum, montem Lydiae, frequentans fistula se oblectaret, Apollinem in certamen euocauit iudice Tmolo, cuius mons erat. <milestone unit="par" n="2"/> Itaque cum Apollini uictoria esset adiudicata, Midae regi assidenti soli displicuit; quam ob causam deus iratus aures eius asininas fecit. <milestone unit="par" n="3"/> Ille criminis sui notam tonsori tantum ostendit, praecipiens ei ut <del>ut</del>, si crimen eius celaret, participem eum regni efficeret. <milestone unit="par" n="4"/> Ille in terram fodit et secretum domini sui in defosso terrae dixit et operuit; in eodem loco calamus est natus. <milestone unit="par" n="5"/> Vnde sibi pastor tibiam faciens, quae cum percutiebatur dicebat «Mida rex aures asininas habet!» — nihilominus quod ex terra conceperat. <milestone unit="par" n="6"/> Quidam tradunt non Pan, sed Marsyam cum Apolline certasse. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pan cum Tmolum, montem Lydiae, frequentans fistula
+                  se oblectaret, Apollinem in certamen euocauit iudice Tmolo, cuius mons erat.
+                     <milestone unit="par" n="2"/> Itaque cum Apollini uictoria esset adiudicata,
+                  Midae regi assidenti soli displicuit; quam ob causam deus iratus aures eius
+                  asininas fecit. <milestone unit="par" n="3"/> Ille criminis sui notam tonsori
+                  tantum ostendit, praecipiens ei ut <del>ut</del>, si crimen eius celaret,
+                  participem eum regni efficeret. <milestone unit="par" n="4"/> Ille in terram fodit
+                  et secretum domini sui in defosso terrae dixit et operuit; in eodem loco calamus
+                  est natus. <milestone unit="par" n="5"/> Vnde sibi pastor tibiam faciens, quae cum
+                  percutiebatur dicebat «Mida rex aures asininas habet!» — nihilominus quod ex terra
+                  conceperat. <milestone unit="par" n="6"/> Quidam tradunt non Pan, sed Marsyam cum
+                  Apolline certasse. </p>
             </div>
 
             <div type="cap" n="90">
                <head> Fabula Arachne<supplied>s</supplied> et Mineruae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Arachne Lydia, Idmonis et Ippopis filia, studio lanificii famam qu<supplied>ae</supplied>sierat. <milestone unit="par" n="2"/> Cumque materna industria cunctas praecessisset in opere faciendo, festis diebus insolentius gloriata est quam mortalem decuerat; nam Mineruam in certamen prouocauit. <milestone unit="par" n="3"/> Quae in anum uersa in hoc ad eam uenit, ut eius audaciam compesceret; quam cum uidisset in certamine permanentem, reuersa in suam speciem opere proposito in certamen descendit. <milestone unit="par" n="4"/> Sed uicta Arachne cum contumeliose a Minerua pulsa esset, suspendio se affecit; propter studium autem, quod a Minerua acceperat, in araneam uersa est, ut opere inutili nullum sui effectum capere posset. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Arachne Lydia, Idmonis et Ippopis filia, studio
+                  lanificii famam qu<supplied>ae</supplied>sierat. <milestone unit="par" n="2"/>
+                  Cumque materna industria cunctas praecessisset in opere faciendo, festis diebus
+                  insolentius gloriata est quam mortalem decuerat; nam Mineruam in certamen
+                  prouocauit. <milestone unit="par" n="3"/> Quae in anum uersa in hoc ad eam uenit,
+                  ut eius audaciam compesceret; quam cum uidisset in certamine permanentem, reuersa
+                  in suam speciem opere proposito in certamen descendit. <milestone unit="par" n="4"
+                  /> Sed uicta Arachne cum contumeliose a Minerua pulsa esset, suspendio se affecit;
+                  propter studium autem, quod a Minerua acceperat, in araneam uersa est, ut opere
+                  inutili nullum sui effectum capere posset. </p>
             </div>
 
             <div type="cap" n="91">
                <head> Fabula Alcestae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Admetus, rex Graeciae, Alcestam in coniugio petit. <milestone unit="par" n="2"/> Cuius pater edictum proposuerat, ut, si quis duas feras sibi dispares suo curru iungeret, ipse illam in coniugio acciperet. <milestone unit="par" n="3"/> Is Admetus Apollinem atque Herculem petit et ei ad currum leonem et aprum iunxerunt; itaque Alcestam in coniugium accepit. <milestone unit="par" n="4"/> Cum in infirmitatem cecidisset Admetus et mori se comperisset, Apollinem deprecatus est; ille uero dixit se ei aliquid non posse praestare, nisi si quis se de eius propinquis ad mortem pro eo uoluntarie obtulisset, quod uxor effecit. <milestone unit="par" n="5"/> Itaque Hercules dum ad Tricerberum canem abstrahendum descenderet, etiam ipsam de inferis leuat. <milestone unit="par" n="6"/> Admetum <del>de</del>posuerunt in modum menti<supplied>s</supplied>, sed Alcestam pro praesumptione. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Admetus, rex Graeciae, Alcestam in coniugio petit.
+                     <milestone unit="par" n="2"/> Cuius pater edictum proposuerat, ut, si quis duas
+                  feras sibi dispares suo curru iungeret, ipse illam in coniugio acciperet.
+                     <milestone unit="par" n="3"/> Is Admetus Apollinem atque Herculem petit et ei
+                  ad currum leonem et aprum iunxerunt; itaque Alcestam in coniugium accepit.
+                     <milestone unit="par" n="4"/> Cum in infirmitatem cecidisset Admetus et mori se
+                  comperisset, Apollinem deprecatus est; ille uero dixit se ei aliquid non posse
+                  praestare, nisi si quis se de eius propinquis ad mortem pro eo uoluntarie
+                  obtulisset, quod uxor effecit. <milestone unit="par" n="5"/> Itaque Hercules dum
+                  ad Tricerberum canem abstrahendum descenderet, etiam ipsam de inferis leuat.
+                     <milestone unit="par" n="6"/> Admetum <del>de</del>posuerunt in modum
+                     menti<supplied>s</supplied>, sed Alcestam pro praesumptione. </p>
             </div>
 
             <div type="cap" n="92">
                <head> Fabula Neptuni et Amyci.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Neptunus, cum incideret in amorem Melopae nymphae, habuit ex ea<del>m</del> filium Amycum, Bebryciorum regem. <milestone unit="par" n="2"/> Qui effracta lege solitus erat uenientes hospites ad se recipere et cogebat eos cestibus secum dimicare uictorque existens interficiebat eos. <milestone unit="par" n="3"/> Hanc eius feritatem cum multi essent perpessi, nouissime in eodem certamine superatus morte multatus est a Polluce, qui cum Argonautis pellem auream Colchis petebat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Neptunus, cum incideret in amorem Melopae nymphae,
+                  habuit ex ea<del>m</del> filium Amycum, Bebryciorum regem. <milestone unit="par"
+                     n="2"/> Qui effracta lege solitus erat uenientes hospites ad se recipere et
+                  cogebat eos cestibus secum dimicare uictorque existens interficiebat eos.
+                     <milestone unit="par" n="3"/> Hanc eius feritatem cum multi essent perpessi,
+                  nouissime in eodem certamine superatus morte multatus est a Polluce, qui cum
+                  Argonautis pellem auream Colchis petebat. </p>
             </div>
 
             <div type="cap" n="93">
                <head> Fabula Neptuni et Erycis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum animaduertisset Neptunus Venerem spatiantem in litore Siculi maris, eam compressit; ex quo grauida facta filium peperit, quem nominauit Erycem. <milestone unit="par" n="2"/> Qui cum in Sicilia regnaret, uiribus suis fidens legem posuit uenientibus ad se ut secum cestibus decertarent. <milestone unit="par" n="3"/> Quo cum uenisset Hercules et ex Hispania ageret armenta Gery<del>gi</del>onis, cum eo congressus est eumque superatum interfecit. <milestone unit="par" n="4"/> A cuius nomine mons Siciliae Eryx nominatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum animaduertisset Neptunus Venerem spatiantem in
+                  litore Siculi maris, eam compressit; ex quo grauida facta filium peperit, quem
+                  nominauit Erycem. <milestone unit="par" n="2"/> Qui cum in Sicilia regnaret,
+                  uiribus suis fidens legem posuit uenientibus ad se ut secum cestibus decertarent.
+                     <milestone unit="par" n="3"/> Quo cum uenisset Hercules et ex Hispania ageret
+                  armenta Gery<del>gi</del>onis, cum eo congressus est eumque superatum interfecit.
+                     <milestone unit="par" n="4"/> A cuius nomine mons Siciliae Eryx nominatur. </p>
             </div>
 
             <div type="cap" n="94">
                <head> Fabula Arion<supplied>is</supplied> et delphini.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Arion autem inter delphinas: Lesbius citharoedus optimus fuit. <milestone unit="par" n="2"/> Qui cum Tarento Corinthum cum multis opibus peteret et uideret sibi in mari tendi insidias a nautis, petit ut paululum cithara caneret. <milestone unit="par" n="3"/> Ad cuius sonum cum delphini conuenissent, se excussit supra unum et ita imminens uitauit periculum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Arion autem inter delphinas: Lesbius citharoedus
+                  optimus fuit. <milestone unit="par" n="2"/> Qui cum Tarento Corinthum cum multis
+                  opibus peteret et uideret sibi in mari tendi insidias a nautis, petit ut paululum
+                  cithara caneret. <milestone unit="par" n="3"/> Ad cuius sonum cum delphini
+                  conuenissent, se excussit supra unum et ita imminens uitauit periculum. </p>
             </div>
 
             <div type="cap" n="95">
-               <head> 
+               <head>
                   <supplied>De oraculo columbarum</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> In Epiro dicitur nemus fuisse, in quo responsa dabant columbae. <milestone unit="par" n="2"/> Quod ideo fingitur, quia lingua Thessal<del>i</del>a peliades et columbae et uaticinatrices dicuntur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> In Epiro dicitur nemus fuisse, in quo responsa
+                  dabant columbae. <milestone unit="par" n="2"/> Quod ideo fingitur, quia lingua
+                     Thessal<del>i</del>a peliades et columbae et uaticinatrices dicuntur. </p>
             </div>
 
             <div type="cap" n="96">
                <head> Fabula Antiopae, Zethi et Amphion<supplied>is</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Antiopa, Nyctei filia, ab Epapho per dolum est stuprata; quae ob id a uiro Lyco est ui eiecta; qua pulsa, Dircen duxit uxorem, <supplied>cui suspicio incidit uirum suum clam cum Antiopa concubuisse</supplied> imperauitque famulis, ut Antiopam uinctam in tenebras clauderent. <milestone unit="par" n="2"/> Cui cum partus instaret, Iouis uoluntate effugit uincula et in monte Cithaerone — seu Aracyntho — partum exposuit natosque Zethum et Amphionem proiecit. <milestone unit="par" n="3"/> Hos pastor quidam pro suis educauit; quos postea cum mater agnouisset, illi iniurias eius exsecuti Lycum interfecerunt; Dircen uero tauro indomito religatam uita priuauerunt. <milestone unit="par" n="4"/> De cuius sanguine palus Dirce<del>n</del>, quae est Thebis, facta esse dicitur. <milestone unit="par" n="5"/> Quorum unus Amphion studium citharae habuit et sic citharizare dicitur, ut montes et siluas ac saxa ad se uocare dicatur; quae saxa ac lapides Zethus, frater eius, ad Thebas duxit; diciturque earum Thebarum inde struxisse muros. <milestone unit="par" n="6"/> Dircaeus uero Amphion a Dirca fonte<del>m</del> appellatus, quia matrem eius dii in fontem Dircam mutauerint; qui est Thebis ortus sanguine matris eius, <hi rend="italic">in Actaeo Ar<supplied>a</supplied>cyntho</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Antiopa, Nyctei filia, ab Epapho per dolum est
+                  stuprata; quae ob id a uiro Lyco est ui eiecta; qua pulsa, Dircen duxit uxorem,
+                     <supplied>cui suspicio incidit uirum suum clam cum Antiopa
+                     concubuisse</supplied> imperauitque famulis, ut Antiopam uinctam in tenebras
+                  clauderent. <milestone unit="par" n="2"/> Cui cum partus instaret, Iouis uoluntate
+                  effugit uincula et in monte Cithaerone — seu Aracyntho — partum exposuit natosque
+                  Zethum et Amphionem proiecit. <milestone unit="par" n="3"/> Hos pastor quidam pro
+                  suis educauit; quos postea cum mater agnouisset, illi iniurias eius exsecuti Lycum
+                  interfecerunt; Dircen uero tauro indomito religatam uita priuauerunt. <milestone
+                     unit="par" n="4"/> De cuius sanguine palus Dirce<del>n</del>, quae est Thebis,
+                  facta esse dicitur. <milestone unit="par" n="5"/> Quorum unus Amphion studium
+                  citharae habuit et sic citharizare dicitur, ut montes et siluas ac saxa ad se
+                  uocare dicatur; quae saxa ac lapides Zethus, frater eius, ad Thebas duxit;
+                  diciturque earum Thebarum inde struxisse muros. <milestone unit="par" n="6"/>
+                  Dircaeus uero Amphion a Dirca fonte<del>m</del> appellatus, quia matrem eius dii
+                  in fontem Dircam mutauerint; qui est Thebis ortus sanguine matris eius, <hi
+                     rend="italic">in Actaeo Ar<supplied>a</supplied>cyntho</hi>. </p>
             </div>
 
             <div type="cap" n="97">
                <head> Fabula Nyctimone<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Nyctimone, postquam cum patre concubuit et agnouit facinus, se in siluis abdidit et lucem refugit; ubi deorum miseratione conuersa est in auem. <milestone unit="par" n="2"/> Quae pro tanto facinore auibus est ammirationi. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Nyctimone, postquam cum patre concubuit et agnouit
+                  facinus, se in siluis abdidit et lucem refugit; ubi deorum miseratione conuersa
+                  est in auem. <milestone unit="par" n="2"/> Quae pro tanto facinore auibus est
+                  ammirationi. </p>
             </div>
 
             <div type="cap" n="98">
                <head> Fabula Glauci.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Gla<supplied>u</supplied>cus piscator fuit de A<supplied>n</supplied>thedone ciuitate. <milestone unit="par" n="2"/> Qui cum captos pisces super herbam posuisset in litore et illi recepto spiritu maria petissent, sensit quandam herbarum potentiam; quibus esis conuersus est in numen marinum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Gla<supplied>u</supplied>cus piscator fuit de
+                     A<supplied>n</supplied>thedone ciuitate. <milestone unit="par" n="2"/> Qui cum
+                  captos pisces super herbam posuisset in litore et illi recepto spiritu maria
+                  petissent, sensit quandam herbarum potentiam; quibus esis conuersus est in numen
+                  marinum. </p>
             </div>
 
             <div type="cap" n="99">
                <head> Fabula Glauci et Veneris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> 
-                  <supplied>P</supplied>otnia ciuitas est, de qua fuit Glaucus. <milestone unit="par" n="2"/> Qui cum sacra Veneris sperneret, illa irata equa<del>li</del>bus inmisit furorem, quibus utebatur ad currum, et eum morsibus dilacerauerunt. <milestone unit="par" n="3"/> Hoc ideo fingitur, quod eis furorem Venus immiserit, quia dilaniatus est Glaucus effrenatis nimia cupiditate equa<del>li</del>bus, cum eas prohiberet a coitu, ut essent uelociores. </p>
+               <p>
+                  <milestone unit="par" n="1"/>
+                  <supplied>P</supplied>otnia ciuitas est, de qua fuit Glaucus. <milestone
+                     unit="par" n="2"/> Qui cum sacra Veneris sperneret, illa irata
+                     equa<del>li</del>bus inmisit furorem, quibus utebatur ad currum, et eum
+                  morsibus dilacerauerunt. <milestone unit="par" n="3"/> Hoc ideo fingitur, quod eis
+                  furorem Venus immiserit, quia dilaniatus est Glaucus effrenatis nimia cupiditate
+                     equa<del>li</del>bus, cum eas prohiberet a coitu, ut essent uelociores. </p>
             </div>
 
             <div type="cap" n="100">
                <head> Fabula Chelone<supplied>s</supplied> et Mercurii.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Virgo quaedam Chelone nomine linguae impatientis fuit. <milestone unit="par" n="2"/> Verum cum Iuppiter Iunonem sibi nuptiis iungeret, praecepit Mercurio ut omnes deos et homines atque animalia ad nuptias uocaret. <milestone unit="par" n="3"/> Quibus sola Chelo<supplied>n</supplied>e irridens et detrahens nuptiis uenire contempsit. <milestone unit="par" n="4"/> Quam cum Mercurius non uenire notaret, denuo descendit ad terras et aedes Chelonis, super fluuium positas, praecipitauit in mare; ipsam Chelonem in animal sui nominis conuertit, quam nos testudinem dicimus, fecitque ut pro poena dorso tectum prona portaret. Vnde incuruatis aedificiis hoc est nomen impositum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Virgo quaedam Chelone nomine linguae impatientis
+                  fuit. <milestone unit="par" n="2"/> Verum cum Iuppiter Iunonem sibi nuptiis
+                  iungeret, praecepit Mercurio ut omnes deos et homines atque animalia ad nuptias
+                  uocaret. <milestone unit="par" n="3"/> Quibus sola Chelo<supplied>n</supplied>e
+                  irridens et detrahens nuptiis uenire contempsit. <milestone unit="par" n="4"/>
+                  Quam cum Mercurius non uenire notaret, denuo descendit ad terras et aedes
+                  Chelonis, super fluuium positas, praecipitauit in mare; ipsam Chelonem in animal
+                  sui nominis conuertit, quam nos testudinem dicimus, fecitque ut pro poena dorso
+                  tectum prona portaret. Vnde incuruatis aedificiis hoc est nomen impositum. </p>
             </div>
          </div>
 
@@ -700,626 +1740,1550 @@
 
             <div type="cap" n="1">
                <head> Fabula Saturni et eius filiorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Saturnus Polluris filius dicitur, Opis maritus, senior, uelato capite, falcem ferens. <milestone unit="par" n="2"/> Qui sic dicitur regnasse et multa sibi regna subiugasse, unde et quia magnae potentiae fuit pro deo summo habitus est. <milestone unit="par" n="3"/> Qui<del>a</del> habuit ex Rhea tres filios, Iouem, Neptunum, Plutonem. <milestone unit="par" n="4"/> Quorum unus, Iuppiter scilicet, patri testes resecauit et in mare proiecit et ex eorum spuma nata est Venus, dea libidinis. <milestone unit="par" n="5"/> Hi fratres et per sortem postea mundum totum sibi diuiserunt: Iuppiter caelum, Neptunus mare, Pluto infernum occupauit. <milestone unit="par" n="6"/> Et quod singuli fratres potentiam in regno habere uiderentur, aliquid indicii gerunt: Iuppiter trifidum fulmen, Neptunus tridentem, Pluto tricerberum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Saturnus Polluris filius dicitur, Opis maritus,
+                  senior, uelato capite, falcem ferens. <milestone unit="par" n="2"/> Qui sic
+                  dicitur regnasse et multa sibi regna subiugasse, unde et quia magnae potentiae
+                  fuit pro deo summo habitus est. <milestone unit="par" n="3"/> Qui<del>a</del>
+                  habuit ex Rhea tres filios, Iouem, Neptunum, Plutonem. <milestone unit="par" n="4"
+                  /> Quorum unus, Iuppiter scilicet, patri testes resecauit et in mare proiecit et
+                  ex eorum spuma nata est Venus, dea libidinis. <milestone unit="par" n="5"/> Hi
+                  fratres et per sortem postea mundum totum sibi diuiserunt: Iuppiter caelum,
+                  Neptunus mare, Pluto infernum occupauit. <milestone unit="par" n="6"/> Et quod
+                  singuli fratres potentiam in regno habere uiderentur, aliquid indicii gerunt:
+                  Iuppiter trifidum fulmen, Neptunus tridentem, Pluto tricerberum. </p>
             </div>
 
             <div type="cap" n="2">
                <head> Fabula Saturni et Philyrae et Chironis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> 
-                  <supplied>Dum</supplied> cum amata Philyra Saturnus coiret, Ops eius uxor aduenit; cuius praesentiam ueritus, se in equum conuertit, quale<supplied>m</supplied> numen potuit imitari. <milestone unit="par" n="2"/> Exinde natus est Chiron dimidia parte homo, dimidia equus. <milestone unit="par" n="3"/> Iste Chiron primus adinuentor fuit medicinae, quam postea Aesculapio demonstrauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/>
+                  <supplied>Dum</supplied> cum amata Philyra Saturnus coiret, Ops eius uxor aduenit;
+                  cuius praesentiam ueritus, se in equum conuertit, quale<supplied>m</supplied>
+                  numen potuit imitari. <milestone unit="par" n="2"/> Exinde natus est Chiron
+                  dimidia parte homo, dimidia equus. <milestone unit="par" n="3"/> Iste Chiron
+                  primus adinuentor fuit medicinae, quam postea Aesculapio demonstrauit. </p>
             </div>
 
             <div type="cap" n="3">
                <head> Fabula de ortu Iouis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Saturnus a Themideo oraculo comperiens a filio se posse regno depelli, natos ex Rhea uxore deuorabat. <milestone unit="par" n="2"/> Quae natum Iouem, pulchritudine eius delectata, nymphis commendauit in monte Cretae Dictaeo, ubi eum aluerunt apes et adhibiti sunt Curetes et Corybantes, qui tonitru prohiberent audiri pueri uagitum; unde ipsi sunt Matris deum ministri. <milestone unit="par" n="3"/> Sed tunc cum natus esset Iuppiter et partum eius celaret mater, misit Saturno gemmare in simi<supplied>li</supplied>tudinem pueri celsam, quam abadir uocant, cuius natura semper mouetur; quam accipiens pater dentibus collisit et consumpsit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Saturnus a Themideo oraculo comperiens a filio se
+                  posse regno depelli, natos ex Rhea uxore deuorabat. <milestone unit="par" n="2"/>
+                  Quae natum Iouem, pulchritudine eius delectata, nymphis commendauit in monte
+                  Cretae Dictaeo, ubi eum aluerunt apes et adhibiti sunt Curetes et Corybantes, qui
+                  tonitru prohiberent audiri pueri uagitum; unde ipsi sunt Matris deum ministri.
+                     <milestone unit="par" n="3"/> Sed tunc cum natus esset Iuppiter et partum eius
+                  celaret mater, misit Saturno gemmare in simi<supplied>li</supplied>tudinem pueri
+                  celsam, quam abadir uocant, cuius natura semper mouetur; quam accipiens pater
+                  dentibus collisit et consumpsit. </p>
             </div>
 
             <div type="cap" n="4">
                <head> Fabula Iouis et Saturni et Veneris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter adultus, cum Saturnus quadam die ad usum corporis exiret, illato cultro amputauit testiculos eius, quos in mare proiecit, ex quorum spuma Venus nata est. <milestone unit="par" n="2"/> Et mox Iuppiter patrem regno expulit. <milestone unit="par" n="3"/> Sed Saturnus in Latium — i<supplied>n</supplied> Italiam — fugit et ibi latuit; et desierunt aurea esse saecula sub Iouis imperio, quae usque ad eum ob simplicem uitam hominis aurea dicta fuerant. <milestone unit="par" n="4"/> Iuppiter suam sororem Iunonem accepit uxorem. <milestone unit="par" n="5"/> Mystice autem primum Ioue<supplied>m</supplied> ponunt, ut ignem — unde et Zeus graece, quod est uita siue calor, dicitur —, secundam Iunonem, quasi aerem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter adultus, cum Saturnus quadam die ad usum
+                  corporis exiret, illato cultro amputauit testiculos eius, quos in mare proiecit,
+                  ex quorum spuma Venus nata est. <milestone unit="par" n="2"/> Et mox Iuppiter
+                  patrem regno expulit. <milestone unit="par" n="3"/> Sed Saturnus in Latium —
+                     i<supplied>n</supplied> Italiam — fugit et ibi latuit; et desierunt aurea esse
+                  saecula sub Iouis imperio, quae usque ad eum ob simplicem uitam hominis aurea
+                  dicta fuerant. <milestone unit="par" n="4"/> Iuppiter suam sororem Iunonem accepit
+                  uxorem. <milestone unit="par" n="5"/> Mystice autem primum
+                     Ioue<supplied>m</supplied> ponunt, ut ignem — unde et Zeus graece, quod est
+                  uita siue calor, dicitur —, secundam Iunonem, quasi aerem. </p>
             </div>
 
             <div type="cap" n="5">
                <head> Fabula Iunonis et horti Hesperidum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter cum Iunonem duceret uxorem, Terram dicitur uenisse ferentem aurea mala cum ramis; inde Iunonem ammiratam petisse a Terra, ut in suis hortis sereret, qui erant usque ad <supplied>A</supplied>t<del>ha</del>lante<supplied>m</supplied> montem. <milestone unit="par" n="2"/> Cuius filiae dum saepius de arboribus mala decerperent, Iuno dicitur peruigilem draconem ibi custodem posuisse, quem post Hercules occidit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter cum Iunonem duceret uxorem, Terram dicitur
+                  uenisse ferentem aurea mala cum ramis; inde Iunonem ammiratam petisse a Terra, ut
+                  in suis hortis sereret, qui erant usque ad
+                     <supplied>A</supplied>t<del>ha</del>lante<supplied>m</supplied> montem.
+                     <milestone unit="par" n="2"/> Cuius filiae dum saepius de arboribus mala
+                  decerperent, Iuno dicitur peruigilem draconem ibi custodem posuisse, quem post
+                  Hercules occidit. </p>
             </div>
 
             <div type="cap" n="6">
                <head> Fabula Neptuni.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Neptunus dictus quasi nube tonans, quem Graeci Posidonium uocant, tertius potestate a Ioue et Iunone, praeest aquarum elemento. <milestone unit="par" n="2"/> Hic tridentem ferre pingitur, eo quod aquaru<supplied>m</supplied> natura triplici uirtute fungatur, id est liquida, fecunda, potabilis. <milestone unit="par" n="3"/> Huic Neptuno Amphitritem in coniugium deputant — amphi enim graece dicitur circumcirca —, eo quod omnibus tribus elementis aqua conclusa sit. <milestone unit="par" n="4"/> Qui Neptunus habuit ex Venere Erycem, <supplied>regem</supplied> Siciliae, filium, ex Merope nympha Amycum, Bebryc<supplied>i</supplied>orum regem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Neptunus dictus quasi nube tonans, quem Graeci
+                  Posidonium uocant, tertius potestate a Ioue et Iunone, praeest aquarum elemento.
+                     <milestone unit="par" n="2"/> Hic tridentem ferre pingitur, eo quod
+                     aquaru<supplied>m</supplied> natura triplici uirtute fungatur, id est liquida,
+                  fecunda, potabilis. <milestone unit="par" n="3"/> Huic Neptuno Amphitritem in
+                  coniugium deputant — amphi enim graece dicitur circumcirca —, eo quod omnibus
+                  tribus elementis aqua conclusa sit. <milestone unit="par" n="4"/> Qui Neptunus
+                  habuit ex Venere Erycem, <supplied>regem</supplied> Siciliae, filium, ex Merope
+                  nympha Amycum, Bebryc<supplied>i</supplied>orum regem. </p>
             </div>
 
             <div type="cap" n="7">
                <head> Fabula Plutonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pluto, frater Iouis et Neptuni, dicitur terrarum praesul, quia plutos graece diuitiae dicuntur. <milestone unit="par" n="2"/> Hunc alii Orcum uocant, quasi receptorem mortuorum, quia tenebris abdicatum inferis praeesse tradunt. <milestone unit="par" n="3"/> Huius pedibus Tricerberum canem subiciunt, quod mortalium iurgiorum inuidiae ternario conflentur statu, id est naturali, causali, accidenti. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pluto, frater Iouis et Neptuni, dicitur terrarum
+                  praesul, quia plutos graece diuitiae dicuntur. <milestone unit="par" n="2"/> Hunc
+                  alii Orcum uocant, quasi receptorem mortuorum, quia tenebris abdicatum inferis
+                  praeesse tradunt. <milestone unit="par" n="3"/> Huius pedibus Tricerberum canem
+                  subiciunt, quod mortalium iurgiorum inuidiae ternario conflentur statu, id est
+                  naturali, causali, accidenti. </p>
             </div>
 
             <div type="cap" n="8">
                <head> De tribus Furiis uel Eumenidis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tres Furias, dictas Eumenidas, Plutoni dicunt dese<supplied>r</supplied>uire. <milestone unit="par" n="2"/> Quarum prima Alecto graece impausabilis dicitur, Tisiphone, id est istarum uox, Megaera, quasi magna contentio. <milestone unit="par" n="3"/> Hae<del>c</del> pro crinibus habent angues. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tres Furias, dictas Eumenidas, Plutoni dicunt
+                     dese<supplied>r</supplied>uire. <milestone unit="par" n="2"/> Quarum prima
+                  Alecto graece impausabilis dicitur, Tisiphone, id est istarum uox, Megaera, quasi
+                  magna contentio. <milestone unit="par" n="3"/> Hae<del>c</del> pro crinibus habent
+                  angues. </p>
             </div>
 
             <div type="cap" n="9">
                <head> De tribus Fatis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tria Fata et<supplied>iam</supplied> Plutoni destinant. <milestone unit="par" n="2"/> Hae<supplied>c</supplied> quoque Parcae dictae per antiphrasin, quod nulli parcant. <milestone unit="par" n="3"/> Clotho colum baiulat, Lachesis trahit, Atropos occat. <milestone unit="par" n="4"/> Clotho graece latine dicitur euocatio, Lachesis sors, Atropos sine ordine. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tria Fata et<supplied>iam</supplied> Plutoni
+                  destinant. <milestone unit="par" n="2"/> Hae<supplied>c</supplied> quoque Parcae
+                  dictae per antiphrasin, quod nulli parcant. <milestone unit="par" n="3"/> Clotho
+                  colum baiulat, Lachesis trahit, Atropos occat. <milestone unit="par" n="4"/>
+                  Clotho graece latine dicitur euocatio, Lachesis sors, Atropos sine ordine. </p>
             </div>
 
             <div type="cap" n="10">
                <head> De tribus Harpyiis seu Stymphalidis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tres Harpyiae in inferis uigiliis deputantur. <milestone unit="par" n="2"/> 
-                  <supplied>A</supplied>ello cupit, rapit Occipito, Celaenoque recondit. <milestone unit="par" n="3"/> 
-                  <supplied>A</supplied>ello, id est alienum tollens; Occipito, id est citius auferens; Celaeno, id est nigra. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tres Harpyiae in inferis uigiliis deputantur.
+                     <milestone unit="par" n="2"/>
+                  <supplied>A</supplied>ello cupit, rapit Occipito, Celaenoque recondit. <milestone
+                     unit="par" n="3"/>
+                  <supplied>A</supplied>ello, id est alienum tollens; Occipito, id est citius
+                  auferens; Celaeno, id est nigra. </p>
             </div>
 
             <div type="cap" n="11">
                <head> Proserpina seu Diana.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Proserpinam, Cereris filiam, nuptam uolunt Plutoni. <milestone unit="par" n="2"/> Ceres enim gaudium dicitur et est dea frumenti. <milestone unit="par" n="3"/> Proserpina uero dicta, quod ex ea proserpant fruges. <milestone unit="par" n="4"/> Haec et Vesta dicitur, quod herbis uel uariis uestita sit rebus. <milestone unit="par" n="5"/> Diana et eadem est dicta, quasi duana, quod luna et die et nocte appareat. <milestone unit="par" n="6"/> Ipsam et Lucinam asseuerant, eo quod luceat. <milestone unit="par" n="7"/> Eandem et Triuiam, eo quod tribus fungatur figuris; de qua Vir<supplied>g</supplied>il<supplied>i</supplied>us <hi rend="italic">Tria uirginis ora Dianae</hi>, quia eadem Luna, eadem Diana, eadem Proserpina uocatur. <milestone unit="par" n="8"/> Haec et <hi rend="italic">Latonia uirgo</hi> dicitur — a matre Latona — et <hi rend="italic">Plutonia coniux</hi>. <milestone unit="par" n="9"/> Graece Hecate dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Proserpinam, Cereris filiam, nuptam uolunt Plutoni.
+                     <milestone unit="par" n="2"/> Ceres enim gaudium dicitur et est dea frumenti.
+                     <milestone unit="par" n="3"/> Proserpina uero dicta, quod ex ea proserpant
+                  fruges. <milestone unit="par" n="4"/> Haec et Vesta dicitur, quod herbis uel
+                  uariis uestita sit rebus. <milestone unit="par" n="5"/> Diana et eadem est dicta,
+                  quasi duana, quod luna et die et nocte appareat. <milestone unit="par" n="6"/>
+                  Ipsam et Lucinam asseuerant, eo quod luceat. <milestone unit="par" n="7"/> Eandem
+                  et Triuiam, eo quod tribus fungatur figuris; de qua
+                     Vir<supplied>g</supplied>il<supplied>i</supplied>us <hi rend="italic">Tria
+                     uirginis ora Dianae</hi>, quia eadem Luna, eadem Diana, eadem Proserpina
+                  uocatur. <milestone unit="par" n="8"/> Haec et <hi rend="italic">Latonia
+                     uirgo</hi> dicitur — a matre Latona — et <hi rend="italic">Plutonia
+                  coniux</hi>. <milestone unit="par" n="9"/> Graece Hecate dicitur. </p>
             </div>
 
             <div type="cap" n="12">
                <head> Fabula Apollinis uel Solis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Apollinem, filium Iouis, fratrem Dianae, Solem dici uoluerunt. <milestone unit="par" n="2"/> Hunc et diuinationis deum ponunt, ex <supplied>eo</supplied> quod sol omnia obscura manifestat in lucem. <milestone unit="par" n="3"/> Solem autem dicunt quasi solum; ipsum Titan, quasi unum ex Titanis qui aduersum Iouem non fecit; ipsum Phoebum, quasi ephoebum, hoc est adolescentem — unde et Sol puer pingitur, eo quod cotidie oriatur et noua luce nascatur. <milestone unit="par" n="4"/> Pythium quoque eundem Apollinem uocant a Pythone, immensae molis serpente, quem Apollo sagittarum ictibus sternens nominis quoque spolia reportauit, ut Pythius uocaretur. <milestone unit="par" n="5"/> Huic quoque quadrigam <supplied>ad</supplied>scribunt, illam ob causam, quod quadrifido limite diei metiatur spatium; uel quod quattuor sunt tempora anni. <milestone unit="par" n="6"/> Quattuor equorum Solis nomina: Acteon, Lampus, Erythraeus et Philogeus. <milestone unit="par" n="7"/> Erythraeus graece rubeus dicitur, eo quod sol matutino lumine rubicundus exsurgat; Acteon splendens; Lampus uero ardens; Philogeus terram amans dicitur, eo quod uespere occasibus sol pro<del>ti</del>nus incumbat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Apollinem, filium Iouis, fratrem Dianae, Solem dici
+                  uoluerunt. <milestone unit="par" n="2"/> Hunc et diuinationis deum ponunt, ex
+                     <supplied>eo</supplied> quod sol omnia obscura manifestat in lucem. <milestone
+                     unit="par" n="3"/> Solem autem dicunt quasi solum; ipsum Titan, quasi unum ex
+                  Titanis qui aduersum Iouem non fecit; ipsum Phoebum, quasi ephoebum, hoc est
+                  adolescentem — unde et Sol puer pingitur, eo quod cotidie oriatur et noua luce
+                  nascatur. <milestone unit="par" n="4"/> Pythium quoque eundem Apollinem uocant a
+                  Pythone, immensae molis serpente, quem Apollo sagittarum ictibus sternens nominis
+                  quoque spolia reportauit, ut Pythius uocaretur. <milestone unit="par" n="5"/> Huic
+                  quoque quadrigam <supplied>ad</supplied>scribunt, illam ob causam, quod quadrifido
+                  limite diei metiatur spatium; uel quod quattuor sunt tempora anni. <milestone
+                     unit="par" n="6"/> Quattuor equorum Solis nomina: Acteon, Lampus, Erythraeus et
+                  Philogeus. <milestone unit="par" n="7"/> Erythraeus graece rubeus dicitur, eo quod
+                  sol matutino lumine rubicundus exsurgat; Acteon splendens; Lampus uero ardens;
+                  Philogeus terram amans dicitur, eo quod uespere occasibus sol pro<del>ti</del>nus
+                  incumbat. </p>
             </div>
 
             <div type="cap" n="13">
                <head> De nouem Musis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Nouem Musas Apollini deputant, ipsumque decimum Musis adiciunt, quia humanae uocis decem modulamina sunt. <milestone unit="par" n="2"/> Et haec nomina et interpretationes Musarum: Clio, id est cognitio quaerendae scientiae, quae reperit historias; Euterpe, id est bene delectans, quae tibias inuenit; Melpomene, id est meditationem faciens, quae tragoedias edidit; Thalia, id est capacitas, quae comoedias edidit; Polhymnia, id est multa<supplied>m</supplied> memoriam faciens, quae rhetoricam inuenit; Erato, id est inueniens simile, quae geometriam reperit; Terpsichore, id est delectans instructionem, quae psalterium instituit; Vrania, id est caelestis, quae astrologiam inuenit; Calliope, id est optimae uocis, quae litteras docuit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Nouem Musas Apollini deputant, ipsumque decimum
+                  Musis adiciunt, quia humanae uocis decem modulamina sunt. <milestone unit="par"
+                     n="2"/> Et haec nomina et interpretationes Musarum: Clio, id est cognitio
+                  quaerendae scientiae, quae reperit historias; Euterpe, id est bene delectans, quae
+                  tibias inuenit; Melpomene, id est meditationem faciens, quae tragoedias edidit;
+                  Thalia, id est capacitas, quae comoedias edidit; Polhymnia, id est
+                     multa<supplied>m</supplied> memoriam faciens, quae rhetoricam inuenit; Erato,
+                  id est inueniens simile, quae geometriam reperit; Terpsichore, id est delectans
+                  instructionem, quae psalterium instituit; Vrania, id est caelestis, quae
+                  astrologiam inuenit; Calliope, id est optimae uocis, quae litteras docuit. </p>
             </div>
 
             <div type="cap" n="14">
                <head> Fabula Apollinis et corui et Coronide filie Phlegyae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> In Apollinis etiam tutela coruum ponunt: siue quod solus contra rerum naturam in mediis ipsis aestiuis feruoribus ouiparos pullulet foetus; siue quod in or<supplied>ne</supplied>oscopicis libris solus inter omnes aues sexaginta quattuor significationes habeat uocum. <milestone unit="par" n="2"/> Haec est autem fabula. <milestone unit="par" n="3"/> Coruus, Apollinis tutela usus, eo sacrificante missus a fonte aquam puram petitum, uidit arbores complures ficorum immaturas; eas expectans dum maturescerent, in arbore quadam earum consedit. <milestone unit="par" n="4"/> Itaque post aliquot dies coctis ficis et <del>e</del>a coruo pluribus earum comesis, expectans Apollo coruum uidit cum cratere pleno uolare festinantem. <milestone unit="par" n="5"/> Pro quo a<supplied>d</supplied>misso eius dicitur, quod diu moratus sit, Apollinem, qui coactus mora corui alia aqua est usus, hac ignominia eum affecisse, ut quamdiu fici coquerentur, coruus bibere non posset; ideo quod guttur habeat pertusum illis diebus. <milestone unit="par" n="6"/> Istrius autem et complures dixerunt Coronida Phleg<supplied>y</supplied>ae filiam fuisse, hanc autem ex Apolline Aesculapium procreasse; sed postea Scin Ealti filium cum ea concubuisse; quod autem <supplied>cum</supplied> uideret coruus, Apollini nuntiasse; qui cum fuerit antea candidus, pro incommodo nuntio eum nigrum fecisse et Scin sagittis confixisse. </p>
+               <p>
+                  <milestone unit="par" n="1"/> In Apollinis etiam tutela coruum ponunt: siue quod
+                  solus contra rerum naturam in mediis ipsis aestiuis feruoribus ouiparos pullulet
+                  foetus; siue quod in or<supplied>ne</supplied>oscopicis libris solus inter omnes
+                  aues sexaginta quattuor significationes habeat uocum. <milestone unit="par" n="2"
+                  /> Haec est autem fabula. <milestone unit="par" n="3"/> Coruus, Apollinis tutela
+                  usus, eo sacrificante missus a fonte aquam puram petitum, uidit arbores complures
+                  ficorum immaturas; eas expectans dum maturescerent, in arbore quadam earum
+                  consedit. <milestone unit="par" n="4"/> Itaque post aliquot dies coctis ficis et
+                     <del>e</del>a coruo pluribus earum comesis, expectans Apollo coruum uidit cum
+                  cratere pleno uolare festinantem. <milestone unit="par" n="5"/> Pro quo
+                     a<supplied>d</supplied>misso eius dicitur, quod diu moratus sit, Apollinem, qui
+                  coactus mora corui alia aqua est usus, hac ignominia eum affecisse, ut quamdiu
+                  fici coquerentur, coruus bibere non posset; ideo quod guttur habeat pertusum illis
+                  diebus. <milestone unit="par" n="6"/> Istrius autem et complures dixerunt Coronida
+                     Phleg<supplied>y</supplied>ae filiam fuisse, hanc autem ex Apolline Aesculapium
+                  procreasse; sed postea Scin Ealti filium cum ea concubuisse; quod autem
+                     <supplied>cum</supplied> uideret coruus, Apollini nuntiasse; qui cum fuerit
+                  antea candidus, pro incommodo nuntio eum nigrum fecisse et Scin sagittis
+                  confixisse. </p>
             </div>
 
             <div type="cap" n="15">
                <head> Fabula Apollinis et Daphni<supplied>di</supplied>s seu lauri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> In Apollinis etiam tutelam laurum ascribunt. <milestone unit="par" n="2"/> Nam scimus et Daphnem, Ladonis fluminis Arcadiae filiam, dilectam ab Apolline et Terrae miseratione in laurum conuersam — <milestone unit="par" n="3"/> et unde laurus nasci posset, nisi de fluuialibus aquis? <milestone unit="par" n="4"/> Et, sicut poetae describunt, si laurum dormientibus ad caput posueris, uera somnia esse uisuros! — <milestone unit="par" n="5"/> et Hyacintum amatum tam a Borea, quam ab Apolline. <milestone unit="par" n="6"/> Qui cum magis Apollinis amore laetaretur, dum exercetur disco, ab irato Borea eodem disco est interemptus et mutatus in florem nominis <supplied>sui</supplied>.</p>
+               <p>
+                  <milestone unit="par" n="1"/> In Apollinis etiam tutelam laurum ascribunt.
+                     <milestone unit="par" n="2"/> Nam scimus et Daphnem, Ladonis fluminis Arcadiae
+                  filiam, dilectam ab Apolline et Terrae miseratione in laurum conuersam —
+                     <milestone unit="par" n="3"/> et unde laurus nasci posset, nisi de fluuialibus
+                  aquis? <milestone unit="par" n="4"/> Et, sicut poetae describunt, si laurum
+                  dormientibus ad caput posueris, uera somnia esse uisuros! — <milestone unit="par"
+                     n="5"/> et Hyacintum amatum tam a Borea, quam ab Apolline. <milestone
+                     unit="par" n="6"/> Qui cum magis Apollinis amore laetaretur, dum exercetur
+                  disco, ab irato Borea eodem disco est interemptus et mutatus in florem nominis
+                     <supplied>sui</supplied>.</p>
             </div>
 
             <div type="cap" n="16">
                <head> Fabula Apollinis et Heridani.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Apollo, qui et Sol, cum Clymene nympha coiens, Phaethonta, siue Eridanum, dicitur genuisse. <milestone unit="par" n="2"/> Qui suscitauit Hippolytum occisum precatu patris et Dianae. <milestone unit="par" n="3"/> Hic a patre inpetrato curru, agitare non potuit et, cum eius errore mundus arderet, fulminatus a Ioue in fluuium Italiae cecidit. <milestone unit="par" n="4"/> Et tunc a luce ardoris sui Phaethon appellatus est et pristinum nomen fluuio dedit, unde mixta haec duo nomina inter Solis filium et fluuium inuenimus. <milestone unit="par" n="5"/> Postea eius sorores, Fletusa et Lampetusa, flendo in populos uersae sunt. <milestone unit="par" n="6"/> Hac ira commotus Apollo fabros Sicanos, Iouis fulmina facientes, interfecit et propter hoc Iuppiter eum diuinitate exuit et a caelo deiecit. <milestone unit="par" n="7"/> Qui expulsus boues Admeti regis per quattuor annos pauit super Euphratem fluuium, ubi quam plures habuit filios. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Apollo, qui et Sol, cum Clymene nympha coiens,
+                  Phaethonta, siue Eridanum, dicitur genuisse. <milestone unit="par" n="2"/> Qui
+                  suscitauit Hippolytum occisum precatu patris et Dianae. <milestone unit="par"
+                     n="3"/> Hic a patre inpetrato curru, agitare non potuit et, cum eius errore
+                  mundus arderet, fulminatus a Ioue in fluuium Italiae cecidit. <milestone
+                     unit="par" n="4"/> Et tunc a luce ardoris sui Phaethon appellatus est et
+                  pristinum nomen fluuio dedit, unde mixta haec duo nomina inter Solis filium et
+                  fluuium inuenimus. <milestone unit="par" n="5"/> Postea eius sorores, Fletusa et
+                  Lampetusa, flendo in populos uersae sunt. <milestone unit="par" n="6"/> Hac ira
+                  commotus Apollo fabros Sicanos, Iouis fulmina facientes, interfecit et propter hoc
+                  Iuppiter eum diuinitate exuit et a caelo deiecit. <milestone unit="par" n="7"/>
+                  Qui expulsus boues Admeti regis per quattuor annos pauit super Euphratem fluuium,
+                  ubi quam plures habuit filios. </p>
             </div>
 
             <div type="cap" n="17">
                <head> Fabula Mercurii et Maie matris eius.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter iacuit in Cylle<supplied>ni</supplied>o monte cum Maia et habuit filium Mercurium, quem Iuno ita dilexit, quod propria mamma eum lactauit et artem medicam insinuauit. <milestone unit="par" n="2"/> Pater uero tradidit ei uirgam caduc<supplied>e</supplied>am; qua<del>m</del> si quem ex grossiori parte a capite tangeret, moreretur; quem uero a subtili parte, uiu<del>i</del>eret. <milestone unit="par" n="3"/> Mercurius quasi medius currens dicitur appellatus, quod sermo currat inter homines medius; unde et uelox et errans inducitur. <milestone unit="par" n="4"/> Alas eius in capite et in pedibus significare uolucrem fieri per aera sermonem. <milestone unit="par" n="5"/> Nuntium dictum, quoniam per sermonem omnia cogitata nuntiantur. <milestone unit="par" n="6"/> Ideo autem furti magistrum dicunt, quia sermo animos audientium fallit. <milestone unit="par" n="7"/> Virgam tenet, qua serpentes diuidit, id est uenena; nam bellantes ac dissidentes interpretum oratione sedantur, unde secundum Liuium legati pacis caduc<supplied>e</supplied>atores dicuntur — sicut enim per fetiales bella indicebantur, ita pax per caduc<supplied>e</supplied>atores fiebat —. <milestone unit="par" n="8"/> Hermes autem dicitur graece apo tes hermeneias, latine interpres. <milestone unit="par" n="9"/> Qui ob uirtutem multarumque artium scientiam Trimegistus — id est ter maximus — nominatus est. <milestone unit="par" n="10"/> Cur autem eum capite canino fingunt, haec ratio dicitur, quod inter omnia animalia canis sagacissimum genus et perspicax habeatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter iacuit in Cylle<supplied>ni</supplied>o
+                  monte cum Maia et habuit filium Mercurium, quem Iuno ita dilexit, quod propria
+                  mamma eum lactauit et artem medicam insinuauit. <milestone unit="par" n="2"/>
+                  Pater uero tradidit ei uirgam caduc<supplied>e</supplied>am; qua<del>m</del> si
+                  quem ex grossiori parte a capite tangeret, moreretur; quem uero a subtili parte,
+                     uiu<del>i</del>eret. <milestone unit="par" n="3"/> Mercurius quasi medius
+                  currens dicitur appellatus, quod sermo currat inter homines medius; unde et uelox
+                  et errans inducitur. <milestone unit="par" n="4"/> Alas eius in capite et in
+                  pedibus significare uolucrem fieri per aera sermonem. <milestone unit="par" n="5"
+                  /> Nuntium dictum, quoniam per sermonem omnia cogitata nuntiantur. <milestone
+                     unit="par" n="6"/> Ideo autem furti magistrum dicunt, quia sermo animos
+                  audientium fallit. <milestone unit="par" n="7"/> Virgam tenet, qua serpentes
+                  diuidit, id est uenena; nam bellantes ac dissidentes interpretum oratione
+                  sedantur, unde secundum Liuium legati pacis caduc<supplied>e</supplied>atores
+                  dicuntur — sicut enim per fetiales bella indicebantur, ita pax per
+                     caduc<supplied>e</supplied>atores fiebat —. <milestone unit="par" n="8"/>
+                  Hermes autem dicitur graece apo tes hermeneias, latine interpres. <milestone
+                     unit="par" n="9"/> Qui ob uirtutem multarumque artium scientiam Trimegistus —
+                  id est ter maximus — nominatus est. <milestone unit="par" n="10"/> Cur autem eum
+                  capite canino fingunt, haec ratio dicitur, quod inter omnia animalia canis
+                  sagacissimum genus et perspicax habeatur. </p>
             </div>
 
             <div type="cap" n="18">
                <head> Fabula Semele et filii eius Liberi patris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter cum Semele concubuit, de qua natus est Liber pater. <milestone unit="par" n="2"/> Ad quam cum fulmine ueniens, illa crepuit, unde pater puerum tollens in femore suo misit; post Maroni nutriendum dedit. <milestone unit="par" n="3"/> Hic Indiam debellauit et inter deos deputatus est. <milestone unit="par" n="4"/> Itaque cum Semele quattuor sorores appellatae sunt, Ino, Autonoe, Semele et Agaue; quae Agaue caput filii uiolenter abscidit. <milestone unit="par" n="5"/> Hae quattuor sorores Bacchae dictae sunt et mystice per has quattuor ebrietatis genera signantur, id est uinolentia, obliuio, libido, insania. <milestone unit="par" n="6"/> 
-                  <supplied>I</supplied>uno autem suspectam eandem Semele<supplied>m</supplied>, Cadmi et Hermionae filiam cum haberet, quod cum Ioue concubuisset, in anum conuersa, ut se fallacia sine inuidia cuiusquam ulcisceretur, hortatur eam, ut tale pignus amoris a Ioue peteret, proinde <supplied>ut</supplied> auctoritas ipsius concubitus insignis esset. <milestone unit="par" n="7"/> Quod cum impetrauisset, deus instructus tonitribus ac fulminibus domum Semeles ingressus est. <milestone unit="par" n="8"/> 
-                  <supplied>Eius</supplied> decepta<supplied>e</supplied> optatis tecta et ipsam flamma<del>m</del> adurit Liberumque, conceptum utero, grauidae incendio eripuit ac femore insui<supplied>t</supplied> suo; postea completis mensibus, nymphis, quae Nysam montem Indiae perfrequentabant, clam tradidit nutriendum. <milestone unit="par" n="9"/> Septem enim fuerant sorores, eaedem nymphae Dodonidae appellatae, quae a Lycurgo fugatae ad Thetin profugerunt, ut scribit Pherecydes et Asclepiades. <milestone unit="par" n="10"/> Quam ob causam ab Ioue eis gratia est relata, quod inter sidera sunt constitutae, quae septem numero Hyadae sunt appellatae. <milestone unit="par" n="11"/> Hic Liber pater — seu Dionisius — tigribus sedere dicitur, quod omnis uinolentia feritati semper insistat; et Lyaeus dicitur quasi lenitatem praestans. <milestone unit="par" n="12"/> Iuuenis etiam pingitur, quia ebrietas numquam matura est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter cum Semele concubuit, de qua natus est
+                  Liber pater. <milestone unit="par" n="2"/> Ad quam cum fulmine ueniens, illa
+                  crepuit, unde pater puerum tollens in femore suo misit; post Maroni nutriendum
+                  dedit. <milestone unit="par" n="3"/> Hic Indiam debellauit et inter deos deputatus
+                  est. <milestone unit="par" n="4"/> Itaque cum Semele quattuor sorores appellatae
+                  sunt, Ino, Autonoe, Semele et Agaue; quae Agaue caput filii uiolenter abscidit.
+                     <milestone unit="par" n="5"/> Hae quattuor sorores Bacchae dictae sunt et
+                  mystice per has quattuor ebrietatis genera signantur, id est uinolentia, obliuio,
+                  libido, insania. <milestone unit="par" n="6"/>
+                  <supplied>I</supplied>uno autem suspectam eandem Semele<supplied>m</supplied>,
+                  Cadmi et Hermionae filiam cum haberet, quod cum Ioue concubuisset, in anum
+                  conuersa, ut se fallacia sine inuidia cuiusquam ulcisceretur, hortatur eam, ut
+                  tale pignus amoris a Ioue peteret, proinde <supplied>ut</supplied> auctoritas
+                  ipsius concubitus insignis esset. <milestone unit="par" n="7"/> Quod cum
+                  impetrauisset, deus instructus tonitribus ac fulminibus domum Semeles ingressus
+                  est. <milestone unit="par" n="8"/>
+                  <supplied>Eius</supplied> decepta<supplied>e</supplied> optatis tecta et ipsam
+                     flamma<del>m</del> adurit Liberumque, conceptum utero, grauidae incendio
+                  eripuit ac femore insui<supplied>t</supplied> suo; postea completis mensibus,
+                  nymphis, quae Nysam montem Indiae perfrequentabant, clam tradidit nutriendum.
+                     <milestone unit="par" n="9"/> Septem enim fuerant sorores, eaedem nymphae
+                  Dodonidae appellatae, quae a Lycurgo fugatae ad Thetin profugerunt, ut scribit
+                  Pherecydes et Asclepiades. <milestone unit="par" n="10"/> Quam ob causam ab Ioue
+                  eis gratia est relata, quod inter sidera sunt constitutae, quae septem numero
+                  Hyadae sunt appellatae. <milestone unit="par" n="11"/> Hic Liber pater — seu
+                  Dionisius — tigribus sedere dicitur, quod omnis uinolentia feritati semper
+                  insistat; et Lyaeus dicitur quasi lenitatem praestans. <milestone unit="par"
+                     n="12"/> Iuuenis etiam pingitur, quia ebrietas numquam matura est. </p>
             </div>
 
             <div type="cap" n="19">
                <head> Fabula Liberi et Iouis Hammonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Liber, seu Dionisius, cum Indos peteret et per Xerolibyam exercitum duceret, fatigatus siti Iouis sui patris auxilium implorauit; et statim uiso ariete fons secutus est. <milestone unit="par" n="2"/> Vnde factum est ab eo deinceps Ioui Hammoni — ab hare<del>re</del>nis dicto — simulacrum cum capite arietino. <milestone unit="par" n="3"/> Quod ideo fingitur, quia satis eius sunt inuoluta responsa. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Liber, seu Dionisius, cum Indos peteret et per
+                  Xerolibyam exercitum duceret, fatigatus siti Iouis sui patris auxilium implorauit;
+                  et statim uiso ariete fons secutus est. <milestone unit="par" n="2"/> Vnde factum
+                  est ab eo deinceps Ioui Hammoni — ab hare<del>re</del>nis dicto — simulacrum cum
+                  capite arietino. <milestone unit="par" n="3"/> Quod ideo fingitur, quia satis eius
+                  sunt inuoluta responsa. </p>
             </div>
 
             <div type="cap" n="20">
                <head> Fabula Liberi et Tyrrhenorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum Tyrrheni nautae dormientem in litore Liberum patrem inuenissent, furtim eum in nauem suam rapuerunt. <milestone unit="par" n="2"/> Qui cum esset experrectus in naui, quo duceretur interrogauit; responderunt illi, quo uellet. <milestone unit="par" n="3"/> Liber ait ad Naxum insulam, sibi sacratam; illi autem alio uela flectere coeperunt. <milestone unit="par" n="4"/> Quam ob rem numen iratum tigres sibi dicatas uisibus eorum obiecit; quo<del>rum</del> illi terrore perterriti, sese praecipites in fluctus dedere. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum Tyrrheni nautae dormientem in litore Liberum
+                  patrem inuenissent, furtim eum in nauem suam rapuerunt. <milestone unit="par"
+                     n="2"/> Qui cum esset experrectus in naui, quo duceretur interrogauit;
+                  responderunt illi, quo uellet. <milestone unit="par" n="3"/> Liber ait ad Naxum
+                  insulam, sibi sacratam; illi autem alio uela flectere coeperunt. <milestone
+                     unit="par" n="4"/> Quam ob rem numen iratum tigres sibi dicatas uisibus eorum
+                  obiecit; quo<del>rum</del> illi terrore perterriti, sese praecipites in fluctus
+                  dedere. </p>
             </div>
 
             <div type="cap" n="21">
                <head> Fabula Liberi patris et Lycurgi regis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lycurgus rex Thraciae fuit, qui, ut fabula habet, dum contemnens Liberum eius amputat uites, crura sua incidit. <milestone unit="par" n="2"/> Re autem uera abstemius fuit, id est abstinens; quos constat acrioris esse naturae, quod etiam <supplied>de</supplied> Demosthene dictum est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lycurgus rex Thraciae fuit, qui, ut fabula habet,
+                  dum contemnens Liberum eius amputat uites, crura sua incidit. <milestone
+                     unit="par" n="2"/> Re autem uera abstemius fuit, id est abstinens; quos constat
+                  acrioris esse naturae, quod etiam <supplied>de</supplied> Demosthene dictum est.
+               </p>
             </div>
 
             <div type="cap" n="22">
                <head> Fabula Mineruae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Minerua, dea sapientiae, multorum inuentrix fuit ingeniorum. <milestone unit="par" n="2"/> Haec graece Athena<del>s</del> dicitur, apud Latinos autem Minerua, quasi manus artium uariarum. <milestone unit="par" n="3"/> Ideo autem de capite Iouis dicitur esse nata, quia sensus sapientis, qui inuenit omnia, in capite est. <milestone unit="par" n="4"/> Haec et Tritonia dicitur, quia circa Tritonium lacum dicitur apparuisse in uirginali aetate. <milestone unit="par" n="5"/> Pallas autem eadem est dicta, uel ab insula Pallene, in qua nutrita est, uel apo toy palle<supplied>in to dory</supplied>, id est ab hastae concussione; uel quod Pallantem gigantem occidit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Minerua, dea sapientiae, multorum inuentrix fuit
+                  ingeniorum. <milestone unit="par" n="2"/> Haec graece Athena<del>s</del> dicitur,
+                  apud Latinos autem Minerua, quasi manus artium uariarum. <milestone unit="par"
+                     n="3"/> Ideo autem de capite Iouis dicitur esse nata, quia sensus sapientis,
+                  qui inuenit omnia, in capite est. <milestone unit="par" n="4"/> Haec et Tritonia
+                  dicitur, quia circa Tritonium lacum dicitur apparuisse in uirginali aetate.
+                     <milestone unit="par" n="5"/> Pallas autem eadem est dicta, uel ab insula
+                  Pallene, in qua nutrita est, uel apo toy palle<supplied>in to dory</supplied>, id
+                  est ab hastae concussione; uel quod Pallantem gigantem occidit. </p>
             </div>
 
             <div type="cap" n="23">
                <head> Item de <supplied>Minerua</supplied>, fabula Marsyae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Minerua eadem ex osse tibias inuenit. <milestone unit="par" n="2"/> Cum quibus cum in conuiuio deorum cecinisset eiusque tumentes buccas dii omnes irrisissent, illa ad Tritoniam paludem pergens, in aqua faciem suam speculata est et, dum turpia adiudicasset buccarum inflamina, tibias iecit. <milestone unit="par" n="3"/> Quibus Marsyas repertis, doctior factus, Apollinem concertaturus de cantibus prouocauit; et ambo sibi Midam regem iudicem deligunt. <milestone unit="par" n="4"/> Cuius iudicio Marsyas uictus poenas pendit ac suspensus et enudatus usque ad necem uerberibus ab eo est caesus; et tantum sanguinis sui fusum est, ut fons inde nasceretur, cuius Iuuenalis meminit dicens <hi rend="italic">ceu Marsyas uictus</hi>. <milestone unit="par" n="5"/> Alii tradunt quod nymphae satyrique ceterique ruris incolae in tantum Marsyam satyrum fletu prosecuti sunt, quod eius cantu carituri essent, ut ex lacrimis eorum flumen creuerit, quod Marsyas dicitur. <milestone unit="par" n="6"/> Quidam dicunt Midam regem non recte iudicasse et ob id aures eius asininas ab Apolline deprauatas. <milestone unit="par" n="7"/> Sed hoc alias. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Minerua eadem ex osse tibias inuenit. <milestone
+                     unit="par" n="2"/> Cum quibus cum in conuiuio deorum cecinisset eiusque
+                  tumentes buccas dii omnes irrisissent, illa ad Tritoniam paludem pergens, in aqua
+                  faciem suam speculata est et, dum turpia adiudicasset buccarum inflamina, tibias
+                  iecit. <milestone unit="par" n="3"/> Quibus Marsyas repertis, doctior factus,
+                  Apollinem concertaturus de cantibus prouocauit; et ambo sibi Midam regem iudicem
+                  deligunt. <milestone unit="par" n="4"/> Cuius iudicio Marsyas uictus poenas pendit
+                  ac suspensus et enudatus usque ad necem uerberibus ab eo est caesus; et tantum
+                  sanguinis sui fusum est, ut fons inde nasceretur, cuius Iuuenalis meminit dicens
+                     <hi rend="italic">ceu Marsyas uictus</hi>. <milestone unit="par" n="5"/> Alii
+                  tradunt quod nymphae satyrique ceterique ruris incolae in tantum Marsyam satyrum
+                  fletu prosecuti sunt, quod eius cantu carituri essent, ut ex lacrimis eorum flumen
+                  creuerit, quod Marsyas dicitur. <milestone unit="par" n="6"/> Quidam dicunt Midam
+                  regem non recte iudicasse et ob id aures eius asininas ab Apolline deprauatas.
+                     <milestone unit="par" n="7"/> Sed hoc alias. </p>
             </div>
 
             <div type="cap" n="24">
                <head> Fabula Priapi et Loti nymphae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lotos nympha quaedam fuit, quam cum amatam Priapus insequeretur, illa deorum miseratione in arborem uersa est, quae uulgo faba Syriaca dicitur. <milestone unit="par" n="2"/> Sic ipse Priapus pulsus est de La<supplied>m</supplied>psaco ciuitate propter uirili<supplied>s</supplied> membri magnitudinem; postea in numerum deorum receptus, numen hortorum esse meruit. <milestone unit="par" n="3"/> De hoc Horatius: <hi rend="italic">Fures dextra coercet obscenoque ruber porrectus ab inguine palus; ast importuna<supplied>s</supplied> uolucres in uertice haru<supplied>n</supplied>do terret fixa</hi>. <milestone unit="par" n="4"/> Dicitur autem praeesse hortis propter eorum fecunditatem; nam cum alia terra semel aliquid creet, horti numquam sine fructibus sunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lotos nympha quaedam fuit, quam cum amatam Priapus
+                  insequeretur, illa deorum miseratione in arborem uersa est, quae uulgo faba
+                  Syriaca dicitur. <milestone unit="par" n="2"/> Sic ipse Priapus pulsus est de
+                     La<supplied>m</supplied>psaco ciuitate propter uirili<supplied>s</supplied>
+                  membri magnitudinem; postea in numerum deorum receptus, numen hortorum esse
+                  meruit. <milestone unit="par" n="3"/> De hoc Horatius: <hi rend="italic">Fures
+                     dextra coercet obscenoque ruber porrectus ab inguine palus; ast
+                        importuna<supplied>s</supplied> uolucres in uertice
+                        haru<supplied>n</supplied>do terret fixa</hi>. <milestone unit="par" n="4"/>
+                  Dicitur autem praeesse hortis propter eorum fecunditatem; nam cum alia terra semel
+                  aliquid creet, horti numquam sine fructibus sunt. </p>
             </div>
 
             <div type="cap" n="25">
                <head> Fabula Pan<supplied>is</supplied> figuratiua.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pan deus est rusticus, in naturae formatus similitudinem; unde et Pan dictus est, id est omne. <milestone unit="par" n="2"/> Habet enim cornua in radiorum solis et cornuum lunae similitudinem; rubet enim eius facies ad aetheris imitationem; in pectore nebridem habet stellata<supplied>m</supplied>, ad stellarum imaginem; inferior eius pars hispida propter arbores, uirgulta, feras; caprinos pedes habet, ut ostendat terrae soliditatem. <milestone unit="par" n="3"/> Fistulam habet septem calamorum propter harmoniam caeli, in qua septem soni sunt; unde dicit Virgilius <hi rend="italic">septem discrimina uocum</hi>. <milestone unit="par" n="4"/> Curuam ergo calauropam habet, id est pedum, quia annus intra se recurrit. <milestone unit="par" n="5"/> Hi<supplied>c</supplied> quia totius naturae deus est, a poetis fingitur cum Amore deo luctatus et ab eo uictus, quia <hi rend="italic">amor omnia uincit</hi>. <milestone unit="par" n="6"/> Hic ergo amauit Syringam nympham; quam cum insequeretur, illa implorato Terrae auxilio in calamum uersa est; quem Pan ad amoris solacium incidit et sibi fistulam fecit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pan deus est rusticus, in naturae formatus
+                  similitudinem; unde et Pan dictus est, id est omne. <milestone unit="par" n="2"/>
+                  Habet enim cornua in radiorum solis et cornuum lunae similitudinem; rubet enim
+                  eius facies ad aetheris imitationem; in pectore nebridem habet
+                     stellata<supplied>m</supplied>, ad stellarum imaginem; inferior eius pars
+                  hispida propter arbores, uirgulta, feras; caprinos pedes habet, ut ostendat terrae
+                  soliditatem. <milestone unit="par" n="3"/> Fistulam habet septem calamorum propter
+                  harmoniam caeli, in qua septem soni sunt; unde dicit Virgilius <hi rend="italic"
+                     >septem discrimina uocum</hi>. <milestone unit="par" n="4"/> Curuam ergo
+                  calauropam habet, id est pedum, quia annus intra se recurrit. <milestone
+                     unit="par" n="5"/> Hi<supplied>c</supplied> quia totius naturae deus est, a
+                  poetis fingitur cum Amore deo luctatus et ab eo uictus, quia <hi rend="italic"
+                     >amor omnia uincit</hi>. <milestone unit="par" n="6"/> Hic ergo amauit Syringam
+                  nympham; quam cum insequeretur, illa implorato Terrae auxilio in calamum uersa
+                  est; quem Pan ad amoris solacium incidit et sibi fistulam fecit. </p>
             </div>
 
             <div type="cap" n="26">
                <head> Fabula Vulcani.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Vulcanus, eo quod deformis esset, a parentibus suis, id est Ioue et Iunone, spretus est et in insulam Lemn<del>i</del>um praecipitatus illicque a simiis nutritus. <milestone unit="par" n="2"/> Hic cum Ioui fulmina fabricaret, non est admissus ad epulas deorum; postea cum rogaret patrem suum Iouem ut idem Mineruae coniugium sortiretur, concessum est sibi, si concessu ipsius Mineruae posset fieri. <milestone unit="par" n="3"/> Illa autem amorem suum spernente et nimium reluctante, effectum libidinis proiecit in terram; unde natus est puer draconteis pedibus, qui appellatus est Erichthonius, quasi de terra et lite procreatus; nam eris est lis, chthon terra. <milestone unit="par" n="4"/> Hic ad tegendam pedum foeditatem iunctis equis usus est curru, quo tegeret sui corporis turpitudinem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Vulcanus, eo quod deformis esset, a parentibus suis,
+                  id est Ioue et Iunone, spretus est et in insulam Lemn<del>i</del>um praecipitatus
+                  illicque a simiis nutritus. <milestone unit="par" n="2"/> Hic cum Ioui fulmina
+                  fabricaret, non est admissus ad epulas deorum; postea cum rogaret patrem suum
+                  Iouem ut idem Mineruae coniugium sortiretur, concessum est sibi, si concessu
+                  ipsius Mineruae posset fieri. <milestone unit="par" n="3"/> Illa autem amorem suum
+                  spernente et nimium reluctante, effectum libidinis proiecit in terram; unde natus
+                  est puer draconteis pedibus, qui appellatus est Erichthonius, quasi de terra et
+                  lite procreatus; nam eris est lis, chthon terra. <milestone unit="par" n="4"/> Hic
+                  ad tegendam pedum foeditatem iunctis equis usus est curru, quo tegeret sui
+                  corporis turpitudinem. </p>
             </div>
 
             <div type="cap" n="27">
                <head> Fabula Phorci.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phorcus Thoosae nymphae et Neptuni filius dicitur; ut autem Varro dicit, rex fuit Corsicae et Sardiniae. <milestone unit="par" n="2"/> Qui cum <supplied>ab</supplied> Atlante rege nauali certamine cum magna exercitus parte fuisset obrutus, finxerunt socii eius eum in deum marinum esse conuersum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phorcus Thoosae nymphae et Neptuni filius dicitur;
+                  ut autem Varro dicit, rex fuit Corsicae et Sardiniae. <milestone unit="par" n="2"
+                  /> Qui cum <supplied>ab</supplied> Atlante rege nauali certamine cum magna
+                  exercitus parte fuisset obrutus, finxerunt socii eius eum in deum marinum esse
+                  conuersum. </p>
             </div>
 
             <div type="cap" n="28">
                <head> Fabula trium Gorgonum et Persei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phorcus tres habuit filias, Sthennon, Euryalen, Medusam, quae uno intuebantur oculo; et intuentes in lapidem conuertebantur, unde et Gorgones dictae a terrore; gorgon namque graece terror dicitur. <milestone unit="par" n="2"/> Contra quas missus est Perseus cum crystallino clipeo et harpe, quod est genus falcati teli, et adiutorio Mineruae eas interfecit. <milestone unit="par" n="3"/> Re uera tres fuerunt sorores unius pulchritudinis; unde fictum est, ut uno intuerentur oculo. <milestone unit="par" n="4"/> Fuerunt autem locupletissimae, unde et Gorgones quasi geor<del>e</del>ges, id est quasi terrae cultrices: ge enim graece, latine terra; <hi rend="italic">orgia</hi> dicitur cultura. <milestone unit="par" n="5"/> Mortuo patre, Medusa maior filia in regnum sucessit, quam Perseus rex Asiae interfecit et eius regnum abstulit. <milestone unit="par" n="6"/> Veritas tamen hoc modo se habet: Gorgon terror interpretatur, Sthenno<del>n</del> debilitas, Euryale<del>n</del> lata profunditas, Medusa amentia uel obliuio, haec autem omnia in <supplied>h</supplied>om<supplied>i</supplied>nibus terrorem operantur. <milestone unit="par" n="7"/> Perseus autem in figura uirtutis ponitur, qui Gorgonem auxilio Mineruae interfecit; quia uirtus auxilio sapientiae omnes uincit terrores. <milestone unit="par" n="8"/> De sanguine autem Gorgonis natus est Pegasus, qui fama interpretatur, et pede suo fontem Castaliae siue Pegaseum produxit; quia uirtus, omnia superans, bonam sibi adquirit famam. <milestone unit="par" n="9"/> Finguntur autem <supplied>poetae</supplied> de illo potare fonte, quia poeticis figmentis maxime fama iuuatur. <milestone unit="par" n="10"/> Notandum est uero, quod Pegasus equus fuit Neptuni. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phorcus tres habuit filias, Sthennon, Euryalen,
+                  Medusam, quae uno intuebantur oculo; et intuentes in lapidem conuertebantur, unde
+                  et Gorgones dictae a terrore; gorgon namque graece terror dicitur. <milestone
+                     unit="par" n="2"/> Contra quas missus est Perseus cum crystallino clipeo et
+                  harpe, quod est genus falcati teli, et adiutorio Mineruae eas interfecit.
+                     <milestone unit="par" n="3"/> Re uera tres fuerunt sorores unius
+                  pulchritudinis; unde fictum est, ut uno intuerentur oculo. <milestone unit="par"
+                     n="4"/> Fuerunt autem locupletissimae, unde et Gorgones quasi
+                  geor<del>e</del>ges, id est quasi terrae cultrices: ge enim graece, latine terra;
+                     <hi rend="italic">orgia</hi> dicitur cultura. <milestone unit="par" n="5"/>
+                  Mortuo patre, Medusa maior filia in regnum sucessit, quam Perseus rex Asiae
+                  interfecit et eius regnum abstulit. <milestone unit="par" n="6"/> Veritas tamen
+                  hoc modo se habet: Gorgon terror interpretatur, Sthenno<del>n</del> debilitas,
+                     Euryale<del>n</del> lata profunditas, Medusa amentia uel obliuio, haec autem
+                  omnia in <supplied>h</supplied>om<supplied>i</supplied>nibus terrorem operantur.
+                     <milestone unit="par" n="7"/> Perseus autem in figura uirtutis ponitur, qui
+                  Gorgonem auxilio Mineruae interfecit; quia uirtus auxilio sapientiae omnes uincit
+                  terrores. <milestone unit="par" n="8"/> De sanguine autem Gorgonis natus est
+                  Pegasus, qui fama interpretatur, et pede suo fontem Castaliae siue Pegaseum
+                  produxit; quia uirtus, omnia superans, bonam sibi adquirit famam. <milestone
+                     unit="par" n="9"/> Finguntur autem <supplied>poetae</supplied> de illo potare
+                  fonte, quia poeticis figmentis maxime fama iuuatur. <milestone unit="par" n="10"/>
+                  Notandum est uero, quod Pegasus equus fuit Neptuni. </p>
             </div>
 
             <div type="cap" n="29">
                <head> Fabula Medusae Gorgonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Medusa Gorgo, cum propter pulchritudinem a pluribus peteretur, coniugium Neptuni effugere non potuit. <milestone unit="par" n="2"/> Quae quoniam in templo Mineruae cum eo concubuit, propter religionem loci, quem inquinauit, crines eius ab eadem in serpentes sunt mutati, ut quae petita <del>in</del> initio a pluribus procis esset, obiecta deformitate, obuios in fugam uerteret. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Medusa Gorgo, cum propter pulchritudinem a pluribus
+                  peteretur, coniugium Neptuni effugere non potuit. <milestone unit="par" n="2"/>
+                  Quae quoniam in templo Mineruae cum eo concubuit, propter religionem loci, quem
+                  inquinauit, crines eius ab eadem in serpentes sunt mutati, ut quae petita
+                     <del>in</del> initio a pluribus procis esset, obiecta deformitate, obuios in
+                  fugam uerteret. </p>
             </div>
 
             <div type="cap" n="30">
                <head> Fabula trium Gratiarum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter tres filias habuisse legitur cum Iunone, famulas Veneris; quarum nomina sunt Pasithea, Eugiale, Euprosine. <milestone unit="par" n="2"/> Et quia blandae sunt et mites, ideo Gratiae uocabantur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter tres filias habuisse legitur cum Iunone,
+                  famulas Veneris; quarum nomina sunt Pasithea, Eugiale, Euprosine. <milestone
+                     unit="par" n="2"/> Et quia blandae sunt et mites, ideo Gratiae uocabantur. </p>
             </div>
 
             <div type="cap" n="31">
-               <head> Fabula Lemniadum et<supplied>Hyp</supplied>sip<del>h</del>yle<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lemniades, cum diis omnibus decimas frugum annis singulis soluerent, solam Venerem praetermittendam esse dixerunt. <milestone unit="par" n="2"/> Quae irata his odorem immisit hircinum; quas mariti execrantes deserta Lemno odio coniugum Thrac<del>i</del>as petiuerunt eorumque filias sibi asciuere coniugio. <milestone unit="par" n="3"/> Quod ut Lemniadibus compertum est, stimulante Venere in omne genus uirile coniurant remeantesque ex Thracia uiros omnes interemerunt. <milestone unit="par" n="4"/> Inter quas Hy<supplied>p</supplied>sip<del>h</del>yle patri Thoanti sola subuenit, ut non solum parceret, uerum etiam fugientem prosequeretur ad litus; tunc Thoanti Liber occurrit eumque ad insulam Chion prospera nauigatione perdu6xit. <milestone unit="par" n="5"/> Lennon Argonautae uenerunt, quos Lemniades hospitio suscipientes cum his concubuerunt; Hy<supplied>p</supplied>sip<del>h</del>yle ex Iasone filios procreauit Eonium et Thoantem; cum plurimis diebus detenti essent, ab Hercule obiurgati discesserunt. <milestone unit="par" n="6"/> Lemniades autem postquam intellexerunt Hy<supplied>p</supplied>sip<del>h</del>ylem patrem suum seruasse, interficere eam conatae sunt; illa, dum fugit, a praedonibus est capta et Nemeam deportata et Lycurgo, regionis eius regi, in seruitutem distracta. </p>
+               <head> Fabula Lemniadum
+                     et<supplied>Hyp</supplied>sip<del>h</del>yle<supplied>s</supplied>.</head>
+               <p>
+                  <milestone unit="par" n="1"/> Lemniades, cum diis omnibus decimas frugum annis
+                  singulis soluerent, solam Venerem praetermittendam esse dixerunt. <milestone
+                     unit="par" n="2"/> Quae irata his odorem immisit hircinum; quas mariti
+                  execrantes deserta Lemno odio coniugum Thrac<del>i</del>as petiuerunt eorumque
+                  filias sibi asciuere coniugio. <milestone unit="par" n="3"/> Quod ut Lemniadibus
+                  compertum est, stimulante Venere in omne genus uirile coniurant remeantesque ex
+                  Thracia uiros omnes interemerunt. <milestone unit="par" n="4"/> Inter quas
+                     Hy<supplied>p</supplied>sip<del>h</del>yle patri Thoanti sola subuenit, ut non
+                  solum parceret, uerum etiam fugientem prosequeretur ad litus; tunc Thoanti Liber
+                  occurrit eumque ad insulam Chion prospera nauigatione perdu6xit. <milestone
+                     unit="par" n="5"/> Lennon Argonautae uenerunt, quos Lemniades hospitio
+                  suscipientes cum his concubuerunt; Hy<supplied>p</supplied>sip<del>h</del>yle ex
+                  Iasone filios procreauit Eonium et Thoantem; cum plurimis diebus detenti essent,
+                  ab Hercule obiurgati discesserunt. <milestone unit="par" n="6"/> Lemniades autem
+                  postquam intellexerunt Hy<supplied>p</supplied>sip<del>h</del>ylem patrem suum
+                  seruasse, interficere eam conatae sunt; illa, dum fugit, a praedonibus est capta
+                  et Nemeam deportata et Lycurgo, regionis eius regi, in seruitutem distracta. </p>
             </div>
 
             <div type="cap" n="32">
                <head> Fabula Danai et Aegisti.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Danaus, Beli filius, ex pluribus coniugibus quinquaginta filias habuit; totidemque frater eius Aegistus filios, qui Danaum fratrem, ut filias filiis suis in matrimonium copularet, postulauit. <milestone unit="par" n="2"/> Danaus, responso accepto a diis quod generi<del>s</del> sui manibus interiret, Argos profectus est et primum dicitur nauim fecisse, a cuius nomine Argo dicta est nauis. <milestone unit="par" n="3"/> Aegistus mittit filios suos ad persequendum fratrem hisque praecepit ut aut Danaum occiderent, aut domum non redirent, ut Agenor filio Cadmo imperauerat. <milestone unit="par" n="4"/> Qui postquam Argos uenerunt, coeperunt patruum obpugnare; Danaus postquam uidit se non posse resistere, filias suas eis uxores spopondit. <milestone unit="par" n="5"/> Quae patris iussu in nocte uiros suos uniuersae interfecerunt, praeter Clytemnestram seu Hypermestram, quae sola Lynceo uiro suo pepercit. <milestone unit="par" n="6"/> Ob hoc scelus Danai filiae apud inferos hac dicuntur poena damnatae ut aquam in dolium pertusum mittant. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Danaus, Beli filius, ex pluribus coniugibus
+                  quinquaginta filias habuit; totidemque frater eius Aegistus filios, qui Danaum
+                  fratrem, ut filias filiis suis in matrimonium copularet, postulauit. <milestone
+                     unit="par" n="2"/> Danaus, responso accepto a diis quod generi<del>s</del> sui
+                  manibus interiret, Argos profectus est et primum dicitur nauim fecisse, a cuius
+                  nomine Argo dicta est nauis. <milestone unit="par" n="3"/> Aegistus mittit filios
+                  suos ad persequendum fratrem hisque praecepit ut aut Danaum occiderent, aut domum
+                  non redirent, ut Agenor filio Cadmo imperauerat. <milestone unit="par" n="4"/> Qui
+                  postquam Argos uenerunt, coeperunt patruum obpugnare; Danaus postquam uidit se non
+                  posse resistere, filias suas eis uxores spopondit. <milestone unit="par" n="5"/>
+                  Quae patris iussu in nocte uiros suos uniuersae interfecerunt, praeter
+                  Clytemnestram seu Hypermestram, quae sola Lynceo uiro suo pepercit. <milestone
+                     unit="par" n="6"/> Ob hoc scelus Danai filiae apud inferos hac dicuntur poena
+                  damnatae ut aquam in dolium pertusum mittant. </p>
             </div>
 
             <div type="cap" n="33">
                <head> Historia Dardani et origo Troianorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Dardanus et Iasius fratres fuerunt, Electrae — filiae Atlantis — filii; sed Dardanus de Ioue, Iasius de Coryntho procreatus est, a cuius nomine mons et oppidum nomen accepit. <milestone unit="par" n="2"/> Postea Iasium dicitur Dardanus occidisse. <milestone unit="par" n="3"/> Idem Dardanus ab Italiae regione Tuscia ex responso locum mutans per Thraciam Samum delatus est, quam Samothraciam nominauit; et hinc ad Phfygiam deuenit, quam Dardaniam a suo nomine nominauit. <milestone unit="par" n="4"/> Ex quo natus est Erichthonius, qui in istis locis regnauit. <milestone unit="par" n="5"/> Ex Erichthonio Tros, qui iustitia et pietate laudabilis fuit; isque, ut memoriam sui nominis faceret aeternam, Troiam nominauit. <milestone unit="par" n="6"/> Qui etiam Tros filios habuit Ilum Assaracumque; hicque — maior natu erat — regnauit atque Troiam de suo nomine Ilium nominauit, Assaracus a primatu recessit. <milestone unit="par" n="7"/> Ilus Laomedon<supplied>tem</supplied> filium habuit, ex Laomedonte primus Priamus natus est; Assaracus Capyn genuit, ex quo Anchises editus est, Anchisesque Aeneam procreauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Dardanus et Iasius fratres fuerunt, Electrae —
+                  filiae Atlantis — filii; sed Dardanus de Ioue, Iasius de Coryntho procreatus est,
+                  a cuius nomine mons et oppidum nomen accepit. <milestone unit="par" n="2"/> Postea
+                  Iasium dicitur Dardanus occidisse. <milestone unit="par" n="3"/> Idem Dardanus ab
+                  Italiae regione Tuscia ex responso locum mutans per Thraciam Samum delatus est,
+                  quam Samothraciam nominauit; et hinc ad Phfygiam deuenit, quam Dardaniam a suo
+                  nomine nominauit. <milestone unit="par" n="4"/> Ex quo natus est Erichthonius, qui
+                  in istis locis regnauit. <milestone unit="par" n="5"/> Ex Erichthonio Tros, qui
+                  iustitia et pietate laudabilis fuit; isque, ut memoriam sui nominis faceret
+                  aeternam, Troiam nominauit. <milestone unit="par" n="6"/> Qui etiam Tros filios
+                  habuit Ilum Assaracumque; hicque — maior natu erat — regnauit atque Troiam de suo
+                  nomine Ilium nominauit, Assaracus a primatu recessit. <milestone unit="par" n="7"
+                  /> Ilus Laomedon<supplied>tem</supplied> filium habuit, ex Laomedonte primus
+                  Priamus natus est; Assaracus Capyn genuit, ex quo Anchises editus est, Anchisesque
+                  Aeneam procreauit. </p>
             </div>
 
             <div type="cap" n="34">
                <head> Fabula Laomedontis et Herculis et Hesio<supplied>nae</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Laomedon rex fuit Troianorum, pater Priami, qui petiit Neptunum et Apollinem, ut aedificarent urbem Troiam promissa mercede; quam cum ipsi aedificassent, mentitus est munera. <milestone unit="par" n="2"/> Vnde indignatus Apollo pestilentiam eis inmisit, Neptunus cetum maximum. <milestone unit="par" n="3"/> Super quibus dum consuleretur, Apollo respondit contraria dicens omnes filias eius ceto esse opponendas, qui totam ciuitatem deuastabat. <milestone unit="par" n="4"/> Tunc superueniens Hercules, dum Colchos peteret, Hesionam filiam ipsius petiit in coniugio, quam ille ei promisit, si a ceto posset eam liberare. <milestone unit="par" n="5"/> Hercules, interfecto ceto, coniugem sibi promissam petiit, sed ille mentitus est; unde indignatus Hercules Troiae muros destruxit et Hesionam cuidam socio suo Telamoni dedit. <milestone unit="par" n="6"/> Ex qua natus est Teucer: nam Aiacem ex alia constat esse natum. <milestone unit="par" n="7"/> Tunc Hercules Priamum redemptum a sociis in paterno regno locauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Laomedon rex fuit Troianorum, pater Priami, qui
+                  petiit Neptunum et Apollinem, ut aedificarent urbem Troiam promissa mercede; quam
+                  cum ipsi aedificassent, mentitus est munera. <milestone unit="par" n="2"/> Vnde
+                  indignatus Apollo pestilentiam eis inmisit, Neptunus cetum maximum. <milestone
+                     unit="par" n="3"/> Super quibus dum consuleretur, Apollo respondit contraria
+                  dicens omnes filias eius ceto esse opponendas, qui totam ciuitatem deuastabat.
+                     <milestone unit="par" n="4"/> Tunc superueniens Hercules, dum Colchos peteret,
+                  Hesionam filiam ipsius petiit in coniugio, quam ille ei promisit, si a ceto posset
+                  eam liberare. <milestone unit="par" n="5"/> Hercules, interfecto ceto, coniugem
+                  sibi promissam petiit, sed ille mentitus est; unde indignatus Hercules Troiae
+                  muros destruxit et Hesionam cuidam socio suo Telamoni dedit. <milestone unit="par"
+                     n="6"/> Ex qua natus est Teucer: nam Aiacem ex alia constat esse natum.
+                     <milestone unit="par" n="7"/> Tunc Hercules Priamum redemptum a sociis in
+                  paterno regno locauit. </p>
             </div>
 
             <div type="cap" n="35">
                <head> Fabula Acestae et Ippotes.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Laomedon praenotatus rex aedificata sibi a Neptuno et Apolline urbe Troia dum promissis eos fraudasset, Neptunus iratus cetos grandes urbi immisit. <milestone unit="par" n="2"/> Pro quibus consultus Apollo respondit obiciendas nobiles puellas beluae. <milestone unit="par" n="3"/> Quod cum fieret, timens Ippotes quidam nobilis filiae Acestae — cum Laomedontis regis filia iam esset, orta seditione, religata — impositam eam naui misit, quo fors tulisset. <milestone unit="par" n="4"/> Haec ad Siciliam delata, a Cri<supplied>ni</supplied>s<del>i</del>o fluuio, conuerso in canem uel in ursum, compressa, Acesten edidit. <milestone unit="par" n="5"/> Qui ex matris nomine Troianis ciuitatem condidit, quae hodie Acesta nominatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Laomedon praenotatus rex aedificata sibi a Neptuno
+                  et Apolline urbe Troia dum promissis eos fraudasset, Neptunus iratus cetos grandes
+                  urbi immisit. <milestone unit="par" n="2"/> Pro quibus consultus Apollo respondit
+                  obiciendas nobiles puellas beluae. <milestone unit="par" n="3"/> Quod cum fieret,
+                  timens Ippotes quidam nobilis filiae Acestae — cum Laomedontis regis filia iam
+                  esset, orta seditione, religata — impositam eam naui misit, quo fors tulisset.
+                     <milestone unit="par" n="4"/> Haec ad Siciliam delata, a
+                     Cri<supplied>ni</supplied>s<del>i</del>o fluuio, conuerso in canem uel in
+                  ursum, compressa, Acesten edidit. <milestone unit="par" n="5"/> Qui ex matris
+                  nomine Troianis ciuitatem condidit, quae hodie Acesta nominatur. </p>
             </div>
 
             <div type="cap" n="36">
                <head> Fabula Teucri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Teucer cum Troia spoliata sine fratre esset reuersus, qui se furore propter arma perdita Achillis interemerat, Salamine pulsus Sidonem uenit; ex quo Dido cuncta<del>m</del> cognouit. <milestone unit="par" n="2"/> Is Teucer, quod auxilium non dedit fratri suo interfecto — ut quidam uolunt — apud Troiam et quod ossa eius in patriam non detulerit et filium eius paruulum secum non adduxerit, credebatur eum occidisse, ne coheres eius esset. <milestone unit="par" n="3"/> Actus a patre in exilium, Belum, Phoenicum regem, adiit, qui Cyprum insulam armis subegerat; ibi Teucer longo bello urbem condidit, quam Salami<supplied>n</supplied>am nomine patrìae uocauit.</p>
                <p>
-                  <milestone unit="par" n="4"/> Hic Teucer cum hostibus Danais fuit; alius est Teucrus, a quo Troiani Teucri dicuntur, qui post Dardani obitum Troiae muros extruxit et ampliauit. <milestone unit="par" n="5"/> Aiax autem et Achilles patrueles fuerunt, quoniam Telamon et Peleus fuerunt fratres, Aeaci filii. </p>
+                  <milestone unit="par" n="1"/> Teucer cum Troia spoliata sine fratre esset
+                  reuersus, qui se furore propter arma perdita Achillis interemerat, Salamine pulsus
+                  Sidonem uenit; ex quo Dido cuncta<del>m</del> cognouit. <milestone unit="par"
+                     n="2"/> Is Teucer, quod auxilium non dedit fratri suo interfecto — ut quidam
+                  uolunt — apud Troiam et quod ossa eius in patriam non detulerit et filium eius
+                  paruulum secum non adduxerit, credebatur eum occidisse, ne coheres eius esset.
+                     <milestone unit="par" n="3"/> Actus a patre in exilium, Belum, Phoenicum regem,
+                  adiit, qui Cyprum insulam armis subegerat; ibi Teucer longo bello urbem condidit,
+                  quam Salami<supplied>n</supplied>am nomine patrìae uocauit.</p>
+               <p>
+                  <milestone unit="par" n="4"/> Hic Teucer cum hostibus Danais fuit; alius est
+                  Teucrus, a quo Troiani Teucri dicuntur, qui post Dardani obitum Troiae muros
+                  extruxit et ampliauit. <milestone unit="par" n="5"/> Aiax autem et Achilles
+                  patrueles fuerunt, quoniam Telamon et Peleus fuerunt fratres, Aeaci filii. </p>
             </div>
 
             <div type="cap" n="37">
                <head> Fabula Tithoni et Aurorae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tithonus fuit frater Laomedontis, regis Troianorum. <milestone unit="par" n="2"/> Qui cum adamatus fuisset ab Aurora, petiit ab ea longitudinem uitae; unde tamdiu uixit, donec prae nimia senectute uersus est in cicadam. <milestone unit="par" n="3"/> Hic filium suum Memnonem, ex ipsa progenitum, ad Troiae misit auxilia; <hi rend="italic">niger</hi> autem dictus <hi rend="italic">Aethiops</hi>, quia, unde prima surgit aurora, dubia lux est. <milestone unit="par" n="4"/> Huius apud Troiam extincti et sepulti tumulum aues annuo uolatu conuentu officiose celebrant. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tithonus fuit frater Laomedontis, regis Troianorum.
+                     <milestone unit="par" n="2"/> Qui cum adamatus fuisset ab Aurora, petiit ab ea
+                  longitudinem uitae; unde tamdiu uixit, donec prae nimia senectute uersus est in
+                  cicadam. <milestone unit="par" n="3"/> Hic filium suum Memnonem, ex ipsa
+                  progenitum, ad Troiae misit auxilia; <hi rend="italic">niger</hi> autem dictus <hi
+                     rend="italic">Aethiops</hi>, quia, unde prima surgit aurora, dubia lux est.
+                     <milestone unit="par" n="4"/> Huius apud Troiam extincti et sepulti tumulum
+                  aues annuo uolatu conuentu officiose celebrant. </p>
             </div>
 
             <div type="cap" n="38">
                <head> Fabula Pyrrhi et Heleni.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Achille, ut in historia legimus, percusso a Paride sagitta in templo Apollinis Thymbraei, moriens petiit ut euicta Troia ad eius sepulcrum Polyxena immolaretur; quod filius eius Pyrrhus, quem ex Deidamia habuit, impleuit. <milestone unit="par" n="2"/> Postmodum in patria, in numinis Apollinis insultationem, in templo eius Delphico aras patri constituit et illic ei coepit sacrificare. <milestone unit="par" n="3"/> Hic Pyrrhus dum ab Oreste, cuius sponsam Hermione<supplied>m</supplied> rapere uoluerat, occisus iam exspiraret, praecepit ut Andromache, sua coniux, Heleno daretur. <milestone unit="par" n="4"/> Quem quidem captiuum a Troia duxerat, sed in multis ab eodem Heleno fideliter erat praemonitus et cautus redditus, unde et hoc beneficium ei reddidit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Achille, ut in historia legimus, percusso a Paride
+                  sagitta in templo Apollinis Thymbraei, moriens petiit ut euicta Troia ad eius
+                  sepulcrum Polyxena immolaretur; quod filius eius Pyrrhus, quem ex Deidamia habuit,
+                  impleuit. <milestone unit="par" n="2"/> Postmodum in patria, in numinis Apollinis
+                  insultationem, in templo eius Delphico aras patri constituit et illic ei coepit
+                  sacrificare. <milestone unit="par" n="3"/> Hic Pyrrhus dum ab Oreste, cuius
+                  sponsam Hermione<supplied>m</supplied> rapere uoluerat, occisus iam exspiraret,
+                  praecepit ut Andromache, sua coniux, Heleno daretur. <milestone unit="par" n="4"/>
+                  Quem quidem captiuum a Troia duxerat, sed in multis ab eodem Heleno fideliter erat
+                  praemonitus et cautus redditus, unde et hoc beneficium ei reddidit. </p>
             </div>
 
             <div type="cap" n="39">
                <head> Fabula Diomedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Diomedes, qui et Tytides, postquam ira Veneris — a se uulneratae, dum Aeneam, filium eius, in certamine nube interposita liberasset ab eius manibus — uxorem apud Argos turpiter uiuere resciret, noluit reuerti, sed tenuit partes Apuliae; et edomita omni<del>s</del> montis Gargani multitudine in eodem tractu ciuitates plures condidit. <milestone unit="par" n="2"/> Nam et Beneuentum et Equumtuticuum ipse condidit et Arpos, quae et Argyrippa dicitur; ad quam Venulus Argiuus de Tiburte mittitur, non ad Arpinum, quam constat esse Campaniae. <milestone unit="par" n="3"/> Vnde est illud: <hi rend="italic">Praedam Tiburtum ex agmine raptam portat</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Diomedes, qui et Tytides, postquam ira Veneris — a
+                  se uulneratae, dum Aeneam, filium eius, in certamine nube interposita liberasset
+                  ab eius manibus — uxorem apud Argos turpiter uiuere resciret, noluit reuerti, sed
+                  tenuit partes Apuliae; et edomita omni<del>s</del> montis Gargani multitudine in
+                  eodem tractu ciuitates plures condidit. <milestone unit="par" n="2"/> Nam et
+                  Beneuentum et Equumtuticuum ipse condidit et Arpos, quae et Argyrippa dicitur; ad
+                  quam Venulus Argiuus de Tiburte mittitur, non ad Arpinum, quam constat esse
+                  Campaniae. <milestone unit="par" n="3"/> Vnde est illud: <hi rend="italic">Praedam
+                     Tiburtum ex agmine raptam portat</hi>. </p>
             </div>
 
             <div type="cap" n="40">
                <head> De Diomede et Palladio.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Diomedes cum multis casibus affligeretur, Palladium, quod apud ipsum erat, Troianis oraculo iussus est reddere. <milestone unit="par" n="2"/> Quod cum uellet implere, Aeneam inuenit sacrificantem; qui ne sacrificii ordinem rumperet, Palladium Nautes accepit. <milestone unit="par" n="3"/> Vnde Nautorum familia Mineruae sacra seruabat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Diomedes cum multis casibus affligeretur, Palladium,
+                  quod apud ipsum erat, Troianis oraculo iussus est reddere. <milestone unit="par"
+                     n="2"/> Quod cum uellet implere, Aeneam inuenit sacrificantem; qui ne
+                  sacrificii ordinem rumperet, Palladium Nautes accepit. <milestone unit="par" n="3"
+                  /> Vnde Nautorum familia Mineruae sacra seruabat. </p>
             </div>
 
             <div type="cap" n="41">
                <head> Fabula sociorum Diomedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Diomedis socios constat in aues esse conuersos post ducis sui interitum, quem extinctum impatienter dolebant. <milestone unit="par" n="2"/> Hae aues hodieque latine Diomedeae uocantur, Graeci eas herodios dixerunt. <milestone unit="par" n="3"/> Habitant autem insulam Electridem siue Febram, quae est haud longe a Calabria in conspectu Tarentinae ciuitatis. <milestone unit="par" n="4"/> Quin etiam de his auibus dicitur, quod Graecis nauibus laetae occurrant, Latinas uehementer fugiant, memores originis suae. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Diomedis socios constat in aues esse conuersos post
+                  ducis sui interitum, quem extinctum impatienter dolebant. <milestone unit="par"
+                     n="2"/> Hae aues hodieque latine Diomedeae uocantur, Graeci eas herodios
+                  dixerunt. <milestone unit="par" n="3"/> Habitant autem insulam Electridem siue
+                  Febram, quae est haud longe a Calabria in conspectu Tarentinae ciuitatis.
+                     <milestone unit="par" n="4"/> Quin etiam de his auibus dicitur, quod Graecis
+                  nauibus laetae occurrant, Latinas uehementer fugiant, memores originis suae. </p>
             </div>
 
             <div type="cap" n="42">
                <head> De Euboea insula et Naupl<supplied>i</supplied>o Palamede.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Euboea insula est, in qua mons est Capher<supplied>e</supplied>us, circa quem Graeci periere naufragio; quia Naupl<supplied>i</supplied>us, Palamedis pater, dolens filium suum factione mortuum, cum uideret Graecos tempestate laborare, montem Caphereum ascendit et elata facula signum dedit uicini portus. <milestone unit="par" n="2"/> Quare decepti sunt Graeci et inter asperrimos scopulos naufragium pertulerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Euboea insula est, in qua mons est
+                     Capher<supplied>e</supplied>us, circa quem Graeci periere naufragio; quia
+                     Naupl<supplied>i</supplied>us, Palamedis pater, dolens filium suum factione
+                  mortuum, cum uideret Graecos tempestate laborare, montem Caphereum ascendit et
+                  elata facula signum dedit uicini portus. <milestone unit="par" n="2"/> Quare
+                  decepti sunt Graeci et inter asperrimos scopulos naufragium pertulerunt. </p>
             </div>
 
             <div type="cap" n="43">
                <head> De alia Euboea et Cumis ciuitate.</head>
-               <p> Euboea item insula est, de cuius ciuitate Chalcide profecti sunt ad nouas sedes quaerendas; et haud longe a Bais — qui locus a socio Vlixis Baio illic sepulto nomen accepit — inuenerunt uacuum litus, ubi uisa muliere grauida ciuitatem condiderunt; quae res fecundam ostendebat rem publicam; et eam Cumas uoca<supplied>ru</supplied>nt, siue a praegnante, siue ab undis. </p>
+               <p> Euboea item insula est, de cuius ciuitate Chalcide profecti sunt ad nouas sedes
+                  quaerendas; et haud longe a Bais — qui locus a socio Vlixis Baio illic sepulto
+                  nomen accepit — inuenerunt uacuum litus, ubi uisa muliere grauida ciuitatem
+                  condiderunt; quae res fecundam ostendebat rem publicam; et eam Cumas
+                     uoca<supplied>ru</supplied>nt, siue a praegnante, siue ab undis. </p>
             </div>
 
             <div type="cap" n="44">
                <head> Fabula Meleagri et Oenei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Oeneus: pater Tydei et Meleagri, Parthaonis filius, rex Aetoliae, cuius ciuitas est Calydon no<supplied>bi</supplied>lissima; hic summam potestatem regni sui turbauit negligentia sacrorum. <milestone unit="par" n="2"/> Annua siquidem uota pro imperii fructibus celebrans, numen Dianae contempsit; propter quam nimia indignatione oppressus est, ut uideretur omnes placaturus, si illam solam adorasset. <milestone unit="par" n="3"/> Ea aprum summae magnitudinis regioni inmisit; qui uastator Calydoniae terrae ab urbe gentis est appellatus. <milestone unit="par" n="4"/> Cuius Oeneus feritate fractus, edictum tale proposuit, ut dimidiam regni partem caperet, qui monstrum interemisset. <milestone unit="par" n="5"/> Meleagri uirtus periculum non expauit; siquidem ipse eius filius undique iuuentutem collectam ad illam noui generis expeditionem uocauit. <milestone unit="par" n="6"/> Inter quos Atalante conuenit, Iasi filia, summa uenatrix; quae in saltibus prima omnium praedictum aprum sagitta percussit. <milestone unit="par" n="7"/> Postea Meleager uenientem in se feram excepit interemitque; et gratus aduersus puellam, quae inter uiros successu uirtutis enituerat, pellem monstri illius cum capite ad laudis illius testimonium ei dedit. <milestone unit="par" n="8"/> Sed munus, peractum fortitudine, inuidia prodidit; Plexippus namque <supplied>et</supplied> Agenor, Meleagri auunculi, indignati sunt sibi praelatam fuisse uirginem et eam dono spoliauerunt. <milestone unit="par" n="9"/> Qua contentione fata sibi maturauere: id indignatus Meleager, consanguinitate calcata, matris suae fratrem Plexippum occidit sibique matris affectum abstulit. <milestone unit="par" n="10"/> Alt<supplied>hae</supplied>a siquidem germanorum ultione saeuit; nam titionem, quem occultum habuit — qui, cum nasceretur Meleager, in regia subito sortis eius apparuerat ut <del>uaticinatum erat quod</del> iuuenis tamdiu uiueret quoadusque seruatus esset — <del>quem</del> mater ignibus mersit eumque cum filii vece satis extinxit. <milestone unit="par" n="11"/> Quae postquam admissum nefas agnouit, laqueo uitam finiuit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Oeneus: pater Tydei et Meleagri, Parthaonis filius,
+                  rex Aetoliae, cuius ciuitas est Calydon no<supplied>bi</supplied>lissima; hic
+                  summam potestatem regni sui turbauit negligentia sacrorum. <milestone unit="par"
+                     n="2"/> Annua siquidem uota pro imperii fructibus celebrans, numen Dianae
+                  contempsit; propter quam nimia indignatione oppressus est, ut uideretur omnes
+                  placaturus, si illam solam adorasset. <milestone unit="par" n="3"/> Ea aprum
+                  summae magnitudinis regioni inmisit; qui uastator Calydoniae terrae ab urbe gentis
+                  est appellatus. <milestone unit="par" n="4"/> Cuius Oeneus feritate fractus,
+                  edictum tale proposuit, ut dimidiam regni partem caperet, qui monstrum
+                  interemisset. <milestone unit="par" n="5"/> Meleagri uirtus periculum non expauit;
+                  siquidem ipse eius filius undique iuuentutem collectam ad illam noui generis
+                  expeditionem uocauit. <milestone unit="par" n="6"/> Inter quos Atalante conuenit,
+                  Iasi filia, summa uenatrix; quae in saltibus prima omnium praedictum aprum sagitta
+                  percussit. <milestone unit="par" n="7"/> Postea Meleager uenientem in se feram
+                  excepit interemitque; et gratus aduersus puellam, quae inter uiros successu
+                  uirtutis enituerat, pellem monstri illius cum capite ad laudis illius testimonium
+                  ei dedit. <milestone unit="par" n="8"/> Sed munus, peractum fortitudine, inuidia
+                  prodidit; Plexippus namque <supplied>et</supplied> Agenor, Meleagri auunculi,
+                  indignati sunt sibi praelatam fuisse uirginem et eam dono spoliauerunt. <milestone
+                     unit="par" n="9"/> Qua contentione fata sibi maturauere: id indignatus
+                  Meleager, consanguinitate calcata, matris suae fratrem Plexippum occidit sibique
+                  matris affectum abstulit. <milestone unit="par" n="10"/>
+                     Alt<supplied>hae</supplied>a siquidem germanorum ultione saeuit; nam titionem,
+                  quem occultum habuit — qui, cum nasceretur Meleager, in regia subito sortis eius
+                  apparuerat ut <del>uaticinatum erat quod</del> iuuenis tamdiu uiueret quoadusque
+                  seruatus esset — <del>quem</del> mater ignibus mersit eumque cum filii vece satis
+                  extinxit. <milestone unit="par" n="11"/> Quae postquam admissum nefas agnouit,
+                  laqueo uitam finiuit. </p>
             </div>
 
             <div type="cap" n="45">
                <head> De Clytemnestra et Oreste filio eius.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Clytemnestra fuit uxor Agamemnonis, qui cum reuersus esset de bello Troiano, interfectus est per Aegisthum adulterum. <milestone unit="par" n="2"/> Nam cum ingressus fuisset domum suam, obtulit ei Clytemnestra uestem sine capitio; quam cum uellet induere et capitium inuenire non posset, ab Aegistho adultero occisus est. <milestone unit="par" n="3"/> Quem postea simul cum matre Orestes interfecit, unde in amentiam uersus est. <milestone unit="par" n="4"/> Hic namque Orestes, Agamemnonis et Clytemnestrae filius — qui<del>a</del> optimis tragoediis fuit in scaenis celebratus — cum matrem et Aegisthum occidisset, insaniuit. <milestone unit="par" n="5"/> Qui, socii Pyladis admonitu, ad euitandas Furias templum Apollinis ingressus, cum uellet exire, inuaserunt eum Furiae. <milestone unit="par" n="6"/> Hinc est: <hi rend="italic">Vltricesque sedent in limine Dirae</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Clytemnestra fuit uxor Agamemnonis, qui cum reuersus
+                  esset de bello Troiano, interfectus est per Aegisthum adulterum. <milestone
+                     unit="par" n="2"/> Nam cum ingressus fuisset domum suam, obtulit ei
+                  Clytemnestra uestem sine capitio; quam cum uellet induere et capitium inuenire non
+                  posset, ab Aegistho adultero occisus est. <milestone unit="par" n="3"/> Quem
+                  postea simul cum matre Orestes interfecit, unde in amentiam uersus est. <milestone
+                     unit="par" n="4"/> Hic namque Orestes, Agamemnonis et Clytemnestrae filius —
+                     qui<del>a</del> optimis tragoediis fuit in scaenis celebratus — cum matrem et
+                  Aegisthum occidisset, insaniuit. <milestone unit="par" n="5"/> Qui, socii Pyladis
+                  admonitu, ad euitandas Furias templum Apollinis ingressus, cum uellet exire,
+                  inuaserunt eum Furiae. <milestone unit="par" n="6"/> Hinc est: <hi rend="italic"
+                     >Vltricesque sedent in limine Dirae</hi>. </p>
             </div>
 
             <div type="cap" n="46">
                <head> Fabula Europae et Iouis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Europa fuit filia regis Graecorum Agenoris. <milestone unit="par" n="2"/> Quae dum colligeret flores in pratis secundum consuetudinem puellarum, Iuppiter in forma<supplied>m</supplied> speciosi tauri conuersus eam uitiauit hoc modo. <milestone unit="par" n="3"/> Cum Mercurius iussu patris in Phoenicem transgre<supplied>s</supplied>sus esset, ut armenta illius regionis ad litus compelleret, Iuppiter in taurum conuersus est. <milestone unit="par" n="4"/> Cum se iumentis Agenoris regis immiscuisset et in amorem sui spatiantes in arena uirgines coegisset, <del>ac</del> paulatim singulis alludens, nouissime Agenoris filiam — cuius in amorem compulsus auerterat figuram — insidentem sibi tergo in insulam Cretam detulit ibique concubiti<supplied>bu</supplied>s eius fruitus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Europa fuit filia regis Graecorum Agenoris.
+                     <milestone unit="par" n="2"/> Quae dum colligeret flores in pratis secundum
+                  consuetudinem puellarum, Iuppiter in forma<supplied>m</supplied> speciosi tauri
+                  conuersus eam uitiauit hoc modo. <milestone unit="par" n="3"/> Cum Mercurius iussu
+                  patris in Phoenicem transgre<supplied>s</supplied>sus esset, ut armenta illius
+                  regionis ad litus compelleret, Iuppiter in taurum conuersus est. <milestone
+                     unit="par" n="4"/> Cum se iumentis Agenoris regis immiscuisset et in amorem sui
+                  spatiantes in arena uirgines coegisset, <del>ac</del> paulatim singulis alludens,
+                  nouissime Agenoris filiam — cuius in amorem compulsus auerterat figuram —
+                  insidentem sibi tergo in insulam Cretam detulit ibique
+                     concubiti<supplied>bu</supplied>s eius fruitus est. </p>
             </div>
 
             <div type="cap" n="47">
                <head> Fabula Agenoris et Cadmi filii eius.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Agenor rapta filia Europa fratres eius ad requirendam sororem misit Cadmum, Cilicem, Phoenicem, ita ut, nisi eam reperissent, ad se non reuerterentur inperat. <milestone unit="par" n="2"/> Cilix diuersas petiit regiones, nouissime constituit Ciliciam; nec minus Phoenix a suo nomine Phoenicem. <milestone unit="par" n="3"/> Cadmus, desperata spe uisendi parentis, Apollinis oraculum ingreditur sciscitans in quibus partibus orbis consisteret. <milestone unit="par" n="4"/> Accepta itaque sorte, ut uaccam a grege secretam, quae lunae signum in latere habe<supplied>re</supplied>t, ageret et, ubi fessa procubuisset, ibi urbem statueret; et paren<del>ti</del>s praecepto in eam terram deuenit, quae postea a b<del>i</del>oue Beotia dicta est. <milestone unit="par" n="5"/> Hic cum ad fontem Martis socios aquatum misisset et ipse post illos uenisset, inuenit eos a dracone consumptos. <milestone unit="par" n="6"/> Quod ut uidit, serpentem interemit et dentes eius euulsos seuit; ex quibus multitudo armatorum gignitur, quae inter se domestico bello confligens concidit ita, ut ex ea multitudine quinque tantum uiri relinquerentur; qui a Mineruae uoluntate condendae urbi Thebarum Cadmo socii additi sunt. <milestone unit="par" n="7"/> Quorum nomina sunt haec: Echion, Idaeus, Chromi<del>n</del>us, Pelorus, Hyper<del>b</del>e<supplied>n</supplied>on. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Agenor rapta filia Europa fratres eius ad
+                  requirendam sororem misit Cadmum, Cilicem, Phoenicem, ita ut, nisi eam
+                  reperissent, ad se non reuerterentur inperat. <milestone unit="par" n="2"/> Cilix
+                  diuersas petiit regiones, nouissime constituit Ciliciam; nec minus Phoenix a suo
+                  nomine Phoenicem. <milestone unit="par" n="3"/> Cadmus, desperata spe uisendi
+                  parentis, Apollinis oraculum ingreditur sciscitans in quibus partibus orbis
+                  consisteret. <milestone unit="par" n="4"/> Accepta itaque sorte, ut uaccam a grege
+                  secretam, quae lunae signum in latere habe<supplied>re</supplied>t, ageret et, ubi
+                  fessa procubuisset, ibi urbem statueret; et paren<del>ti</del>s praecepto in eam
+                  terram deuenit, quae postea a b<del>i</del>oue Beotia dicta est. <milestone
+                     unit="par" n="5"/> Hic cum ad fontem Martis socios aquatum misisset et ipse
+                  post illos uenisset, inuenit eos a dracone consumptos. <milestone unit="par" n="6"
+                  /> Quod ut uidit, serpentem interemit et dentes eius euulsos seuit; ex quibus
+                  multitudo armatorum gignitur, quae inter se domestico bello confligens concidit
+                  ita, ut ex ea multitudine quinque tantum uiri relinquerentur; qui a Mineruae
+                  uoluntate condendae urbi Thebarum Cadmo socii additi sunt. <milestone unit="par"
+                     n="7"/> Quorum nomina sunt haec: Echion, Idaeus, Chromi<del>n</del>us, Pelorus,
+                     Hyper<del>b</del>e<supplied>n</supplied>on. </p>
             </div>
 
             <div type="cap" n="48">
                <head> Fabula Cadmi et Hermionae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cadmus, Agenoris filius, postquam inspectator suarum calamitatum fuerat in exitu nepotum, perosus Thebarum sedes cum Hermiona, Veneris et Martis filia, coniuge sua, in Illyricos sinus profugit. <milestone unit="par" n="2"/> Ibi a diis petita uenia, ut in draconis speciem conuerteretur — qui initio mali causa fuit —, uota sunt impleta et in serpentes ambo uersi sunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cadmus, Agenoris filius, postquam inspectator suarum
+                  calamitatum fuerat in exitu nepotum, perosus Thebarum sedes cum Hermiona, Veneris
+                  et Martis filia, coniuge sua, in Illyricos sinus profugit. <milestone unit="par"
+                     n="2"/> Ibi a diis petita uenia, ut in draconis speciem conuerteretur — qui
+                  initio mali causa fuit —, uota sunt impleta et in serpentes ambo uersi sunt. </p>
             </div>
 
             <div type="cap" n="49">
                <head> De monili Hermionae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hermione, quae ex Martis et Veneris adulterio nata est, cum praedicto Cadmo iungeretur matrimonio, aureum monile Vulcani accepit dono huiusmodi uenenis infectum, ut necesse esset hoc aurum gestanti aerumnarum molibus opprimi. <milestone unit="par" n="2"/> Quantis enim ueneficiis id ipsum monile secundum fabulas infectum fuerit, Statius euidentissime describit. <milestone unit="par" n="3"/> Ea uero Hermiona et Cadmus, uir eius, in dracones sunt conuersi; deinde illud accepit Agaue, quae in furorem uersa filium suum Pentheum trucidauit; deinde Semele, quae Iunone seducente fulminata est a Ioue; deinde Iocasta, uxor Laii, quae cum filio suo Oedipo concumbens inde filios et filias procreauit; postea Argia, Adrasti filia regis, uxor Polynicis, quae Thebanum bellum fieri persuasit; ultimo tamen Eriphyla, uxor Amphiarai uatis, accepit, quae maritum ad bellum ire nolentem prodidit et paene inuitum ire coegit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hermione, quae ex Martis et Veneris adulterio nata
+                  est, cum praedicto Cadmo iungeretur matrimonio, aureum monile Vulcani accepit dono
+                  huiusmodi uenenis infectum, ut necesse esset hoc aurum gestanti aerumnarum molibus
+                  opprimi. <milestone unit="par" n="2"/> Quantis enim ueneficiis id ipsum monile
+                  secundum fabulas infectum fuerit, Statius euidentissime describit. <milestone
+                     unit="par" n="3"/> Ea uero Hermiona et Cadmus, uir eius, in dracones sunt
+                  conuersi; deinde illud accepit Agaue, quae in furorem uersa filium suum Pentheum
+                  trucidauit; deinde Semele, quae Iunone seducente fulminata est a Ioue; deinde
+                  Iocasta, uxor Laii, quae cum filio suo Oedipo concumbens inde filios et filias
+                  procreauit; postea Argia, Adrasti filia regis, uxor Polynicis, quae Thebanum
+                  bellum fieri persuasit; ultimo tamen Eriphyla, uxor Amphiarai uatis, accepit, quae
+                  maritum ad bellum ire nolentem prodidit et paene inuitum ire coegit. </p>
             </div>
 
             <div type="cap" n="50">
                <head> Fabula Eteoclis et Polynicis et Amphiarai.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Eteocles et Polynices Thebani fratres, regnum partiti, hoc pepigere foedus, ut unus uno anno regnum haberet et alter patria<del>m</del> exiret, usque dum completo anno regnum postea haberet. <milestone unit="par" n="2"/> In primo igitur anno Polynices, minor frater, dimittens regnum et post annum illud repetens, a fratre sibi est negatum. <milestone unit="par" n="3"/> Proinde exul ad Adrastum, regem Argiuorum, se contulit ibique sub eo uiriliter militans eius filiam Argiam in coniugem accepit. <milestone unit="par" n="4"/> Postea uero, cum frater sibi reuerso regnum negaret, bellum statuit. <milestone unit="par" n="5"/> Vnde fatatum erat quod, si Amphiaraus sacerdos ad bellum <supplied>ueniret</supplied>, terra eum glutiente, Polynices uictor esset. <milestone unit="par" n="6"/> Amphiaraus autem mortem sciens in domo latuit; quem Eriphyla, uxor sua, accepto monili ab Argia uxore Polynicis, quod Vulcanus Hermionae priuignae suae fabricauit, eum prodidit. <milestone unit="par" n="7"/> Postea a Polynice ductus ad bellum, terra deglutiente ad inferos uiuus cum curru suo deuectus est. <milestone unit="par" n="8"/> Alcmaeon, filius eius, uolens ulcisci patrem, interfecit matrem, ut Orestes. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Eteocles et Polynices Thebani fratres, regnum
+                  partiti, hoc pepigere foedus, ut unus uno anno regnum haberet et alter
+                     patria<del>m</del> exiret, usque dum completo anno regnum postea haberet.
+                     <milestone unit="par" n="2"/> In primo igitur anno Polynices, minor frater,
+                  dimittens regnum et post annum illud repetens, a fratre sibi est negatum.
+                     <milestone unit="par" n="3"/> Proinde exul ad Adrastum, regem Argiuorum, se
+                  contulit ibique sub eo uiriliter militans eius filiam Argiam in coniugem accepit.
+                     <milestone unit="par" n="4"/> Postea uero, cum frater sibi reuerso regnum
+                  negaret, bellum statuit. <milestone unit="par" n="5"/> Vnde fatatum erat quod, si
+                  Amphiaraus sacerdos ad bellum <supplied>ueniret</supplied>, terra eum glutiente,
+                  Polynices uictor esset. <milestone unit="par" n="6"/> Amphiaraus autem mortem
+                  sciens in domo latuit; quem Eriphyla, uxor sua, accepto monili ab Argia uxore
+                  Polynicis, quod Vulcanus Hermionae priuignae suae fabricauit, eum prodidit.
+                     <milestone unit="par" n="7"/> Postea a Polynice ductus ad bellum, terra
+                  deglutiente ad inferos uiuus cum curru suo deuectus est. <milestone unit="par"
+                     n="8"/> Alcmaeon, filius eius, uolens ulcisci patrem, interfecit matrem, ut
+                  Orestes. </p>
             </div>
 
             <div type="cap" n="51">
                <head> Fabula Apollinis et Sibyllae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sibyllam Apollo pio amore dilexit et ei poscendi quae uellet arbitrium obtulit. <milestone unit="par" n="2"/> Illa harenam manibus hausit et tam longam uitam poposcit; cui Apollo id posse fieri respondit, si Erythraeam in qua habitabat insulam relinqueret et eam numquam uideret. <milestone unit="par" n="3"/> Profecta igitur Cumas tenuit et illic corporis uiribus defecta uitam in sola uoce retinuit. <milestone unit="par" n="4"/> Quod cum ciues eius cognouissent, siue inuidia, siue miseratione commoti — incertum est —, ei epistolam miserunt creta antiquo more signatam; qua uisa terra, quia erat de eius insula, in mortem est soluta. <milestone unit="par" n="5"/> Vnde nonnulli hanc esse dicunt, quae Romana fata conscripsit, quod incenso templo Apollinis inde Romam allati sunt libri, unde haec fuerat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sibyllam Apollo pio amore dilexit et ei poscendi
+                  quae uellet arbitrium obtulit. <milestone unit="par" n="2"/> Illa harenam manibus
+                  hausit et tam longam uitam poposcit; cui Apollo id posse fieri respondit, si
+                  Erythraeam in qua habitabat insulam relinqueret et eam numquam uideret. <milestone
+                     unit="par" n="3"/> Profecta igitur Cumas tenuit et illic corporis uiribus
+                  defecta uitam in sola uoce retinuit. <milestone unit="par" n="4"/> Quod cum ciues
+                  eius cognouissent, siue inuidia, siue miseratione commoti — incertum est —, ei
+                  epistolam miserunt creta antiquo more signatam; qua uisa terra, quia erat de eius
+                  insula, in mortem est soluta. <milestone unit="par" n="5"/> Vnde nonnulli hanc
+                  esse dicunt, quae Romana fata conscripsit, quod incenso templo Apollinis inde
+                  Romam allati sunt libri, unde haec fuerat. </p>
             </div>
 
             <div type="cap" n="52">
-               <head> Fabula Caeni<supplied>do</supplied>s nec uiri nec femine et Nept<supplied>uni</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Caenis uirgo fuit, quae a Neptuno pro stupri praemio sexus mutationem meruit. <milestone unit="par" n="2"/> Fuit etiam inuulnerabilis; qui pugnando pro Lapithis contra Centauros crebris ictibus fustium paulatim fixus in terra est. <milestone unit="par" n="3"/> Post mortem tamen in sexum rediit. <milestone unit="par" n="4"/> Hoc autem dicto ostendit P<del>er</del>latonicum illud, uel Aristotelicum, animas per mete<supplied>m</supplied>psychosin — id est per mutationem — sexum plerumque mutare. </p>
+               <head> Fabula Caeni<supplied>do</supplied>s nec uiri nec femine et
+                     Nept<supplied>uni</supplied>.</head>
+               <p>
+                  <milestone unit="par" n="1"/> Caenis uirgo fuit, quae a Neptuno pro stupri praemio
+                  sexus mutationem meruit. <milestone unit="par" n="2"/> Fuit etiam inuulnerabilis;
+                  qui pugnando pro Lapithis contra Centauros crebris ictibus fustium paulatim fixus
+                  in terra est. <milestone unit="par" n="3"/> Post mortem tamen in sexum rediit.
+                     <milestone unit="par" n="4"/> Hoc autem dicto ostendit P<del>er</del>latonicum
+                  illud, uel Aristotelicum, animas per mete<supplied>m</supplied>psychosin — id est
+                  per mutationem — sexum plerumque mutare. </p>
             </div>
 
             <div type="cap" n="53">
                <head> Fabula Tarpeiae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tarpeia sedes dicta est a Tarpeia uirgine. <milestone unit="par" n="2"/> Cum enim Romulus contra Sabinos bella tractaret et Tarpeio cuidam dedisset arcem tuendam, filia eius Tarpeia aquatum profecta in hostes incidit; quam cum hortarentur ad proditionem, illa pro praemio poposcit ornatura manuum sinist<supplied>r</supplied>arum, id est armillas. <milestone unit="par" n="3"/> Facta itaque proditione arcis, hostes ingeniosa morte promissa soluerunt; nam scuta — id est sinistrarum ornatum — super illam iacientes, eam luce priuarunt. <milestone unit="par" n="4"/> Quae illic sepulta Tarpeiae sedi nomen imposuit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tarpeia sedes dicta est a Tarpeia uirgine.
+                     <milestone unit="par" n="2"/> Cum enim Romulus contra Sabinos bella tractaret
+                  et Tarpeio cuidam dedisset arcem tuendam, filia eius Tarpeia aquatum profecta in
+                  hostes incidit; quam cum hortarentur ad proditionem, illa pro praemio poposcit
+                  ornatura manuum sinist<supplied>r</supplied>arum, id est armillas. <milestone
+                     unit="par" n="3"/> Facta itaque proditione arcis, hostes ingeniosa morte
+                  promissa soluerunt; nam scuta — id est sinistrarum ornatum — super illam
+                  iacientes, eam luce priuarunt. <milestone unit="par" n="4"/> Quae illic sepulta
+                  Tarpeiae sedi nomen imposuit. </p>
             </div>
 
             <div type="cap" n="54">
                <head> Fabula Niobe<supplied>s</supplied> et eius filiorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Niobe: Tantali filia, uxor Amphion<supplied>is</supplied>, ex Sipylo Lydiae orta; quae ex Amphione septem filios et septem filias habuit, id est quattuordecim. <milestone unit="par" n="2"/> Quorum nomina sunt haec: Archemorus, Antogorus, Tantalus, Phadimus, Sipylus, Xenarcus, Epinitus; item filiae: Astycratia, Pelopia, Cheloris, Chleodoxe, Ogime, Phegia, Neaera. <milestone unit="par" n="3"/> Quorum numerositate cum se iactaret Niobe et diceret: «Si Latona ideo colitur, quia gemino natorum pignore — seu foedere — uiget, quanto magis ego digna sum ueneratione, quae quattuordecim filios genui!», ab Apolline et Diana — quae et Triuia — sagittis ipsa et maritus et omnes filii sunt interfecti. <milestone unit="par" n="4"/> Vnde Iuuenalis: «Parce, precor, Paean, et tu de<supplied>a</supplied> pone sagittas; nil pueri faciunt, ipsam configite matrem! Amphion clamat, sed Paean contrahit arcum».</p>
+               <p>
+                  <milestone unit="par" n="1"/> Niobe: Tantali filia, uxor
+                     Amphion<supplied>is</supplied>, ex Sipylo Lydiae orta; quae ex Amphione septem
+                  filios et septem filias habuit, id est quattuordecim. <milestone unit="par" n="2"
+                  /> Quorum nomina sunt haec: Archemorus, Antogorus, Tantalus, Phadimus, Sipylus,
+                  Xenarcus, Epinitus; item filiae: Astycratia, Pelopia, Cheloris, Chleodoxe, Ogime,
+                  Phegia, Neaera. <milestone unit="par" n="3"/> Quorum numerositate cum se iactaret
+                  Niobe et diceret: «Si Latona ideo colitur, quia gemino natorum pignore — seu
+                  foedere — uiget, quanto magis ego digna sum ueneratione, quae quattuordecim filios
+                  genui!», ab Apolline et Diana — quae et Triuia — sagittis ipsa et maritus et omnes
+                  filii sunt interfecti. <milestone unit="par" n="4"/> Vnde Iuuenalis: «Parce,
+                  precor, Paean, et tu de<supplied>a</supplied> pone sagittas; nil pueri faciunt,
+                  ipsam configite matrem! Amphion clamat, sed Paean contrahit arcum».</p>
             </div>
 
             <div type="cap" n="55">
                <head> Fabula Acrisii et Dan<supplied>a</supplied>e<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Acrisius, rex Argiuorum, filiam nomine Dan<supplied>a</supplied>e habuit mirae elegantiae. <milestone unit="par" n="2"/> Ex cuius prole cum se oraculo perire posse cognouisset, aeneam turrim fecit et filiam suam intra clausit, crebris excubiis eam custodiri praecipiens. <milestone unit="par" n="3"/> Tunc in aureum Iuppiter imbrem mutatus cum ea concubuit, per tectum dilapsus in gremium uirginis; ex quo coitu Perseus dicitur esse natus. <milestone unit="par" n="4"/> Vnde Terentius: <hi rend="italic">Deum clanculum uenisse per impluuium; factum fucum mulieri<del>s</del>
-                  </hi>. <milestone unit="par" n="5"/> Ideo aut<supplied>em</supplied> in aureum imbrem mutatus dicitur, quia auro custodes corrupit et sic cum ea concubuit. <milestone unit="par" n="6"/> Cum pater ipsius eam grauidam esse comperisset, naui imposuit, ut iret quo fors tulisset. <milestone unit="par" n="7"/> Deorum autem miseratione ad loca tuta — scilicet ad Italiam — delata inuenta est a piscatore Perseo et illic enixa puerum Perseum nominauit. <milestone unit="par" n="8"/> Oblata est autem regi prouinciae illius, qui eam sibi fecit uxorem; cum qua etiam condidit Ardeam, a quibus Turnum originem uolunt ducere. <milestone unit="par" n="9"/> Iuppiter Perseum cuidam regi alendum commisit; quod Iuno dolens nefandis odiis persequi <del>prae</del>c<supplied>o</supplied>epit eum ac regem instigauit, ut eum aliquo modo perderet; qui misit eum ad diuersa monstra perimenda, ut Chimaeram et Gorgonem et Medusam. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Acrisius, rex Argiuorum, filiam nomine
+                     Dan<supplied>a</supplied>e habuit mirae elegantiae. <milestone unit="par" n="2"
+                  /> Ex cuius prole cum se oraculo perire posse cognouisset, aeneam turrim fecit et
+                  filiam suam intra clausit, crebris excubiis eam custodiri praecipiens. <milestone
+                     unit="par" n="3"/> Tunc in aureum Iuppiter imbrem mutatus cum ea concubuit, per
+                  tectum dilapsus in gremium uirginis; ex quo coitu Perseus dicitur esse natus.
+                     <milestone unit="par" n="4"/> Vnde Terentius: <hi rend="italic">Deum clanculum
+                     uenisse per impluuium; factum fucum mulieri<del>s</del>
+                  </hi>. <milestone unit="par" n="5"/> Ideo aut<supplied>em</supplied> in aureum
+                  imbrem mutatus dicitur, quia auro custodes corrupit et sic cum ea concubuit.
+                     <milestone unit="par" n="6"/> Cum pater ipsius eam grauidam esse comperisset,
+                  naui imposuit, ut iret quo fors tulisset. <milestone unit="par" n="7"/> Deorum
+                  autem miseratione ad loca tuta — scilicet ad Italiam — delata inuenta est a
+                  piscatore Perseo et illic enixa puerum Perseum nominauit. <milestone unit="par"
+                     n="8"/> Oblata est autem regi prouinciae illius, qui eam sibi fecit uxorem; cum
+                  qua etiam condidit Ardeam, a quibus Turnum originem uolunt ducere. <milestone
+                     unit="par" n="9"/> Iuppiter Perseum cuidam regi alendum commisit; quod Iuno
+                  dolens nefandis odiis persequi <del>prae</del>c<supplied>o</supplied>epit eum ac
+                  regem instigauit, ut eum aliquo modo perderet; qui misit eum ad diuersa monstra
+                  perimenda, ut Chimaeram et Gorgonem et Medusam. </p>
             </div>
 
             <div type="cap" n="56">
                <head> Fabula Laodomia<supplied>e</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Laodomia uxor Protesilai fuit. <milestone unit="par" n="2"/> Quae, cum maritum in bello Troiano perire cognouisset, optauit ut umbram eius uideret. <milestone unit="par" n="3"/> Qua re concessa non deserens umbram in amplexibus eius periit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Laodomia uxor Protesilai fuit. <milestone unit="par"
+                     n="2"/> Quae, cum maritum in bello Troiano perire cognouisset, optauit ut
+                  umbram eius uideret. <milestone unit="par" n="3"/> Qua re concessa non deserens
+                  umbram in amplexibus eius periit. </p>
             </div>
 
             <div type="cap" n="57">
                <head> Fabula Phyllidis et Demop<supplied>hontis</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phyllis regina Thracum fuit. <milestone unit="par" n="2"/> Haec Demophontem, Thesei filium, regem Atheniensium, redeuntem de Troiano proelio dilexit et in coniugium suum rogauit; ille ait se prius rem suam ordinaturum et sic ad eius nuptias reuersurum. <milestone unit="par" n="3"/> Profectus itaque cum tardaret, Phyllis amoris impatientia et doloris impulsu, quod se spretam credebat, laqueo uitam finiuit et conuersa est in arborem amygdalum sine foliis. <milestone unit="par" n="4"/> Postea reuersus Demophon, cognita re eius amplexus est truncum; qui, uelut sponsi aduentum sentiret, folia emisit. <milestone unit="par" n="5"/> Vnde et phyll<del>er</del>a sunt dicta a Phyllide, quae antea petala dicebantur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phyllis regina Thracum fuit. <milestone unit="par"
+                     n="2"/> Haec Demophontem, Thesei filium, regem Atheniensium, redeuntem de
+                  Troiano proelio dilexit et in coniugium suum rogauit; ille ait se prius rem suam
+                  ordinaturum et sic ad eius nuptias reuersurum. <milestone unit="par" n="3"/>
+                  Profectus itaque cum tardaret, Phyllis amoris impatientia et doloris impulsu, quod
+                  se spretam credebat, laqueo uitam finiuit et conuersa est in arborem amygdalum
+                  sine foliis. <milestone unit="par" n="4"/> Postea reuersus Demophon, cognita re
+                  eius amplexus est truncum; qui, uelut sponsi aduentum sentiret, folia emisit.
+                     <milestone unit="par" n="5"/> Vnde et phyll<del>er</del>a sunt dicta a
+                  Phyllide, quae antea petala dicebantur. </p>
             </div>
 
             <div type="cap" n="58">
                <head> Fabula Alconis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Alcon fuit Cretensis sagittarius optimus. <milestone unit="par" n="2"/> Cuius filium cum draco inuasisset, tanta arte sagittam direxit, ut ea currens in serpentis defigeret se uulnere, nec in filium transisset, unde laudes meruit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Alcon fuit Cretensis sagittarius optimus. <milestone
+                     unit="par" n="2"/> Cuius filium cum draco inuasisset, tanta arte sagittam
+                  direxit, ut ea currens in serpentis defigeret se uulnere, nec in filium
+                  transisset, unde laudes meruit. </p>
             </div>
 
             <div type="cap" n="59">
                <head> Fabula Codri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Codrus rex fuit Atheniensium. <milestone unit="par" n="2"/> Qui orto bello inter Laconas et Athenienses, cum oraculum respondisset illos posse uincere, quorum dux perisset, habitu humili profectus est ad hostium uicina tentoria et illi<supplied>c</supplied> iurgio eos in suam caedem instigauit et a nullo <supplied>cognitus</supplied> satisfecit oraculo. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Codrus rex fuit Atheniensium. <milestone unit="par"
+                     n="2"/> Qui orto bello inter Laconas et Athenienses, cum oraculum respondisset
+                  illos posse uincere, quorum dux perisset, habitu humili profectus est ad hostium
+                  uicina tentoria et illi<supplied>c</supplied> iurgio eos in suam caedem instigauit
+                  et a nullo <supplied>cognitus</supplied> satisfecit oraculo. </p>
             </div>
 
             <div type="cap" n="60">
                <head> Fabula Pirithoi et Martis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pirithous, Lapitharum rex, cum uxore<supplied>m</supplied> duceret, uicinos populos Centauros etiam sibi cognatos et deos omnes excepto Marte ad conuiuium uocauit; unde iratum numen inmisit furorem, ut Centauri et Lapithae in bella uenirent. <milestone unit="par" n="2"/> Vnde Virgilius: <hi rend="italic">Mars gentem immanem perdere uoluit Lapitharum</hi>. <milestone unit="par" n="3"/> Centauri autem Ixionis et nubis filii sunt; quae nubes ipsi a Iunone in sui forma est obposita. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pirithous, Lapitharum rex, cum
+                     uxore<supplied>m</supplied> duceret, uicinos populos Centauros etiam sibi
+                  cognatos et deos omnes excepto Marte ad conuiuium uocauit; unde iratum numen
+                  inmisit furorem, ut Centauri et Lapithae in bella uenirent. <milestone unit="par"
+                     n="2"/> Vnde Virgilius: <hi rend="italic">Mars gentem immanem perdere uoluit
+                     Lapitharum</hi>. <milestone unit="par" n="3"/> Centauri autem Ixionis et nubis
+                  filii sunt; quae nubes ipsi a Iunone in sui forma est obposita. </p>
             </div>
 
             <div type="cap" n="61">
                <head> Fabula Thessalorum et Cent<supplied>aurorum</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pelethronium oppidum est Thessaliae, ubi primum domandorum equorum repertus est usus. <milestone unit="par" n="2"/> Nam cum quidam Thessalus rex, bubus oestro exagitatis, satellites suos ad eos reuocandos ire iussisset illique cursu non sufficerent, ascenderunt equos et eorum uelocitate boues secuti eos stimulis ad tecta reuocarunt. <milestone unit="par" n="3"/> Sed hi uisi, aut cum irent uelociter, aut cum eorum equi circa flumen Peneon potarent capitibus inclinatis, locum fabulae dederunt, ut Centauri esse crederentur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pelethronium oppidum est Thessaliae, ubi primum
+                  domandorum equorum repertus est usus. <milestone unit="par" n="2"/> Nam cum quidam
+                  Thessalus rex, bubus oestro exagitatis, satellites suos ad eos reuocandos ire
+                  iussisset illique cursu non sufficerent, ascenderunt equos et eorum uelocitate
+                  boues secuti eos stimulis ad tecta reuocarunt. <milestone unit="par" n="3"/> Sed
+                  hi uisi, aut cum irent uelociter, aut cum eorum equi circa flumen Peneon potarent
+                  capitibus inclinatis, locum fabulae dederunt, ut Centauri esse crederentur. </p>
             </div>
 
             <div type="cap" n="62">
                <head> Fabula Phoenissae sacerdotis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phoenissa Dryope sacerdos erat Liberi patris. <milestone unit="par" n="2"/> Quae furti<supplied>m</supplied> grauida facta, dum taurum immolandum ad aram cornibus protraxit, oneris oblita, propter nimiam eius lassitudinem infans coactus excidit de uulua. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Phoenissa Dryope sacerdos erat Liberi patris.
+                     <milestone unit="par" n="2"/> Quae furti<supplied>m</supplied> grauida facta,
+                  dum taurum immolandum ad aram cornibus protraxit, oneris oblita, propter nimiam
+                  eius lassitudinem infans coactus excidit de uulua. </p>
             </div>
 
             <div type="cap" n="63">
                <head> Fabula Sisyphi et Aeginae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sisyphus pro hoc tali poena multatur, quia Aeginam Asopi filiam Iuppiter amauit eamque custodi<supplied>ae</supplied> patris clam surripuit et factum Sisypho confessus est, quod ille humana leuitate patri quaerenti prodidit; unde saxum sine fine contra montem rotare dicitur. <milestone unit="par" n="2"/> Aliter: Sisyphus est, qui apud inferos lapidem grandem uoluit, quia multos ingenti saxo necauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sisyphus pro hoc tali poena multatur, quia Aeginam
+                  Asopi filiam Iuppiter amauit eamque custodi<supplied>ae</supplied> patris clam
+                  surripuit et factum Sisypho confessus est, quod ille humana leuitate patri
+                  quaerenti prodidit; unde saxum sine fine contra montem rotare dicitur. <milestone
+                     unit="par" n="2"/> Aliter: Sisyphus est, qui apud inferos lapidem grandem
+                  uoluit, quia multos ingenti saxo necauit. </p>
             </div>
 
             <div type="cap" n="64">
                <head> Fabula Arethusae et Alphei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Arethusa nympha legitur uenatione expleta se lauare in Alpheo flumine. <milestone unit="par" n="2"/> Ex quo cum adamata fuisset et libenter fugisset, deorum miseratione in fontem uersa, secretis meatibus ad Siciliam fluxit. <milestone unit="par" n="3"/> Quam dicitur Alpheus usque ad Siciliam persequi. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Arethusa nympha legitur uenatione expleta se lauare
+                  in Alpheo flumine. <milestone unit="par" n="2"/> Ex quo cum adamata fuisset et
+                  libenter fugisset, deorum miseratione in fontem uersa, secretis meatibus ad
+                  Siciliam fluxit. <milestone unit="par" n="3"/> Quam dicitur Alpheus usque ad
+                  Siciliam persequi. </p>
             </div>
 
             <div type="cap" n="65">
                <head> Fabula Scironis.</head>
-               <p>Sciron alto residens saxo transeuntes coegisse fertur, ut sibi pedes lauarent; quod dum facerent, eos ex improuiso in praecipitium dedit. </p>
+               <p>Sciron alto residens saxo transeuntes coegisse fertur, ut sibi pedes lauarent;
+                  quod dum facerent, eos ex improuiso in praecipitium dedit. </p>
             </div>
 
             <div type="cap" n="66">
                <head> De Crotopo et Cor<supplied>o</supplied>ebo.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Crotopus rex fuit Argiuorum, cuius filiam Apollo uitiauit. <milestone unit="par" n="2"/> Quod pater indignans filiam interemit, quia Vestae sacerdos fuit et in uirginitate semper perdurare debuit. <milestone unit="par" n="3"/> In cuius ultione<supplied>m</supplied> Apollo horribile monstrum misit, quod Coro<supplied>e</supplied>bus iuuenis quidam fortissimus occidit. <milestone unit="par" n="4"/> Et hanc historiam Statius decentissime scribit. <milestone unit="par" n="5"/> Ipsum enim monstrum Lamia uocabatur. <milestone unit="par" n="6"/> Lamiae sunt enim fossae camporum proluuiis plenae, uel uoragines fluminum, unde ipsa ferocissima bestia Lamia dicebatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Crotopus rex fuit Argiuorum, cuius filiam Apollo
+                  uitiauit. <milestone unit="par" n="2"/> Quod pater indignans filiam interemit,
+                  quia Vestae sacerdos fuit et in uirginitate semper perdurare debuit. <milestone
+                     unit="par" n="3"/> In cuius ultione<supplied>m</supplied> Apollo horribile
+                  monstrum misit, quod Coro<supplied>e</supplied>bus iuuenis quidam fortissimus
+                  occidit. <milestone unit="par" n="4"/> Et hanc historiam Statius decentissime
+                  scribit. <milestone unit="par" n="5"/> Ipsum enim monstrum Lamia uocabatur.
+                     <milestone unit="par" n="6"/> Lamiae sunt enim fossae camporum proluuiis
+                  plenae, uel uoragines fluminum, unde ipsa ferocissima bestia Lamia dicebatur. </p>
             </div>
 
             <div type="cap" n="67">
                <head> Fabula Spingis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Spinx quoddam monstrum fuerat, quod in scopulo<del>lo</del> residens praetereuntibus problema proposuit et persoluere non ualentes unguibus et dentibus dilaniauit. <milestone unit="par" n="2"/> Ad quod Oedipus ueniens problema eius enodauit et ipsum occidit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Spinx quoddam monstrum fuerat, quod in
+                     scopulo<del>lo</del> residens praetereuntibus problema proposuit et persoluere
+                  non ualentes unguibus et dentibus dilaniauit. <milestone unit="par" n="2"/> Ad
+                  quod Oedipus ueniens problema eius enodauit et ipsum occidit. </p>
             </div>
 
             <div type="cap" n="68">
                <head> De Athracia mago.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Athracias: qui fuit <supplied>rex</supplied> Thessaliae, pater et Hippocatiae, quam Pirithous duxit uxorem. <milestone unit="par" n="2"/> Qui primus artem magicam apud Thraciam constituit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Athracias: qui fuit <supplied>rex</supplied>
+                  Thessaliae, pater et Hippocatiae, quam Pirithous duxit uxorem. <milestone
+                     unit="par" n="2"/> Qui primus artem magicam apud Thraciam constituit. </p>
             </div>
 
             <div type="cap" n="69">
                <head> Fabula Lycormae fluuii.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lycormas: quidam fluuius, qui et Thebenus dicitur, iuxta quem Nessus est interfectus ab Hercule, concubitum faciens cum Deianira, uxore Herculis. <milestone unit="par" n="2"/> Quae ipsum Herculem quandam tunicam induit cruore Nessi Centauri perunctam, unde ipse perpessus est intolerabile incendium corporis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lycormas: quidam fluuius, qui et Thebenus dicitur,
+                  iuxta quem Nessus est interfectus ab Hercule, concubitum faciens cum Deianira,
+                  uxore Herculis. <milestone unit="par" n="2"/> Quae ipsum Herculem quandam tunicam
+                  induit cruore Nessi Centauri perunctam, unde ipse perpessus est intolerabile
+                  incendium corporis. </p>
             </div>
 
             <div type="cap" n="70">
                <head> Fabula Minois.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Minos, Cretensis, cui ad gloriam et titulum sola natalium sufficeret claritas, mentis placiditate meruit, ut illum plus moribus quam generis auctoritate mir<supplied>ar</supplied>en<supplied>tur</supplied> homines. <milestone unit="par" n="2"/> Fuit enim rex Cretae ita uita clemens ut, quod est mirum, gauderent eum dominum, quibus imperabat, habuisse. <milestone unit="par" n="3"/> Defunctus deinde, quantum mansuetudo mereatur, nec fato quidem honore priuatus est; nam dicitur apud manes de supremo exitu iudicare mortalium. <milestone unit="par" n="4"/> Veteres enim Graeci, ut impios crudelesque poenas apud inferos luere, sic bonum quemque adeptum bonae uitae praemia post mortem esse dixerunt. <milestone unit="par" n="5"/> Quod bonitatis est exemplum, quia Minos se non ut regem aut tyrannum, sed tamquam unum gessit de plebe; quae laus summa est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Minos, Cretensis, cui ad gloriam et titulum sola
+                  natalium sufficeret claritas, mentis placiditate meruit, ut illum plus moribus
+                  quam generis auctoritate mir<supplied>ar</supplied>en<supplied>tur</supplied>
+                  homines. <milestone unit="par" n="2"/> Fuit enim rex Cretae ita uita clemens ut,
+                  quod est mirum, gauderent eum dominum, quibus imperabat, habuisse. <milestone
+                     unit="par" n="3"/> Defunctus deinde, quantum mansuetudo mereatur, nec fato
+                  quidem honore priuatus est; nam dicitur apud manes de supremo exitu iudicare
+                  mortalium. <milestone unit="par" n="4"/> Veteres enim Graeci, ut impios
+                  crudelesque poenas apud inferos luere, sic bonum quemque adeptum bonae uitae
+                  praemia post mortem esse dixerunt. <milestone unit="par" n="5"/> Quod bonitatis
+                  est exemplum, quia Minos se non ut regem aut tyrannum, sed tamquam unum gessit de
+                  plebe; quae laus summa est. </p>
             </div>
 
             <div type="cap" n="71">
                <head> De Centhaurica.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Centaurica, quam Orestes de Scythia transtulit, humano sanguine placari consueuerat. <milestone unit="par" n="2"/> Cuius cum simulacrum in Laconiam delatum esset, ne quod piaculum nasceretur intermissione sollemnis sacrificii, neue crudelitati Graeciae populus oboediret, inuentum est, <supplied>ut</supplied> inter se impuberes pueri de sustinendis uerberibus contenderent ac se in ha<supplied>n</supplied>c patientia<supplied>m</supplied> prouocarent. <milestone unit="par" n="3"/> Et super aram Dianae impositi flagellis uerberabantur tam diu, donec ex humano corpore sanguis flueret, qui instar sacrificii esset. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Centaurica, quam Orestes de Scythia transtulit,
+                  humano sanguine placari consueuerat. <milestone unit="par" n="2"/> Cuius cum
+                  simulacrum in Laconiam delatum esset, ne quod piaculum nasceretur intermissione
+                  sollemnis sacrificii, neue crudelitati Graeciae populus oboediret, inuentum est,
+                     <supplied>ut</supplied> inter se impuberes pueri de sustinendis uerberibus
+                  contenderent ac se in ha<supplied>n</supplied>c patientia<supplied>m</supplied>
+                  prouocarent. <milestone unit="par" n="3"/> Et super aram Dianae impositi flagellis
+                  uerberabantur tam diu, donec ex humano corpore sanguis flueret, qui instar
+                  sacrificii esset. </p>
             </div>
 
             <div type="cap" n="72">
                <head> Fabula Athlante<supplied>s</supplied> et Meleagri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Athlante, I<supplied>a</supplied>s<del>a</del>i regis filia, fugiens cuiusdam concubitus, in uenando facta est comes Dianae. <milestone unit="par" n="2"/> A Meleagro per uim compressa puerum edidit, cuius conceptum, quia diu sub uirginitate celauit, Parthenopaeum uocauit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Athlante, I<supplied>a</supplied>s<del>a</del>i
+                  regis filia, fugiens cuiusdam concubitus, in uenando facta est comes Dianae.
+                     <milestone unit="par" n="2"/> A Meleagro per uim compressa puerum edidit, cuius
+                  conceptum, quia diu sub uirginitate celauit, Parthenopaeum uocauit. </p>
             </div>
 
             <div type="cap" n="73">
                <head> Quare columba dilecta sit Veneri.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Legimus Cupidinem deum et Venerem causa uoluptatis in quosdam nitentes descendere campos lascivaque contentione certare, quis eorum plus florum colligeret. <milestone unit="par" n="2"/> Quare Cupido, uelocitate aduectus pennarum, magis acquisisse dicitur; sed Peristera, nympha quaedam, subito accurrens, adiuuando Venerem colligendoque flores Venerem potentiorem Cupidine fecit. <milestone unit="par" n="3"/> Vnde Cupido deus indignatus sibi gloriae palma ablata ipsam nympham mutauit in columbam; quae etiam graece peristera dicitur. <milestone unit="par" n="4"/> Proinde columba in tutela Veneris esse dicitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Legimus Cupidinem deum et Venerem causa uoluptatis
+                  in quosdam nitentes descendere campos lascivaque contentione certare, quis eorum
+                  plus florum colligeret. <milestone unit="par" n="2"/> Quare Cupido, uelocitate
+                  aduectus pennarum, magis acquisisse dicitur; sed Peristera, nympha quaedam, subito
+                  accurrens, adiuuando Venerem colligendoque flores Venerem potentiorem Cupidine
+                  fecit. <milestone unit="par" n="3"/> Vnde Cupido deus indignatus sibi gloriae
+                  palma ablata ipsam nympham mutauit in columbam; quae etiam graece peristera
+                  dicitur. <milestone unit="par" n="4"/> Proinde columba in tutela Veneris esse
+                  dicitur. </p>
             </div>
 
             <div type="cap" n="74">
                <head> Fabula Iouis et Iunonis et Vulcani.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter et Iuno uoluerunt intimare suam diuinitatem et genuerunt sine coitu: Iuppiter de sua barba Mineruam, Iuno de suo femore Vulcanum progenuit. <milestone unit="par" n="2"/> Is deformior factus ideoque praecipitatus est a caelo, sed miseratione Plutonis praepositus est Cyclopibus, qui faciunt Ioui fulmina; catax tamen permansit. <milestone unit="par" n="3"/> Cum autem adoleuisset, cum consilio Plutonis fecit sellam auream, ut potuisset agnoscere parentem; in qua sedens Iuno risit, unde cognouit suam matrem fore. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter et Iuno uoluerunt intimare suam diuinitatem
+                  et genuerunt sine coitu: Iuppiter de sua barba Mineruam, Iuno de suo femore
+                  Vulcanum progenuit. <milestone unit="par" n="2"/> Is deformior factus ideoque
+                  praecipitatus est a caelo, sed miseratione Plutonis praepositus est Cyclopibus,
+                  qui faciunt Ioui fulmina; catax tamen permansit. <milestone unit="par" n="3"/> Cum
+                  autem adoleuisset, cum consilio Plutonis fecit sellam auream, ut potuisset
+                  agnoscere parentem; in qua sedens Iuno risit, unde cognouit suam matrem fore. </p>
             </div>
 
             <div type="cap" n="75">
                <head> De templo Iunonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Templum Iunonis fuit, in quo mensam Hercules et Diana lectum habuit. <milestone unit="par" n="2"/> Vbi portabantur pueri, ut de ipsa mensa ederent et inde acciperent for<del>it</del>titudinem; et in lecto Dianae dormirent, ut omnibus amabiles fierent et illorum generatio succresceret. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Templum Iunonis fuit, in quo mensam Hercules et
+                  Diana lectum habuit. <milestone unit="par" n="2"/> Vbi portabantur pueri, ut de
+                  ipsa mensa ederent et inde acciperent for<del>it</del>titudinem; et in lecto
+                  Dianae dormirent, ut omnibus amabiles fierent et illorum generatio succresceret.
+               </p>
             </div>
 
             <div type="cap" n="76">
                <head> Fabula Stygis et Victoriae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Styx palus est quaedam apud <supplied>inferos</supplied>, de qua legimus hoc: <hi rend="italic">dii cuius iurare timent et fallere numen</hi>. <milestone unit="par" n="2"/> Quod inter fabulas ideo est, quia dicitur Victoria, Stygis filia, bello gigantum Ioui fauisse; pro cuius <supplied>rei</supplied> remunera<supplied>ti</supplied>one Iuppiter tribuit, ut dii iurantes per eius matrem non audeant fallere. <milestone unit="par" n="3"/> Ratio autem haec est: styx maerorem significat, unde et Styx dicta est a tristitia; dii autem laeti sunt semper — inde etiam immortales —; ergo <supplied>quia</supplied> maerorem non sentiunt, iurant per rem suae naturae contrariam. <milestone unit="par" n="4"/> In qua Thetis Achillem mersit, eius mortem timens, eo quod natus mortali patre esset, et totum praeter plantas impenetrabilem fecit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Styx palus est quaedam apud
+                     <supplied>inferos</supplied>, de qua legimus hoc: <hi rend="italic">dii cuius
+                     iurare timent et fallere numen</hi>. <milestone unit="par" n="2"/> Quod inter
+                  fabulas ideo est, quia dicitur Victoria, Stygis filia, bello gigantum Ioui
+                  fauisse; pro cuius <supplied>rei</supplied> remunera<supplied>ti</supplied>one
+                  Iuppiter tribuit, ut dii iurantes per eius matrem non audeant fallere. <milestone
+                     unit="par" n="3"/> Ratio autem haec est: styx maerorem significat, unde et Styx
+                  dicta est a tristitia; dii autem laeti sunt semper — inde etiam immortales —; ergo
+                     <supplied>quia</supplied> maerorem non sentiunt, iurant per rem suae naturae
+                  contrariam. <milestone unit="par" n="4"/> In qua Thetis Achillem mersit, eius
+                  mortem timens, eo quod natus mortali patre esset, et totum praeter plantas
+                  impenetrabilem fecit. </p>
             </div>
 
             <div type="cap" n="77">
                <head> Fabula Antigone<supplied>s</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Antigone, Laomedontis filia, crinibus decora, formam suam Iunoni praetulit; quare irata Iuno crines eius in angues mutauit. <milestone unit="par" n="2"/> Quae dum lauaretur, deorum misera<supplied>ti</supplied>one in ciconiam uersa est; ob quam causam meretur ut i<supplied>n</supplied> a<supplied>n</supplied>guem infesta narratur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Antigone, Laomedontis filia, crinibus decora, formam
+                  suam Iunoni praetulit; quare irata Iuno crines eius in angues mutauit. <milestone
+                     unit="par" n="2"/> Quae dum lauaretur, deorum misera<supplied>ti</supplied>one
+                  in ciconiam uersa est; ob quam causam meretur ut i<supplied>n</supplied>
+                     a<supplied>n</supplied>guem infesta narratur. </p>
             </div>
 
             <div type="cap" n="78">
                <head> Fabula Apollinis et Cassandrae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum Apollo Cassandram, filiam Priami, adamaret, <supplied>rogauit</supplied> ut secum ea conditione coiret, ut illi scientiam diuinandi concederet. <milestone unit="par" n="2"/> Quae cum sibi promitteret quod uoluit, illi scientiam diuin<del>i</del>andi concessit. <milestone unit="par" n="3"/> Postea Apollo, spe promissi coitus concessa diuinitate frustratus, fidem uera dicenti<del>s</del> sustulit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum Apollo Cassandram, filiam Priami, adamaret,
+                     <supplied>rogauit</supplied> ut secum ea conditione coiret, ut illi scientiam
+                  diuinandi concederet. <milestone unit="par" n="2"/> Quae cum sibi promitteret quod
+                  uoluit, illi scientiam diuin<del>i</del>andi concessit. <milestone unit="par"
+                     n="3"/> Postea Apollo, spe promissi coitus concessa diuinitate frustratus,
+                  fidem uera dicenti<del>s</del> sustulit. </p>
             </div>
 
             <div type="cap" n="79">
                <head> Fabula Mineruae Graecis iratae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Fabula hoc habet propter stuprum Cassandrae (quam Aiax filius Oilei, unus de ducibus Graecorum, in templo Mineruae uitiauit) Graecis iratam Mineruam — uel quod ei uictores <supplied>per</supplied> superbiam sacrificare noluerunt —; unde eos redeuntes grauissima tempestate fatigatos per diuersa dispersit. <milestone unit="par" n="2"/> Horatius: <hi rend="italic">cum Pallas usto uertit Tram ab Ilio</hi>. <milestone unit="par" n="3"/> Re uera autem constat Graecos tempestate laborasse aequinoctio uernali, quando manubiae Mineruales — id est fulmina — tempestates grauissimas commouent. <milestone unit="par" n="4"/> Vt enim Gemini Apollinis et Herculis esse dicuntur, sic Mineruae Aries esse dinoscitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Fabula hoc habet propter stuprum Cassandrae (quam
+                  Aiax filius Oilei, unus de ducibus Graecorum, in templo Mineruae uitiauit) Graecis
+                  iratam Mineruam — uel quod ei uictores <supplied>per</supplied> superbiam
+                  sacrificare noluerunt —; unde eos redeuntes grauissima tempestate fatigatos per
+                  diuersa dispersit. <milestone unit="par" n="2"/> Horatius: <hi rend="italic">cum
+                     Pallas usto uertit Tram ab Ilio</hi>. <milestone unit="par" n="3"/> Re uera
+                  autem constat Graecos tempestate laborasse aequinoctio uernali, quando manubiae
+                  Mineruales — id est fulmina — tempestates grauissimas commouent. <milestone
+                     unit="par" n="4"/> Vt enim Gemini Apollinis et Herculis esse dicuntur, sic
+                  Mineruae Aries esse dinoscitur. </p>
             </div>
 
             <div type="cap" n="80">
                <head> Fabula Pici et Pomonae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Picum amauit Pomona, pomorum dea, et eius uolent<del>at</del>is est sortita coniugium. <milestone unit="par" n="2"/> Postea Circe cum eum amaret et sperneretur, irata eum in auem picum Martium conuertit; nam altera est pica. <milestone unit="par" n="3"/> Hoc autem ideo fingitur, quia augur fuit et domi picum habuit, per quem futura noscebat, quod pontificales indicant libri. <milestone unit="par" n="4"/> Bene autem supra ei lituum dedit, quod est augurum proprium. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Picum amauit Pomona, pomorum dea, et eius
+                     uolent<del>at</del>is est sortita coniugium. <milestone unit="par" n="2"/>
+                  Postea Circe cum eum amaret et sperneretur, irata eum in auem picum Martium
+                  conuertit; nam altera est pica. <milestone unit="par" n="3"/> Hoc autem ideo
+                  fingitur, quia augur fuit et domi picum habuit, per quem futura noscebat, quod
+                  pontificales indicant libri. <milestone unit="par" n="4"/> Bene autem supra ei
+                  lituum dedit, quod est augurum proprium. </p>
             </div>
 
             <div type="cap" n="81">
-               <head> 
+               <head>
                   <supplied>Fabula</supplied> Astraei et Aurorae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Zephyri uenti sunt, iuxta Graecorum uoluntatem nati ex Astraeo et Aurora; unde Tytan<del>t</del>es duce At<del>a</del>lante originem trahunt. <milestone unit="par" n="2"/> Quos Iuno causa Epaphi, ex Ioue nati, contra Iouem excitauit arma sustollere; unde uicti poenas dedere adiuuantibus diis; et Atlanti caeli onus imposuit. <milestone unit="par" n="3"/> Vnde Virgilius: <hi rend="italic">Tantane uos generis tenuit fiducia uestri?</hi> 
-                  <milestone unit="par" n="4"/> Hii autem appellantur diuersis nominibus tam a Graecis quam a nobis: illi Zephyrum, nos Austrum dicimus; nos Aquilonem, illi Boream uocant; illi Eurum, nos Africum dicimus. <milestone unit="par" n="5"/> Virgilius: <hi rend="italic">dilapsus calor atque in uentos ulta recessit</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Zephyri uenti sunt, iuxta Graecorum uoluntatem nati
+                  ex Astraeo et Aurora; unde Tytan<del>t</del>es duce At<del>a</del>lante originem
+                  trahunt. <milestone unit="par" n="2"/> Quos Iuno causa Epaphi, ex Ioue nati,
+                  contra Iouem excitauit arma sustollere; unde uicti poenas dedere adiuuantibus
+                  diis; et Atlanti caeli onus imposuit. <milestone unit="par" n="3"/> Vnde
+                  Virgilius: <hi rend="italic">Tantane uos generis tenuit fiducia uestri?</hi>
+                  <milestone unit="par" n="4"/> Hii autem appellantur diuersis nominibus tam a
+                  Graecis quam a nobis: illi Zephyrum, nos Austrum dicimus; nos Aquilonem, illi
+                  Boream uocant; illi Eurum, nos Africum dicimus. <milestone unit="par" n="5"/>
+                  Virgilius: <hi rend="italic">dilapsus calor atque in uentos ulta recessit</hi>.
+               </p>
             </div>
 
             <div type="cap" n="82">
-               <head> 
+               <head>
                   <supplied>Fabula</supplied> Iouis et Ganymedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ganymedes, filius Troili, filii Priami, cum prima forma ceteris Troianis praeferretur et assiduis uenationibus in Ida silua exerceretur, ab armigero Iouis — scilicet aquila, quae quondam sibi fulmina deferebat — in caelum raptus est et factus est pincerna deorum. <milestone unit="par" n="2"/> Quod officium prius occupauerat Hebe, filia Minois, filii Iouis. <milestone unit="par" n="3"/> Vel aliter: Iuppiter ne infamiam uirentis — id est masculini — concubitus subiret, uersus in aquilam ex Ida monte rapuit eum et fecit eum pincernam in caelo. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Ganymedes, filius Troili, filii Priami, cum prima
+                  forma ceteris Troianis praeferretur et assiduis uenationibus in Ida silua
+                  exerceretur, ab armigero Iouis — scilicet aquila, quae quondam sibi fulmina
+                  deferebat — in caelum raptus est et factus est pincerna deorum. <milestone
+                     unit="par" n="2"/> Quod officium prius occupauerat Hebe, filia Minois, filii
+                  Iouis. <milestone unit="par" n="3"/> Vel aliter: Iuppiter ne infamiam uirentis —
+                  id est masculini — concubitus subiret, uersus in aquilam ex Ida monte rapuit eum
+                  et fecit eum pincernam in caelo. </p>
             </div>
 
             <div type="cap" n="83">
                <head> Fabula Liriope<supplied>s</supplied> et Narcissi.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Liriope nympha ex amne Cephiso procreauit Narcissum, cui Tiresias omnia prospera pollicitus est, si pulchritudinis suae nullam habuisset notitiam. <milestone unit="par" n="2"/> Hunc igitur cum Echo diligeret, n<supplied>eque</supplied> ullam uiam potiendi inueniret, cura iuuenis, quem extremis uocibus persequeretur fugientem, extabuit eiusque corporis reliquiae in lapidem uersae sunt. <milestone unit="par" n="3"/> Quod ei incidit Iunonis ira, quia garrulitate sua eam saepe est morata, ne Iuppiter in montibus, dum persequeretur nymphas, deprehendi posset. <milestone unit="par" n="4"/> Fertur Echo filia Iunonis; et ob deformitatem in montibus est recondita, ne quid eius praeter uocem inspici posset, quae tamen post obitum auditur. <milestone unit="par" n="5"/> Narcissum autem supradictum ob nimiam crudelitatem, quam in Echo exhibebat, Nemesis — id est fortuna ultrix fastidientium — in amorem sui pertulit, ut non minori flamma ac illa exureretur. <milestone unit="par" n="6"/> Qui cum assidua uenatione fatigatus iuxta fontem in opaco procubuisset et hauriens aquam similitudinem sui conspexisset et diutius ibidem moraretur, nouissime extabuit ita ut uita priuaretur. <milestone unit="par" n="7"/> Ex cuius reliquiis flos extitit, quem Naides nymphae flentes casum fratris Narcissi nomine notarunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Liriope nympha ex amne Cephiso procreauit Narcissum,
+                  cui Tiresias omnia prospera pollicitus est, si pulchritudinis suae nullam
+                  habuisset notitiam. <milestone unit="par" n="2"/> Hunc igitur cum Echo diligeret,
+                     n<supplied>eque</supplied> ullam uiam potiendi inueniret, cura iuuenis, quem
+                  extremis uocibus persequeretur fugientem, extabuit eiusque corporis reliquiae in
+                  lapidem uersae sunt. <milestone unit="par" n="3"/> Quod ei incidit Iunonis ira,
+                  quia garrulitate sua eam saepe est morata, ne Iuppiter in montibus, dum
+                  persequeretur nymphas, deprehendi posset. <milestone unit="par" n="4"/> Fertur
+                  Echo filia Iunonis; et ob deformitatem in montibus est recondita, ne quid eius
+                  praeter uocem inspici posset, quae tamen post obitum auditur. <milestone
+                     unit="par" n="5"/> Narcissum autem supradictum ob nimiam crudelitatem, quam in
+                  Echo exhibebat, Nemesis — id est fortuna ultrix fastidientium — in amorem sui
+                  pertulit, ut non minori flamma ac illa exureretur. <milestone unit="par" n="6"/>
+                  Qui cum assidua uenatione fatigatus iuxta fontem in opaco procubuisset et hauriens
+                  aquam similitudinem sui conspexisset et diutius ibidem moraretur, nouissime
+                  extabuit ita ut uita priuaretur. <milestone unit="par" n="7"/> Ex cuius reliquiis
+                  flos extitit, quem Naides nymphae flentes casum fratris Narcissi nomine notarunt.
+               </p>
             </div>
 
             <div type="cap" n="84">
                <head> Fabula Sirenum et Proserpinae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sirenes, Acheloi fluuii et Melpo<supplied>me</supplied>nes Musae filiae, cum Proserpinam raptam requirerent et eam minime inuenissent, a diis nouissime impetrarunt, ut uersae in uolucres non tantum in terris, sed etiam in mari requisitam consequi possent. <milestone unit="par" n="2"/> Nouissime deuenerunt ad petram Martis, quae imminebat proximo pelago. <milestone unit="par" n="3"/> Harum itaque fatum fuit ut, quamdiu earum uox audita <supplied>non</supplied> esset mortalibus, manerent incolumes. <milestone unit="par" n="4"/> Forte Vlixes monitu Circes, filiae Solis, praeteruectus est; tum se praecipitauerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sirenes, Acheloi fluuii et
+                     Melpo<supplied>me</supplied>nes Musae filiae, cum Proserpinam raptam
+                  requirerent et eam minime inuenissent, a diis nouissime impetrarunt, ut uersae in
+                  uolucres non tantum in terris, sed etiam in mari requisitam consequi possent.
+                     <milestone unit="par" n="2"/> Nouissime deuenerunt ad petram Martis, quae
+                  imminebat proximo pelago. <milestone unit="par" n="3"/> Harum itaque fatum fuit
+                  ut, quamdiu earum uox audita <supplied>non</supplied> esset mortalibus, manerent
+                  incolumes. <milestone unit="par" n="4"/> Forte Vlixes monitu Circes, filiae Solis,
+                  praeteruectus est; tum se praecipitauerunt. </p>
             </div>
 
             <div type="cap" n="85">
                <head> Fabula Latonae et Lyc<supplied>i</supplied>orum rusticorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Latona, Coei gigantis filia, cum Iunonis ira ob adulterium ex Ioue conceptos Apollinem et Dianam parere non posset nullaque errantem eam regio susciperet, nouissime uenit in Lyciam. <milestone unit="par" n="2"/> Et cum ardore aestiuo sitim sedare uellet, ab his, qui iuncum legebant secus litus, prohibita est accedere. <milestone unit="par" n="3"/> Quam ob rem ira accensa, petiit a diis, ut numquam stagno accolae carerent; auditis precibus Iuppiter agricolas in speciem ranarum conuertit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Latona, Coei gigantis filia, cum Iunonis ira ob
+                  adulterium ex Ioue conceptos Apollinem et Dianam parere non posset nullaque
+                  errantem eam regio susciperet, nouissime uenit in Lyciam. <milestone unit="par"
+                     n="2"/> Et cum ardore aestiuo sitim sedare uellet, ab his, qui iuncum legebant
+                  secus litus, prohibita est accedere. <milestone unit="par" n="3"/> Quam ob rem ira
+                  accensa, petiit a diis, ut numquam stagno accolae carerent; auditis precibus
+                  Iuppiter agricolas in speciem ranarum conuertit. </p>
             </div>
 
             <div type="cap" n="86">
                <head> Fabula Medeae et Iasonis et Aesonis et nutricii Liberi patris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iason postquam Medeam in Graeciam duxit et promisso sibi coniugio copulauit, multis rebus expertus ingenium eius, petit ut parentem Aesonem in adolescentiam perduceret. <milestone unit="par" n="2"/> At illa nondum amore deposito, quem in eum habuit, nihil denegando ei, ahenum constituit; herbarum genera, quarum scientiam habuit, uariis regionibus quaesita coquens, Aesonem interemptum in tepidis herbis immiscuit et in pristinum uigorem perduxit.</p>
                <p>
-                  <milestone unit="par" n="3"/> Liber pater, ut animaduertit Aesonem senectutem remediis Medeae expulisse, petit ut nutricibus suis ferret auxilium easque in adolescentium uigorem reduceret. <milestone unit="par" n="4"/> Cuius auctoritate et auxilio illa compulsa, iisdem remediis, quibus Aesonem, in primam iuuentutem reduxit, Libero aeternum beneficium dedit. </p>
+                  <milestone unit="par" n="1"/> Iason postquam Medeam in Graeciam duxit et promisso
+                  sibi coniugio copulauit, multis rebus expertus ingenium eius, petit ut parentem
+                  Aesonem in adolescentiam perduceret. <milestone unit="par" n="2"/> At illa nondum
+                  amore deposito, quem in eum habuit, nihil denegando ei, ahenum constituit;
+                  herbarum genera, quarum scientiam habuit, uariis regionibus quaesita coquens,
+                  Aesonem interemptum in tepidis herbis immiscuit et in pristinum uigorem
+                  perduxit.</p>
+               <p>
+                  <milestone unit="par" n="3"/> Liber pater, ut animaduertit Aesonem senectutem
+                  remediis Medeae expulisse, petit ut nutricibus suis ferret auxilium easque in
+                  adolescentium uigorem reduceret. <milestone unit="par" n="4"/> Cuius auctoritate
+                  et auxilio illa compulsa, iisdem remediis, quibus Aesonem, in primam iuuentutem
+                  reduxit, Libero aeternum beneficium dedit. </p>
             </div>
 
             <div type="cap" n="87">
                <head> Fabula Deucalionis et Pyrrhae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iuppiter propter audaciam Lycaonis ceterorumque mortalium, qui sceleribus suis etiam deorum potentiam tentabant, orbem terrarum profusis imbribus inundauit diluuio. <milestone unit="par" n="2"/> Primum autem diluuium sub Ogyge rege Thebanorum extitit, non sub Saturno; secundum sub Ioue, quod et Deucalionis dicitur. <milestone unit="par" n="3"/> Et cum duo mortales pietate ceteros antecessissent, Deucalion, Promethei filius, ac Pyrrha, eadem soror et uxor, in Parnaso monte proluuiem imbrium effugerunt. <milestone unit="par" n="4"/> Et sorte moniti Themidis, quae eo tempore antistes terrae erat, a diis per preces ueniam acceperunt generandae prolis. <milestone unit="par" n="5"/> Apolline namque consulto in templo, quod in eodem colle habebatur, respondit oraculum ut in monte ossa matris suae in terram proicerent. <milestone unit="par" n="6"/> Proinde magna<del>m</del> ambiguitate<del>m</del> haerere coeperunt, quae essent ossa matris suae, tandem recordati sunt quod terra eorum mater esset et petrae ossa terrae; mox igitur post tergum saxa proiciebant. <milestone unit="par" n="7"/> Quae Deucalion mittebat, uiri efficiebantur, quae Pyrrha, feminae. <milestone unit="par" n="8"/> Postea uenit Prometheus et uiuificabat homines illos, fac<del>i</del>e caelesti adhibita. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Iuppiter propter audaciam Lycaonis ceterorumque
+                  mortalium, qui sceleribus suis etiam deorum potentiam tentabant, orbem terrarum
+                  profusis imbribus inundauit diluuio. <milestone unit="par" n="2"/> Primum autem
+                  diluuium sub Ogyge rege Thebanorum extitit, non sub Saturno; secundum sub Ioue,
+                  quod et Deucalionis dicitur. <milestone unit="par" n="3"/> Et cum duo mortales
+                  pietate ceteros antecessissent, Deucalion, Promethei filius, ac Pyrrha, eadem
+                  soror et uxor, in Parnaso monte proluuiem imbrium effugerunt. <milestone
+                     unit="par" n="4"/> Et sorte moniti Themidis, quae eo tempore antistes terrae
+                  erat, a diis per preces ueniam acceperunt generandae prolis. <milestone unit="par"
+                     n="5"/> Apolline namque consulto in templo, quod in eodem colle habebatur,
+                  respondit oraculum ut in monte ossa matris suae in terram proicerent. <milestone
+                     unit="par" n="6"/> Proinde magna<del>m</del> ambiguitate<del>m</del> haerere
+                  coeperunt, quae essent ossa matris suae, tandem recordati sunt quod terra eorum
+                  mater esset et petrae ossa terrae; mox igitur post tergum saxa proiciebant.
+                     <milestone unit="par" n="7"/> Quae Deucalion mittebat, uiri efficiebantur, quae
+                  Pyrrha, feminae. <milestone unit="par" n="8"/> Postea uenit Prometheus et
+                  uiuificabat homines illos, fac<del>i</del>e caelesti adhibita. </p>
             </div>
 
             <div type="cap" n="88">
                <head> Fabula Palicorum deorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Symaethos fluuius est Siciliae haud longe <supplied>ab</supplied> urbe Catinensi, circa quem sunt Pali<del>a</del>ci dei, quorum talis est fabula. <milestone unit="par" n="2"/> Aetnam nympham Iuppiter cum uitiasset et fecisset grauidam, timens Iunonem, secundum quosdam Terrae commendauit ipsam puellam et illic enixa est, secundum alios postea partum eius. <milestone unit="par" n="3"/> Cum de terra erupissent duo pueri, Palici sunt dicti, quasi iterum uenientes. <milestone unit="par" n="4"/> Hi primo humanis hostiis placabantur, postea quibusdam sacris mitigati sunt et eorum immutata sacrificia; ideo autem <hi rend="italic">ara placabilis</hi>, quia eorum mitigata sunt numina. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Symaethos fluuius est Siciliae haud longe
+                     <supplied>ab</supplied> urbe Catinensi, circa quem sunt Pali<del>a</del>ci dei,
+                  quorum talis est fabula. <milestone unit="par" n="2"/> Aetnam nympham Iuppiter cum
+                  uitiasset et fecisset grauidam, timens Iunonem, secundum quosdam Terrae
+                  commendauit ipsam puellam et illic enixa est, secundum alios postea partum eius.
+                     <milestone unit="par" n="3"/> Cum de terra erupissent duo pueri, Palici sunt
+                  dicti, quasi iterum uenientes. <milestone unit="par" n="4"/> Hi primo humanis
+                  hostiis placabantur, postea quibusdam sacris mitigati sunt et eorum immutata
+                  sacrificia; ideo autem <hi rend="italic">ara placabilis</hi>, quia eorum mitigata
+                  sunt numina. </p>
             </div>
 
             <div type="cap" n="89">
                <head> Fabula Consi et de circensibus ludis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Consus autem deus est consiliorum; qui ideo templum sub tecto habet, ut ostendat tectum esse debere consilium. <milestone unit="par" n="2"/> Inde est quod et Fidei panno uelata manu sacrificabatur, quia fides tecta esse debet. <milestone unit="par" n="3"/> Iste Consus et eques Neptuni dicitur, unde etiam in eius honorem circenses celebrantur. <milestone unit="par" n="4"/> Circenses autem dicti uel a circuitu, uel quod ubi nunc metae sunt, olim gladii ponebantur, quos circuibant, dicti autem circenses ab ensibus, circa quos currebant. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Consus autem deus est consiliorum; qui ideo templum
+                  sub tecto habet, ut ostendat tectum esse debere consilium. <milestone unit="par"
+                     n="2"/> Inde est quod et Fidei panno uelata manu sacrificabatur, quia fides
+                  tecta esse debet. <milestone unit="par" n="3"/> Iste Consus et eques Neptuni
+                  dicitur, unde etiam in eius honorem circenses celebrantur. <milestone unit="par"
+                     n="4"/> Circenses autem dicti uel a circuitu, uel quod ubi nunc metae sunt,
+                  olim gladii ponebantur, quos circuibant, dicti autem circenses ab ensibus, circa
+                  quos currebant. </p>
             </div>
 
             <div type="cap" n="90">
                <head> Fabula Herculis de Olympiadum ludo.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Hercules et milites sui pugnauerunt primitus super equos iuxta Olympum montem; quos uidentes hostes a longe super equos, crediderunt Centauros esse et stupefacti in fugam uersi sunt. <milestone unit="par" n="2"/> Et ideo Hercules ibi ludos instituit. <milestone unit="par" n="3"/> Hercules enim, apud Graecos uirtute sollemniter multimodo <supplied>celebratus</supplied> cursu pedum sub uno anhelitu octauam partem miliaris — id est CXXV passus — percurrebat et iuxta montem Olympum terminum statuit. <milestone unit="par" n="4"/> Vnde et stadium dictum est a stando ad metam, scilicet cursu peracto —; et est stadium octaua pars miliarii. <milestone unit="par" n="5"/> Postea ad imitationem Herculis ludus est institutus: Olympias est dictus. <milestone unit="par" n="6"/> Olympias dicebatur tempus quattuor annorum, siquidem expletis annis tribus anno quarto ueniente celebra<supplied>ba</supplied>tur festiuitas in honorem Iouis Olympici, id est caelestis. <milestone unit="par" n="7"/> Qui dictus Olympicus ab Olymp<del>ic</del>o monte, ubi colebatur, quem poetae pro caelo ponere solent; est enim mirae altitudinis. <milestone unit="par" n="8"/> In illa autem festiuitate omnia genera ludorum certaminumque exercebantur diuersisque modis ibi currebatur — tam cursu pedum et equis quam curribus — et termino posito, ad quem currerent, mox retro seu in aliam partem flectebant. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Hercules et milites sui pugnauerunt primitus super
+                  equos iuxta Olympum montem; quos uidentes hostes a longe super equos, crediderunt
+                  Centauros esse et stupefacti in fugam uersi sunt. <milestone unit="par" n="2"/> Et
+                  ideo Hercules ibi ludos instituit. <milestone unit="par" n="3"/> Hercules enim,
+                  apud Graecos uirtute sollemniter multimodo <supplied>celebratus</supplied> cursu
+                  pedum sub uno anhelitu octauam partem miliaris — id est CXXV passus — percurrebat
+                  et iuxta montem Olympum terminum statuit. <milestone unit="par" n="4"/> Vnde et
+                  stadium dictum est a stando ad metam, scilicet cursu peracto —; et est stadium
+                  octaua pars miliarii. <milestone unit="par" n="5"/> Postea ad imitationem Herculis
+                  ludus est institutus: Olympias est dictus. <milestone unit="par" n="6"/> Olympias
+                  dicebatur tempus quattuor annorum, siquidem expletis annis tribus anno quarto
+                  ueniente celebra<supplied>ba</supplied>tur festiuitas in honorem Iouis Olympici,
+                  id est caelestis. <milestone unit="par" n="7"/> Qui dictus Olympicus ab
+                     Olymp<del>ic</del>o monte, ubi colebatur, quem poetae pro caelo ponere solent;
+                  est enim mirae altitudinis. <milestone unit="par" n="8"/> In illa autem
+                  festiuitate omnia genera ludorum certaminumque exercebantur diuersisque modis ibi
+                  currebatur — tam cursu pedum et equis quam curribus — et termino posito, ad quem
+                  currerent, mox retro seu in aliam partem flectebant. </p>
             </div>
 
             <div type="cap" n="91">
                <head> Fabula de Thybre.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Thybris Tuscorum rex fuit, qui iuxta hunc fluuium cecidit et ei nomen imposuit Thybris. <milestone unit="par" n="2"/> Alii uolunt istum ipsum regem latrocinatum esse circa huius fluminis ripas et transeuntibus crebras iniurias intulisse; unde Thybris quasi <foreign xml:lang="grc">YBPIC</foreign> dictus est, id est ab iniuria. <milestone unit="par" n="3"/> Alii uolunt eos qui de Sicilia uenerunt Thyb<del>e</del>rin dixisse ad similitudinem fossae Syracusanae, quam fecerunt per iniuriam Afri, item Athenienses, iuxta ciuitatis murum. <milestone unit="par" n="4"/> Liuius dicit ab Albano rege Tiberino Thybrin dictum; sed non procedit ideo, quia etiam ante illum <supplied>et</supplied> Albam Thybris dictus inuenitur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Thybris Tuscorum rex fuit, qui iuxta hunc fluuium
+                  cecidit et ei nomen imposuit Thybris. <milestone unit="par" n="2"/> Alii uolunt
+                  istum ipsum regem latrocinatum esse circa huius fluminis ripas et transeuntibus
+                  crebras iniurias intulisse; unde Thybris quasi <foreign xml:lang="grc"
+                     >YBPIC</foreign> dictus est, id est ab iniuria. <milestone unit="par" n="3"/>
+                  Alii uolunt eos qui de Sicilia uenerunt Thyb<del>e</del>rin dixisse ad
+                  similitudinem fossae Syracusanae, quam fecerunt per iniuriam Afri, item
+                  Athenienses, iuxta ciuitatis murum. <milestone unit="par" n="4"/> Liuius dicit ab
+                  Albano rege Tiberino Thybrin dictum; sed non procedit ideo, quia etiam ante illum
+                     <supplied>et</supplied> Albam Thybris dictus inuenitur. </p>
             </div>
 
             <div type="cap" n="92">
                <head> De Gryneo nemore.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Gryneurn nemus est in finibus Ioniis, Apollini consecratum, in quo aliquando Calchas et Mopsus de peritia diuin<del>i</del>andi dicuntur habuisse inter se certamen. <milestone unit="par" n="2"/> Et cum de pomorum cuiusdam arboris contenderent numero, stetit gloria Mopso; cuius rei dolore Calchas interiit. <milestone unit="par" n="3"/> Hoc Euphorionis continent carmina, quae Gallus transtulit in sermonem Latinum, unde est illud in fine Virgilii, ubi Gallus loquitur: <hi rend="italic">ibo et Chalcidico quae sunt mihi condita uersu carmina</hi>. <milestone unit="par" n="4"/> Nam Chalcis ciuitas est Eubo<supplied>e</supplied>ae, de qua fuit Euphorion. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Gryneurn nemus est in finibus Ioniis, Apollini
+                  consecratum, in quo aliquando Calchas et Mopsus de peritia diuin<del>i</del>andi
+                  dicuntur habuisse inter se certamen. <milestone unit="par" n="2"/> Et cum de
+                  pomorum cuiusdam arboris contenderent numero, stetit gloria Mopso; cuius rei
+                  dolore Calchas interiit. <milestone unit="par" n="3"/> Hoc Euphorionis continent
+                  carmina, quae Gallus transtulit in sermonem Latinum, unde est illud in fine
+                  Virgilii, ubi Gallus loquitur: <hi rend="italic">ibo et Chalcidico quae sunt mihi
+                     condita uersu carmina</hi>. <milestone unit="par" n="4"/> Nam Chalcis ciuitas
+                  est Eubo<supplied>e</supplied>ae, de qua fuit Euphorion. </p>
             </div>
 
             <div type="cap" n="93">
                <head> De Idomeneo rege et eius filio.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Idomeneus, rex Cretensium, cum post euersam Troiam reuerteretur, in tempestate deuouit se sacrificaturum de re, quae ei primum occurrisset. <milestone unit="par" n="2"/> Contigit igitur ut primus filius eius occureret. <milestone unit="par" n="3"/> Quem <supplied>cum</supplied>, ut alii dicunt, immolasset, ut alii, immolare uoluisset, a ciuibus pulsus regno, Sallentinum Calabriae promunctorium tenuit, iuxta quod condidit ciuitatem <hi rend="italic">et Sallentinos obsedit milite campos</hi>.</p>
                <p>
-                  <milestone unit="par" n="4"/> Quinque sunt graecae linguae: Aeolica, Ionica, Dorica, Attica, communis. <milestone unit="par" n="5"/> Nomina septem collium in Roma: Palatinus, Quirinalis, Caelius, Viminalis, Esquilinus, Ianicularis, Auentinus. </p>
+                  <milestone unit="par" n="1"/> Idomeneus, rex Cretensium, cum post euersam Troiam
+                  reuerteretur, in tempestate deuouit se sacrificaturum de re, quae ei primum
+                  occurrisset. <milestone unit="par" n="2"/> Contigit igitur ut primus filius eius
+                  occureret. <milestone unit="par" n="3"/> Quem <supplied>cum</supplied>, ut alii
+                  dicunt, immolasset, ut alii, immolare uoluisset, a ciuibus pulsus regno,
+                  Sallentinum Calabriae promunctorium tenuit, iuxta quod condidit ciuitatem <hi
+                     rend="italic">et Sallentinos obsedit milite campos</hi>.</p>
+               <p>
+                  <milestone unit="par" n="4"/> Quinque sunt graecae linguae: Aeolica, Ionica,
+                  Dorica, Attica, communis. <milestone unit="par" n="5"/> Nomina septem collium in
+                  Roma: Palatinus, Quirinalis, Caelius, Viminalis, Esquilinus, Ianicularis,
+                  Auentinus. </p>
             </div>
 
             <div type="cap" n="94">
                <head> Historia de Croeso rege Lydiae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Croesus, rex Lydorum, aliquando a rege Persarum Cyro captus rogo est suppositus; subito tanta pluuia exorta est, ut ignis extingueretur et ipse occasionem inueniret fugiendi. <milestone unit="par" n="2"/> Hoc cum prospere sibi euenisse gl<supplied>ori</supplied>aretur, opum etiam inmensitate<del>m</del> nimium se iactaret, dictum est ei a Solone, uno de septem sapientibus, non debere quemquam in diuitiis et prosperitate gloriari, cum nesciamus quid superuentura pariat dies. <milestone unit="par" n="3"/> Eadem nocte uidit in somnis, quod Iuppiter aqua eum perfunderet solque exsting<supplied>u</supplied>eret. <milestone unit="par" n="4"/> Quod cum filiae suae Phaniae nuntiaret, illa, ut res se habuit, prudenter resoluit, dicens quod cruci esset affigendus et aqua perfundendus et a sole siccandus. <milestone unit="par" n="5"/> Quod postea ita contigit; nam rursus captus a Cyro et crucifixus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Croesus, rex Lydorum, aliquando a rege Persarum Cyro
+                  captus rogo est suppositus; subito tanta pluuia exorta est, ut ignis extingueretur
+                  et ipse occasionem inueniret fugiendi. <milestone unit="par" n="2"/> Hoc cum
+                  prospere sibi euenisse gl<supplied>ori</supplied>aretur, opum etiam
+                     inmensitate<del>m</del> nimium se iactaret, dictum est ei a Solone, uno de
+                  septem sapientibus, non debere quemquam in diuitiis et prosperitate gloriari, cum
+                  nesciamus quid superuentura pariat dies. <milestone unit="par" n="3"/> Eadem nocte
+                  uidit in somnis, quod Iuppiter aqua eum perfunderet solque
+                     exsting<supplied>u</supplied>eret. <milestone unit="par" n="4"/> Quod cum
+                  filiae suae Phaniae nuntiaret, illa, ut res se habuit, prudenter resoluit, dicens
+                  quod cruci esset affigendus et aqua perfundendus et a sole siccandus. <milestone
+                     unit="par" n="5"/> Quod postea ita contigit; nam rursus captus a Cyro et
+                  crucifixus est. </p>
             </div>
 
             <div type="cap" n="95">
                <head> Fabula Thamyr<supplied>id</supplied>is et Musarum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Thamyris quidam uates fuisse dicitur. <milestone unit="par" n="2"/> Quem Musae diu contra se et Apollinem carmine suo contendentem caecasse feruntur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Thamyris quidam uates fuisse dicitur. <milestone
+                     unit="par" n="2"/> Quem Musae diu contra se et Apollinem carmine suo
+                  contendentem caecasse feruntur. </p>
             </div>
 
             <div type="cap" n="96">
                <head> Fabula sororum Meleagri.</head>
-               <p> Meleagria: Pleuron ciuitas est, ubi Meleagridae, sorores Meleagri, illum a fratre Tydeo interfectum intolerabiliter flentes deorum miseratione in aues, id est in gallinas rusticanas, uersae narrantur. </p>
+               <p> Meleagria: Pleuron ciuitas est, ubi Meleagridae, sorores Meleagri, illum a fratre
+                  Tydeo interfectum intolerabiliter flentes deorum miseratione in aues, id est in
+                  gallinas rusticanas, uersae narrantur. </p>
             </div>
 
             <div type="cap" n="97">
                <head> Fabula Iasonidum et Hypsipyle<supplied>s</supplied> et Phetonei.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Iasonidae: filii Iasonis et Hypsipyles. <milestone unit="par" n="2"/> Quorum alter habere maternum nomen fertur, id est Thoas, quia mater eius filia Thoantis erat, et alter uocabatur a patre nauigaturo Euneus, quia eu graece dicitur bonus, neus dicitur nauis, euneus quas<supplied>i</supplied> bene nauigans.</p>
                <p>
-                  <milestone unit="par" n="3"/> 
-                  <supplied>P</supplied>hetoneus autem, seu Thyoneus, Liberi filius fuit, qui in Chio insula regnauit, pater Thoantis regis, cuius filia Hypsipyle coniuratione contra uiros facta, sola patrem seruauit, quem proauus Liber saluauit. </p>
+                  <milestone unit="par" n="1"/> Iasonidae: filii Iasonis et Hypsipyles. <milestone
+                     unit="par" n="2"/> Quorum alter habere maternum nomen fertur, id est Thoas,
+                  quia mater eius filia Thoantis erat, et alter uocabatur a patre nauigaturo Euneus,
+                  quia eu graece dicitur bonus, neus dicitur nauis, euneus
+                     quas<supplied>i</supplied> bene nauigans.</p>
+               <p>
+                  <milestone unit="par" n="3"/>
+                  <supplied>P</supplied>hetoneus autem, seu Thyoneus, Liberi filius fuit, qui in
+                  Chio insula regnauit, pater Thoantis regis, cuius filia Hypsipyle coniuratione
+                  contra uiros facta, sola patrem seruauit, quem proauus Liber saluauit. </p>
             </div>
 
             <div type="cap" n="98">
                <head> Fabula Myrrhae et Adonis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Myrrha patrem suum amasse dicitur, cum quo inebriato concubuit. <milestone unit="par" n="2"/> Cumque eam pater utero plenam rescisset, crimine cognito eam euaginato gladio coepit persequi; illa in arborem myrrham uersa est. <milestone unit="par" n="3"/> Quam arborem pater gladio percutiens, Adon exinde natus est; quem Adonidem Venerem amasse dicunt. <milestone unit="par" n="4"/> Ideo hoc fingitur, quod myrrha uidelicet arbor generet adonem — quod graece suauitas dicitur — quia myrrhae gumma suauis est odore; unde et a Venere amatur, quia hoc genus pigmenti sit ualde feruidum. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Myrrha patrem suum amasse dicitur, cum quo inebriato
+                  concubuit. <milestone unit="par" n="2"/> Cumque eam pater utero plenam rescisset,
+                  crimine cognito eam euaginato gladio coepit persequi; illa in arborem myrrham
+                  uersa est. <milestone unit="par" n="3"/> Quam arborem pater gladio percutiens,
+                  Adon exinde natus est; quem Adonidem Venerem amasse dicunt. <milestone unit="par"
+                     n="4"/> Ideo hoc fingitur, quod myrrha uidelicet arbor generet adonem — quod
+                  graece suauitas dicitur — quia myrrhae gumma suauis est odore; unde et a Venere
+                  amatur, quia hoc genus pigmenti sit ualde feruidum. </p>
             </div>
 
             <div type="cap" n="99">
                <head> Fabula Aeneae et Lethaei fluuii.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Aeneas dum per inferos pergeret, respexit fluuium quendam loci remotioris, a<supplied>d</supplied> quem innumera multitudo tendebat animarum. <milestone unit="par" n="2"/> Interrogauit patrem quis esset fluuius, uel qua ratione ad eum pergerent animae. <milestone unit="par" n="3"/> Pater ait: «Lethaeus est; pergunt autem animae, ut potent et obliuionem patiantur, ut incipiant uelle remeare». <milestone unit="par" n="4"/> Stupefactus Aeneas interrogat: «Dic, pater, et animae, quae propter praeteritam uitam tot supplicia pertulerunt, possunt habere uotum reuertendi in corpora? Non est uerisimile liberatas de corporis carcere ad eius nexum reuerti.» <milestone unit="par" n="5"/> Suscepta narratione, haec Anchises exsequitur: primo fieri debere ut redeant, deinde posse, deinde uelle. <milestone unit="par" n="6"/> Quae quoniam obscura sunt, aliis subdiuisionibus innotescunt. <milestone unit="par" n="7"/> Debere. Cuncta animalia a Deo originem ducunt, quae quia nasci cernimus, reuertuntur procul dubio; nam unde cuncta procreantur? <milestone unit="par" n="8"/> Deinde posse sic probat. Quia immortales sunt animae et sunt quae possunt reuerti. <milestone unit="par" n="9"/> Tertium est utrum uelint. Quod dicit fieri per Lethaeum fluuium. <milestone unit="par" n="10"/> Et hoc est quod dicturus est, sed incidentes quaestiones faciunt obscuritatem. <milestone unit="par" n="11"/> Sane de hoc fluuio quaeritur a prudentioribus, utrum de illis nouem sit qui ambiunt infernum, aut praeter nouem; et datur intelligi quod ab illis nouem separatus sit. <milestone unit="par" n="12"/> Namque uolunt eum esse imaginem senectutis; nam animae nostrae uigent et alacres sunt et plenae memoria a pueritia usque ad senectam; postea in nimia senectute omnis memoria labitur, qua lapsa mors interuenit et animae in aliud corpus reuertuntur. <milestone unit="par" n="13"/> Vnde fingunt poetae animas <del>in</del> Lethaeo hausto in corpus redire; ergo Lethaeus est obliuio, morti semper uicina. <milestone unit="par" n="14"/> Si anima est aeterna et summi spiritus pars, qua ratione in corpore non totum uidet, nec est tantae prudentiae tantaeque uiuacitatis, ut omnia possit agnoscere? <milestone unit="par" n="15"/> Immo quia coepit in corpus descendere, potat stultitiam et obliuionem, unde non potest implere uim numinis sui post naturae suae obliuionem. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Aeneas dum per inferos pergeret, respexit fluuium
+                  quendam loci remotioris, a<supplied>d</supplied> quem innumera multitudo tendebat
+                  animarum. <milestone unit="par" n="2"/> Interrogauit patrem quis esset fluuius,
+                  uel qua ratione ad eum pergerent animae. <milestone unit="par" n="3"/> Pater ait:
+                  «Lethaeus est; pergunt autem animae, ut potent et obliuionem patiantur, ut
+                  incipiant uelle remeare». <milestone unit="par" n="4"/> Stupefactus Aeneas
+                  interrogat: «Dic, pater, et animae, quae propter praeteritam uitam tot supplicia
+                  pertulerunt, possunt habere uotum reuertendi in corpora? Non est uerisimile
+                  liberatas de corporis carcere ad eius nexum reuerti.» <milestone unit="par" n="5"
+                  /> Suscepta narratione, haec Anchises exsequitur: primo fieri debere ut redeant,
+                  deinde posse, deinde uelle. <milestone unit="par" n="6"/> Quae quoniam obscura
+                  sunt, aliis subdiuisionibus innotescunt. <milestone unit="par" n="7"/> Debere.
+                  Cuncta animalia a Deo originem ducunt, quae quia nasci cernimus, reuertuntur
+                  procul dubio; nam unde cuncta procreantur? <milestone unit="par" n="8"/> Deinde
+                  posse sic probat. Quia immortales sunt animae et sunt quae possunt reuerti.
+                     <milestone unit="par" n="9"/> Tertium est utrum uelint. Quod dicit fieri per
+                  Lethaeum fluuium. <milestone unit="par" n="10"/> Et hoc est quod dicturus est, sed
+                  incidentes quaestiones faciunt obscuritatem. <milestone unit="par" n="11"/> Sane
+                  de hoc fluuio quaeritur a prudentioribus, utrum de illis nouem sit qui ambiunt
+                  infernum, aut praeter nouem; et datur intelligi quod ab illis nouem separatus sit.
+                     <milestone unit="par" n="12"/> Namque uolunt eum esse imaginem senectutis; nam
+                  animae nostrae uigent et alacres sunt et plenae memoria a pueritia usque ad
+                  senectam; postea in nimia senectute omnis memoria labitur, qua lapsa mors
+                  interuenit et animae in aliud corpus reuertuntur. <milestone unit="par" n="13"/>
+                  Vnde fingunt poetae animas <del>in</del> Lethaeo hausto in corpus redire; ergo
+                  Lethaeus est obliuio, morti semper uicina. <milestone unit="par" n="14"/> Si anima
+                  est aeterna et summi spiritus pars, qua ratione in corpore non totum uidet, nec
+                  est tantae prudentiae tantaeque uiuacitatis, ut omnia possit agnoscere? <milestone
+                     unit="par" n="15"/> Immo quia coepit in corpus descendere, potat stultitiam et
+                  obliuionem, unde non potest implere uim numinis sui post naturae suae obliuionem.
+               </p>
             </div>
 
             <div type="cap" n="100">
                <head> Item de fuga Aeneae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Aeneas, Veneris et Anchisae filius, in euersione Troiae deos p<del>r</del>enates et patrem et filium Ascanium ex incendio rapuit et cum his in Idam montem uenit; ibique uiginti nauibus fabricatis, responsis deorum monitus, mare ingressus est et ad Thraciam uenit; ibique condidit ciuitatem, quam Aenum — id est de suo nomine — uocauit. <milestone unit="par" n="2"/> Inde auspiciis deorum commonitus ad Delon insulam nauigauit; ibique rex Anius —idem et sacerdos Apollinis — erat. <milestone unit="par" n="3"/> Exhinc profectus per Cycladas insulas, uenit ad Cretam insulam, in qua Pergamum ciuitatem condidit; et hortatu deorum admonitus in Italiam perrexit. <milestone unit="par" n="4"/> Stropha<del>li</del>das et multas praeterea Graeciae insulas praeteriens, ad Helenum in Achaiam uenit; cuius uaticinatione monitus, ad litus Italiae, quod non longe uidebat, deuenit et per eas Italiae oras nauigans, quas Graeci inter Italiam et Siciliam uocant, cum magno labore ad Cyclopas uenit. <milestone unit="par" n="5"/> Et cum Trephani portum peruenisset ibique patrem senem amisisset, per Africam peruenit iterum ad Siciliam ibique Acestam condidit urbem. <milestone unit="par" n="6"/> Deinde Italiam nauigans, non longe a Campania Euboicis litoribus allapsus, Cumanam consuluit Sibyllam, cum qua ad infernum descendit, ut cuncta cognosceret. <milestone unit="par" n="7"/> Et deinde Circaeam insulam praeteruectus, tandem ad Italiam uenit, ostium Tiberis intrans, ibique pro pace satis agens petiit et amicitiae Euandri iunctus est et auxilio Tuscorum additus est. <milestone unit="par" n="8"/> Sed <supplied>a</supplied> Turno, filio Glauci et Veniliae, reginae Rutulorum, bello excepto et eo interfecto duxit eius sponsam Lauiniam, Latini regis filiam; de cuius nomine oppidum Lauinium condidit ibique ternis annis regnauit. <milestone unit="par" n="9"/> Mox cum apud Numicum fluuium deambulans nusquam comparuisset, in caelum translatus dicitur.</p>
                <p>
-                  <milestone unit="par" n="10"/> Item aliter. <milestone unit="par" n="11"/> Idem Aeneas, ut Cato dicit, postquam Lauiniam, Latini regis filiam, accepit uxorem uiuente marito Turno, idem Turnus iratus tam in Latinum quam in Aeneam bella suscepit, a Mezentio impetratis auxiliis; in quorum primo bello periit Latinus, in secundo pariter <supplied>Turnus</supplied> et Aeneas. <milestone unit="par" n="12"/> Postea Mezentium interemit Ascanius et Laurolauinium tenuit. <milestone unit="par" n="13"/> Cuius Lauinia timens insidias, grauida confugit in siluas et latuit in casa pastoris Tyri — ad quam alludens <hi rend="italic">Tyrus pater</hi>: recepit eam et fouit —; et illic enixa est Siluium. <milestone unit="par" n="14"/> Sed cum Ascanius flagraret inuidia, euocauit nouercam et ei concessit Laurolauinium; sibi uero Albam constituit. <milestone unit="par" n="15"/> Qui quoniarn sine liberis periit, Silu<supplied>i</supplied>o, qui et ipse Ascanius dictus est, suum reliquit imperium. </p>
+                  <milestone unit="par" n="1"/> Aeneas, Veneris et Anchisae filius, in euersione
+                  Troiae deos p<del>r</del>enates et patrem et filium Ascanium ex incendio rapuit et
+                  cum his in Idam montem uenit; ibique uiginti nauibus fabricatis, responsis deorum
+                  monitus, mare ingressus est et ad Thraciam uenit; ibique condidit ciuitatem, quam
+                  Aenum — id est de suo nomine — uocauit. <milestone unit="par" n="2"/> Inde
+                  auspiciis deorum commonitus ad Delon insulam nauigauit; ibique rex Anius —idem et
+                  sacerdos Apollinis — erat. <milestone unit="par" n="3"/> Exhinc profectus per
+                  Cycladas insulas, uenit ad Cretam insulam, in qua Pergamum ciuitatem condidit; et
+                  hortatu deorum admonitus in Italiam perrexit. <milestone unit="par" n="4"/>
+                     Stropha<del>li</del>das et multas praeterea Graeciae insulas praeteriens, ad
+                  Helenum in Achaiam uenit; cuius uaticinatione monitus, ad litus Italiae, quod non
+                  longe uidebat, deuenit et per eas Italiae oras nauigans, quas Graeci inter Italiam
+                  et Siciliam uocant, cum magno labore ad Cyclopas uenit. <milestone unit="par"
+                     n="5"/> Et cum Trephani portum peruenisset ibique patrem senem amisisset, per
+                  Africam peruenit iterum ad Siciliam ibique Acestam condidit urbem. <milestone
+                     unit="par" n="6"/> Deinde Italiam nauigans, non longe a Campania Euboicis
+                  litoribus allapsus, Cumanam consuluit Sibyllam, cum qua ad infernum descendit, ut
+                  cuncta cognosceret. <milestone unit="par" n="7"/> Et deinde Circaeam insulam
+                  praeteruectus, tandem ad Italiam uenit, ostium Tiberis intrans, ibique pro pace
+                  satis agens petiit et amicitiae Euandri iunctus est et auxilio Tuscorum additus
+                  est. <milestone unit="par" n="8"/> Sed <supplied>a</supplied> Turno, filio Glauci
+                  et Veniliae, reginae Rutulorum, bello excepto et eo interfecto duxit eius sponsam
+                  Lauiniam, Latini regis filiam; de cuius nomine oppidum Lauinium condidit ibique
+                  ternis annis regnauit. <milestone unit="par" n="9"/> Mox cum apud Numicum fluuium
+                  deambulans nusquam comparuisset, in caelum translatus dicitur.</p>
+               <p>
+                  <milestone unit="par" n="10"/> Item aliter. <milestone unit="par" n="11"/> Idem
+                  Aeneas, ut Cato dicit, postquam Lauiniam, Latini regis filiam, accepit uxorem
+                  uiuente marito Turno, idem Turnus iratus tam in Latinum quam in Aeneam bella
+                  suscepit, a Mezentio impetratis auxiliis; in quorum primo bello periit Latinus, in
+                  secundo pariter <supplied>Turnus</supplied> et Aeneas. <milestone unit="par"
+                     n="12"/> Postea Mezentium interemit Ascanius et Laurolauinium tenuit.
+                     <milestone unit="par" n="13"/> Cuius Lauinia timens insidias, grauida confugit
+                  in siluas et latuit in casa pastoris Tyri — ad quam alludens <hi rend="italic"
+                     >Tyrus pater</hi>: recepit eam et fouit —; et illic enixa est Siluium.
+                     <milestone unit="par" n="14"/> Sed cum Ascanius flagraret inuidia, euocauit
+                  nouercam et ei concessit Laurolauinium; sibi uero Albam constituit. <milestone
+                     unit="par" n="15"/> Qui quoniarn sine liberis periit,
+                     Silu<supplied>i</supplied>o, qui et ipse Ascanius dictus est, suum reliquit
+                  imperium. </p>
             </div>
 
             <div type="cap" n="101">
-               <head> 
+               <head>
                   <supplied>Fabula Rhesi</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Rhesus rex Thraciae fuit; qui cum ad Troiae uenisset auxilia clausisque portis tentoria locasset in litore, Dolone prodente, qui missus fuerat speculator, a Diomede et Vlixe est interfectus, qui et ipsi speculatum uenerant. <milestone unit="par" n="2"/> Abducti sunt equi, quibus pendebant fata Troiana. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Rhesus rex Thraciae fuit; qui cum ad Troiae uenisset
+                  auxilia clausisque portis tentoria locasset in litore, Dolone prodente, qui missus
+                  fuerat speculator, a Diomede et Vlixe est interfectus, qui et ipsi speculatum
+                  uenerant. <milestone unit="par" n="2"/> Abducti sunt equi, quibus pendebant fata
+                  Troiana. </p>
             </div>
          </div>
 
@@ -1328,250 +3292,598 @@
 
             <div type="cap" n="1">
                <head> De genealogia deorum et heroum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Ophion, uel secundum philosophos, Oceanus, qui et Nereus, de maiore Thetide genuit Caelium. <milestone unit="par" n="2"/> Caelius genuit Saturnum, Phorcum et Rheam. <milestone unit="par" n="3"/> Phorcus genuit Stenn<del>i</del>onem, Euryalen et Medusam, quae est Gorgona. <milestone unit="par" n="4"/> Saturnus de Rhea genuit Iouem et Iunonem et Neptunum et Plutonem.</p>
                <p>
-                  <milestone unit="par" n="5"/> Atlas de Pleione genuit Steropem Maiam et Electram et alias quattuor. <milestone unit="par" n="6"/> Iuppiter de Electra genuit Dardanum et Teucrum. <milestone unit="par" n="7"/> Dardanus Ilum et Assaracum. <milestone unit="par" n="8"/> Ilus Laomedonta et Ganymedem. <milestone unit="par" n="9"/> Laomedon<del>ta</del> genuit Anchisem, Tithonum, Antenorem, Antigonem, quae uersa est in ciconiam, Hesionam et Priamum. <milestone unit="par" n="10"/> Priamus de Hecuba, filia Dymantis, regis Thebarum, genuit Troilum et Helenum, Polydamanta, Deiphobum, Cassandram, Paridem, Hectorem; qui de Andromache genuit Astyanacta.</p>
+                  <milestone unit="par" n="1"/> Ophion, uel secundum philosophos, Oceanus, qui et
+                  Nereus, de maiore Thetide genuit Caelium. <milestone unit="par" n="2"/> Caelius
+                  genuit Saturnum, Phorcum et Rheam. <milestone unit="par" n="3"/> Phorcus genuit
+                     Stenn<del>i</del>onem, Euryalen et Medusam, quae est Gorgona. <milestone
+                     unit="par" n="4"/> Saturnus de Rhea genuit Iouem et Iunonem et Neptunum et
+                  Plutonem.</p>
                <p>
-                  <milestone unit="par" n="11"/> Anchises de Venere genuit Aeneam. <milestone unit="par" n="12"/> Aeneas de Creusa Iulum, qui et Ascanius, <unclear/> quem interfecit. <milestone unit="par" n="13"/> Ipse, post ueniens in Italiam, de Lauinia, filia Latini, desponsata Turno, genuit Siluium Aeneam. <milestone unit="par" n="14"/> Siluius Latinum. <milestone unit="par" n="15"/> Latinus Epytum, Ca<del>m</del>py<supplied>m</supplied> et Capetum. <milestone unit="par" n="16"/> Capetus Remulum et Acrota<supplied>m</supplied>. <milestone unit="par" n="17"/> Acrota Auentinum. <milestone unit="par" n="18"/> Auentinus P<supplied>a</supplied>latinum. <milestone unit="par" n="19"/> Palatinus Amulium et Numitorem. <milestone unit="par" n="20"/> Amulius genuit Iliam abbatissam. <milestone unit="par" n="21"/> Cum qua Mars concubuit et genuit Romulum et Remum. <milestone unit="par" n="22"/> Romuli uxor Hersilia, de cuius stirpe fuit Iulius.</p>
+                  <milestone unit="par" n="5"/> Atlas de Pleione genuit Steropem Maiam et Electram
+                  et alias quattuor. <milestone unit="par" n="6"/> Iuppiter de Electra genuit
+                  Dardanum et Teucrum. <milestone unit="par" n="7"/> Dardanus Ilum et Assaracum.
+                     <milestone unit="par" n="8"/> Ilus Laomedonta et Ganymedem. <milestone
+                     unit="par" n="9"/> Laomedon<del>ta</del> genuit Anchisem, Tithonum, Antenorem,
+                  Antigonem, quae uersa est in ciconiam, Hesionam et Priamum. <milestone unit="par"
+                     n="10"/> Priamus de Hecuba, filia Dymantis, regis Thebarum, genuit Troilum et
+                  Helenum, Polydamanta, Deiphobum, Cassandram, Paridem, Hectorem; qui de Andromache
+                  genuit Astyanacta.</p>
                <p>
-                  <milestone unit="par" n="23"/> Item Iuppiter concubuit cum una de quattuor filiabus Atlantis, quarum nomina non leguntur, genuitque ex ea Tantalum. <milestone unit="par" n="24"/> Tantalus de Sterope genuit Niobe<supplied>m</supplied> et Pelopem. <milestone unit="par" n="25"/> Pelops de Hippodamia, filia Oenomai, que<supplied>m</supplied> uicit curuli certamine auxilio Myrtili, genuit Atreum et Thyestem. <milestone unit="par" n="26"/> Atreus Agamemnonem et Menelaum. <milestone unit="par" n="27"/> Menelaus de Helena Hermionem. <milestone unit="par" n="28"/> Agamemnon de Clytemnestra Orestem et Iphigeniam.</p>
+                  <milestone unit="par" n="11"/> Anchises de Venere genuit Aeneam. <milestone
+                     unit="par" n="12"/> Aeneas de Creusa Iulum, qui et Ascanius, <unclear/> quem
+                  interfecit. <milestone unit="par" n="13"/> Ipse, post ueniens in Italiam, de
+                  Lauinia, filia Latini, desponsata Turno, genuit Siluium Aeneam. <milestone
+                     unit="par" n="14"/> Siluius Latinum. <milestone unit="par" n="15"/> Latinus
+                  Epytum, Ca<del>m</del>py<supplied>m</supplied> et Capetum. <milestone unit="par"
+                     n="16"/> Capetus Remulum et Acrota<supplied>m</supplied>. <milestone unit="par"
+                     n="17"/> Acrota Auentinum. <milestone unit="par" n="18"/> Auentinus
+                     P<supplied>a</supplied>latinum. <milestone unit="par" n="19"/> Palatinus
+                  Amulium et Numitorem. <milestone unit="par" n="20"/> Amulius genuit Iliam
+                  abbatissam. <milestone unit="par" n="21"/> Cum qua Mars concubuit et genuit
+                  Romulum et Remum. <milestone unit="par" n="22"/> Romuli uxor Hersilia, de cuius
+                  stirpe fuit Iulius.</p>
                <p>
-                  <milestone unit="par" n="29"/> Maior Thetis, uxor Oceani, genuit Thetidem, matrem Achillis, et Clymenem. <milestone unit="par" n="30"/> Clymene<del>n</del> fuit uxor Solis et genuit Phaethonta. <milestone unit="par" n="31"/> Item genuit Aethram. <milestone unit="par" n="32"/> Aethra Theseum.</p>
+                  <milestone unit="par" n="23"/> Item Iuppiter concubuit cum una de quattuor
+                  filiabus Atlantis, quarum nomina non leguntur, genuitque ex ea Tantalum.
+                     <milestone unit="par" n="24"/> Tantalus de Sterope genuit
+                     Niobe<supplied>m</supplied> et Pelopem. <milestone unit="par" n="25"/> Pelops
+                  de Hippodamia, filia Oenomai, que<supplied>m</supplied> uicit curuli certamine
+                  auxilio Myrtili, genuit Atreum et Thyestem. <milestone unit="par" n="26"/> Atreus
+                  Agamemnonem et Menelaum. <milestone unit="par" n="27"/> Menelaus de Helena
+                  Hermionem. <milestone unit="par" n="28"/> Agamemnon de Clytemnestra Orestem et
+                  Iphigeniam.</p>
                <p>
-                  <milestone unit="par" n="33"/> Neptunus genuit Aegeum. <milestone unit="par" n="34"/> Aegeus Theseum. <milestone unit="par" n="35"/> Theseus de Hippolyta, regina Amazonum, concepit Hippolytum. <milestone unit="par" n="36"/> Idem genuit Demophonta.</p>
+                  <milestone unit="par" n="29"/> Maior Thetis, uxor Oceani, genuit Thetidem, matrem
+                  Achillis, et Clymenem. <milestone unit="par" n="30"/> Clymene<del>n</del> fuit
+                  uxor Solis et genuit Phaethonta. <milestone unit="par" n="31"/> Item genuit
+                  Aethram. <milestone unit="par" n="32"/> Aethra Theseum.</p>
                <p>
-                  <milestone unit="par" n="37"/> Item <supplied>Iuppiter</supplied> concubuit cum Alcmena, uxore Amphitr<supplied>y</supplied>onis, et genuit Herculem. <milestone unit="par" n="38"/> Hercules de Deidamia Hyllum.</p>
+                  <milestone unit="par" n="33"/> Neptunus genuit Aegeum. <milestone unit="par"
+                     n="34"/> Aegeus Theseum. <milestone unit="par" n="35"/> Theseus de Hippolyta,
+                  regina Amazonum, concepit Hippolytum. <milestone unit="par" n="36"/> Idem genuit
+                  Demophonta.</p>
                <p>
-                  <milestone unit="par" n="39"/> Item Agenor genuit Cadmum, Europam, Cilicem, Phoenicem. <milestone unit="par" n="40"/> Cadmus accepit Hermionem, filiam Veneris, uxoris Vulcani et Martis, de qua genuit Agauem, Semelem, Autonoem et Inonem. <milestone unit="par" n="41"/> Agaue genuit P<del>h</del>entheum. <milestone unit="par" n="42"/> Semele Bacchum. <milestone unit="par" n="43"/> Autonoe<del>m</del> Actaeona. <milestone unit="par" n="44"/> Ino, uxor Athamantis — post Nephelem, <supplied>quae</supplied> genuit Phrixum et Hellen — genuit Learchum et Melicertam. <milestone unit="par" n="45"/> Cadmo successit Lycus, cuius erat uxor Antiopa, Nyctei filia, cum qua <supplied>Iuppiter</supplied> concubuit in carcere in specie satyri <supplied>et</supplied> genuit Zethum et Amphionem. <milestone unit="par" n="46"/> Qui successit Ly<del>n</del>co et accepit Nioben, de qua genuit septem filios et totidem filias.</p>
+                  <milestone unit="par" n="37"/> Item <supplied>Iuppiter</supplied> concubuit cum
+                  Alcmena, uxore Amphitr<supplied>y</supplied>onis, et genuit Herculem. <milestone
+                     unit="par" n="38"/> Hercules de Deidamia Hyllum.</p>
                <p>
-                  <milestone unit="par" n="47"/> Item Laius de Iocasta genuit Oedipum. <milestone unit="par" n="48"/> 
-                  <supplied>O</supplied>edipus de Iocasta genuit Eteoclem et Polynicem, Ismenem et Antigonem.</p>
+                  <milestone unit="par" n="39"/> Item Agenor genuit Cadmum, Europam, Cilicem,
+                  Phoenicem. <milestone unit="par" n="40"/> Cadmus accepit Hermionem, filiam
+                  Veneris, uxoris Vulcani et Martis, de qua genuit Agauem, Semelem, Autonoem et
+                  Inonem. <milestone unit="par" n="41"/> Agaue genuit P<del>h</del>entheum.
+                     <milestone unit="par" n="42"/> Semele Bacchum. <milestone unit="par" n="43"/>
+                     Autonoe<del>m</del> Actaeona. <milestone unit="par" n="44"/> Ino, uxor
+                  Athamantis — post Nephelem, <supplied>quae</supplied> genuit Phrixum et Hellen —
+                  genuit Learchum et Melicertam. <milestone unit="par" n="45"/> Cadmo successit
+                  Lycus, cuius erat uxor Antiopa, Nyctei filia, cum qua
+                     <supplied>Iuppiter</supplied> concubuit in carcere in specie satyri
+                     <supplied>et</supplied> genuit Zethum et Amphionem. <milestone unit="par"
+                     n="46"/> Qui successit Ly<del>n</del>co et accepit Nioben, de qua genuit septem
+                  filios et totidem filias.</p>
                <p>
-                  <milestone unit="par" n="49"/> Item Adrastus genuit Argiam et Deip<del>h</del>yle<supplied>n</supplied>.</p>
+                  <milestone unit="par" n="47"/> Item Laius de Iocasta genuit Oedipum. <milestone
+                     unit="par" n="48"/>
+                  <supplied>O</supplied>edipus de Iocasta genuit Eteoclem et Polynicem, Ismenem et
+                  Antigonem.</p>
                <p>
-                  <milestone unit="par" n="50"/> Item Mars genuit Parthaonem. <milestone unit="par" n="51"/> Parthaon genuit Oeneum. <milestone unit="par" n="52"/> Thestius genuit Althaeam, Toxeum et P<del>h</del>lexippum. <milestone unit="par" n="53"/> Oeneus de Althaea genuit Meleagrum et Tydeum, Gorgen et Deianiram. <milestone unit="par" n="54"/> Meleager genuit Part<supplied>hen</supplied>opaeum. <milestone unit="par" n="55"/> Tydeus Tytidem, qui fuit dux in Troiano bello.</p>
+                  <milestone unit="par" n="49"/> Item Adrastus genuit Argiam et
+                     Deip<del>h</del>yle<supplied>n</supplied>.</p>
                <p>
-                  <milestone unit="par" n="56"/> Item Iuppiter de Latona, filia Coei, genuit Apollinem et Dianam. <milestone unit="par" n="57"/> Secundum quosdam Coeus fuit filius Titani, qui, concumbens cum Terra, genuit duodecim filios, qui insurrexere contra deos; Apollo uero et Diana, quia non consenserunt iniquitati eorum, caelestem meruere scandere currum.
-<milestone unit="par" n="58"/> Item Iuppiter concubuit cum Maia et genuit Mercurium.</p>
+                  <milestone unit="par" n="50"/> Item Mars genuit Parthaonem. <milestone unit="par"
+                     n="51"/> Parthaon genuit Oeneum. <milestone unit="par" n="52"/> Thestius genuit
+                  Althaeam, Toxeum et P<del>h</del>lexippum. <milestone unit="par" n="53"/> Oeneus
+                  de Althaea genuit Meleagrum et Tydeum, Gorgen et Deianiram. <milestone unit="par"
+                     n="54"/> Meleager genuit Part<supplied>hen</supplied>opaeum. <milestone
+                     unit="par" n="55"/> Tydeus Tytidem, qui fuit dux in Troiano bello.</p>
                <p>
-                  <milestone unit="par" n="59"/> Vulcanus de semine, seu femore, Iunonis. <milestone unit="par" n="60"/> Pallas, quae et Minerua, de cerebro Iouis. <milestone unit="par" n="61"/> Heben genuit Iuno de Ioue, secundum quosdam de lactuca.</p>
+                  <milestone unit="par" n="56"/> Item Iuppiter de Latona, filia Coei, genuit
+                  Apollinem et Dianam. <milestone unit="par" n="57"/> Secundum quosdam Coeus fuit
+                  filius Titani, qui, concumbens cum Terra, genuit duodecim filios, qui insurrexere
+                  contra deos; Apollo uero et Diana, quia non consenserunt iniquitati eorum,
+                  caelestem meruere scandere currum. <milestone unit="par" n="58"/> Item Iuppiter
+                  concubuit cum Maia et genuit Mercurium.</p>
                <p>
-                  <milestone unit="par" n="62"/> Item Venus de spuma testiculorum Saturni, a Ioue de regno expulsi.</p>
+                  <milestone unit="par" n="59"/> Vulcanus de semine, seu femore, Iunonis. <milestone
+                     unit="par" n="60"/> Pallas, quae et Minerua, de cerebro Iouis. <milestone
+                     unit="par" n="61"/> Heben genuit Iuno de Ioue, secundum quosdam de lactuca.</p>
                <p>
-                  <milestone unit="par" n="63"/> 
-                  <supplied>I</supplied>tem Iuppiter concubuit cum Dan<supplied>a</supplied>e, filia Acrisii, et genuit ex ea Perseum.</p>
+                  <milestone unit="par" n="62"/> Item Venus de spuma testiculorum Saturni, a Ioue de
+                  regno expulsi.</p>
                <p>
-                  <milestone unit="par" n="64"/> Item concubuit cum Leda, uxore Tyndari, in specie cygni; inde duo oua nata sunt, ex quorum altero Castor et Pollux, ex alio Clytemnestra et Helena natae sunt.</p>
+                  <milestone unit="par" n="63"/>
+                  <supplied>I</supplied>tem Iuppiter concubuit cum Dan<supplied>a</supplied>e, filia
+                  Acrisii, et genuit ex ea Perseum.</p>
+               <p>
+                  <milestone unit="par" n="64"/> Item concubuit cum Leda, uxore Tyndari, in specie
+                  cygni; inde duo oua nata sunt, ex quorum altero Castor et Pollux, ex alio
+                  Clytemnestra et Helena natae sunt.</p>
                <p>
                   <milestone unit="par" n="65"/> Item Lycurgus genuit Phyllidem et Archemorum.</p>
                <p>
-                  <milestone unit="par" n="66"/> 
-                  <supplied>I</supplied>tem Oeta de Hypsea genuit Chalciopen et Medeam et Absyrtum; unde: <hi rend="italic">non Hypsea pare<supplied>n</supplied>s Chalciopeque soror</hi>.</p>
+                  <milestone unit="par" n="66"/>
+                  <supplied>I</supplied>tem Oeta de Hypsea genuit Chalciopen et Medeam et Absyrtum;
+                  unde: <hi rend="italic">non Hypsea pare<supplied>n</supplied>s Chalciopeque
+                     soror</hi>.</p>
                <p>
-                  <milestone unit="par" n="67"/> Item Admetus de Alcesta genuit Nysam et Sthenoboeam; pro Nysa seruiuit ei Apollo septem annis. <milestone unit="par" n="68"/> Sthenoboeam accepit Proetus in uxorem.</p>
+                  <milestone unit="par" n="67"/> Item Admetus de Alcesta genuit Nysam et
+                  Sthenoboeam; pro Nysa seruiuit ei Apollo septem annis. <milestone unit="par"
+                     n="68"/> Sthenoboeam accepit Proetus in uxorem.</p>
                <p>
                   <milestone unit="par" n="69"/> Item Apollo de Coronide genuit Aesculapium.</p>
                <p>
-                  <milestone unit="par" n="70"/> Item secundum quosdam Apollo concubuit cum Ethea et genuit Circen. <milestone unit="par" n="71"/> Idem genuit Pasiph<supplied>a</supplied>en.</p>
+                  <milestone unit="par" n="70"/> Item secundum quosdam Apollo concubuit cum Ethea et
+                  genuit Circen. <milestone unit="par" n="71"/> Idem genuit
+                     Pasiph<supplied>a</supplied>en.</p>
                <p>
-                  <milestone unit="par" n="72"/> Item Iuppiter concubuit cum Europa, filia Agenoris, genuitque ex ea Minoa. <milestone unit="par" n="73"/> Pasiph<supplied>a</supplied>e de Tauro genuit Minotaurum. <milestone unit="par" n="74"/> Minos de Pasiph<supplied>a</supplied>e Phaedram, A<del>d</del>riadnem et Androgeum. <milestone unit="par" n="75"/> A<del>d</del>riadnem, in insula a Theseo relictam, accepit Bacchus genuitque ex ea Thoanta. <milestone unit="par" n="76"/> Thoas genuit Hypsipylen, quae habitabat in Lemno insula.</p>
+                  <milestone unit="par" n="72"/> Item Iuppiter concubuit cum Europa, filia Agenoris,
+                  genuitque ex ea Minoa. <milestone unit="par" n="73"/>
+                  Pasiph<supplied>a</supplied>e de Tauro genuit Minotaurum. <milestone unit="par"
+                     n="74"/> Minos de Pasiph<supplied>a</supplied>e Phaedram, A<del>d</del>riadnem
+                  et Androgeum. <milestone unit="par" n="75"/> A<del>d</del>riadnem, in insula a
+                  Theseo relictam, accepit Bacchus genuitque ex ea Thoanta. <milestone unit="par"
+                     n="76"/> Thoas genuit Hypsipylen, quae habitabat in Lemno insula.</p>
                <p>
-                  <milestone unit="par" n="77"/> Item La<del>c</del>ertes genuit Vlixem. <milestone unit="par" n="78"/> Vlixes de Penelope genuit Telemachum.</p>
+                  <milestone unit="par" n="77"/> Item La<del>c</del>ertes genuit Vlixem. <milestone
+                     unit="par" n="78"/> Vlixes de Penelope genuit Telemachum.</p>
                <p>
                   <milestone unit="par" n="79"/> Item Nauplius genuit Palamedem.</p>
                <p>
-                  <milestone unit="par" n="80"/> Item Teucontus genuit Telephum. <milestone unit="par" n="81"/> Antenor genuit Artilocum et Acamanta.</p>
+                  <milestone unit="par" n="80"/> Item Teucontus genuit Telephum. <milestone
+                     unit="par" n="81"/> Antenor genuit Artilocum et Acamanta.</p>
                <p>
-                  <milestone unit="par" n="82"/> Phoebus genuit Miletum. <milestone unit="par" n="83"/> Miletus de Cyane, filia Maeandri, genuit Caunum et Byblidem.</p>
+                  <milestone unit="par" n="82"/> Phoebus genuit Miletum. <milestone unit="par"
+                     n="83"/> Miletus de Cyane, filia Maeandri, genuit Caunum et Byblidem.</p>
                <p>
-                  <milestone unit="par" n="84"/> Erechtheus, rex Athenarum, qui successit Pandion<supplied>i</supplied>, patri <del>uxor</del> Philomelae <supplied>et</supplied> Prognes, uxoris Terei et matris Ity<supplied>o</supplied>s, genuit Procrin et Orithyiam. <milestone unit="par" n="85"/> Procrin habuit Cephalus, qui fuit de stirpe Aeoli. <milestone unit="par" n="86"/> Orithyiam rapuit Boreas et genuit ex ea Zetum et Calain. </p>
+                  <milestone unit="par" n="84"/> Erechtheus, rex Athenarum, qui successit
+                     Pandion<supplied>i</supplied>, patri <del>uxor</del> Philomelae
+                     <supplied>et</supplied> Prognes, uxoris Terei et matris
+                     Ity<supplied>o</supplied>s, genuit Procrin et Orithyiam. <milestone unit="par"
+                     n="85"/> Procrin habuit Cephalus, qui fuit de stirpe Aeoli. <milestone
+                     unit="par" n="86"/> Orithyiam rapuit Boreas et genuit ex ea Zetum et Calain.
+               </p>
             </div>
 
             <div type="cap" n="2">
                <head> Fabula de duplici nomine et casu Phlegyae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Phlegyae secundum Euphorionem populi insulani fuerunt satis in deos impii et sacrilegi; unde iratus Neptunus percussit tridenti eam panem insulae, quam Phlegyae tenebant, et eos obruit.</p>
                <p>
-                  <milestone unit="par" n="2"/> P<supplied>h</supplied>legyas autem, Ixionis pater, habuit filiam Coronidem, quam Apollo uitiauit, unde suscepit Aesculapium. <milestone unit="par" n="3"/> Quod pater dolens incendit templum Apollinis et eius sagittis est ad inferos trusus. <milestone unit="par" n="4"/> Vnde Statius: <hi rend="italic">P<supplied>h</supplied>legyam subter caua saxa iacentem aeterno premit accubitu</hi>.</p>
+                  <milestone unit="par" n="1"/> Phlegyae secundum Euphorionem populi insulani
+                  fuerunt satis in deos impii et sacrilegi; unde iratus Neptunus percussit tridenti
+                  eam panem insulae, quam Phlegyae tenebant, et eos obruit.</p>
                <p>
-                  <milestone unit="par" n="5"/> «Discite iustitiam!»: uel nunc in poenis locati. </p>
+                  <milestone unit="par" n="2"/> P<supplied>h</supplied>legyas autem, Ixionis pater,
+                  habuit filiam Coronidem, quam Apollo uitiauit, unde suscepit Aesculapium.
+                     <milestone unit="par" n="3"/> Quod pater dolens incendit templum Apollinis et
+                  eius sagittis est ad inferos trusus. <milestone unit="par" n="4"/> Vnde Statius:
+                     <hi rend="italic">P<supplied>h</supplied>legyam subter caua saxa iacentem
+                     aeterno premit accubitu</hi>.</p>
+               <p>
+                  <milestone unit="par" n="5"/> «Discite iustitiam!»: uel nunc in poenis locati.
+               </p>
             </div>
 
             <div type="cap" n="3">
                <head> Historia de Laconum filiis incertis parentibus natis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lacones, diu bello attriti ab Atheniensibus et inopiam timentes uirorum, praeceperunt ut uirgines cum quibuscumque concumberent. <milestone unit="par" n="2"/> Quo facto, dum post uictoriam iuuenes parentibus nati incertis erubescerent originem suam — nam et Partheniatae appellabantur —, duce Phalantho, octauo ab Hercule, nauigiis uenerunt ad oppidum Calabriae, quod Taras, Neptuni filius, condiderat, et id auctum habitauerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lacones, diu bello attriti ab Atheniensibus et
+                  inopiam timentes uirorum, praeceperunt ut uirgines cum quibuscumque concumberent.
+                     <milestone unit="par" n="2"/> Quo facto, dum post uictoriam iuuenes parentibus
+                  nati incertis erubescerent originem suam — nam et Partheniatae appellabantur —,
+                  duce Phalantho, octauo ab Hercule, nauigiis uenerunt ad oppidum Calabriae, quod
+                  Taras, Neptuni filius, condiderat, et id auctum habitauerunt. </p>
             </div>
 
             <div type="cap" n="4">
                <head> Fabula Iouis et Thetidis et Achillis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Cum Iuppiter Thetidem ducere uellet, fata prohibuerunt, eo quod proles, quae nasceretur, Iouem pelleret regno, sicut ipse Saturnum expulerat. <milestone unit="par" n="2"/> Thetis dea Peleo mortali homini nupsit; ex quo genuit Achillem. <milestone unit="par" n="3"/> De cuius morte timens a Neptuno frustra consolatur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Cum Iuppiter Thetidem ducere uellet, fata
+                  prohibuerunt, eo quod proles, quae nasceretur, Iouem pelleret regno, sicut ipse
+                  Saturnum expulerat. <milestone unit="par" n="2"/> Thetis dea Peleo mortali homini
+                  nupsit; ex quo genuit Achillem. <milestone unit="par" n="3"/> De cuius morte
+                  timens a Neptuno frustra consolatur. </p>
             </div>
 
             <div type="cap" n="5">
                <head> De nuptiis Pelei et Thetidis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> 
-                  <supplied>P</supplied>eleus, Aeaci uel Acei filius, <del>cum</del> Thetidem, Nerei et Doridis nimphae filiam, in matrimonium accepit omnibus diis ad nuptias inuitatis praeter Discordiam. <milestone unit="par" n="2"/> Quae irata malum aureum in conuiuium iecit, inscriptum «pulcherrimae deae donum»; quo collecto inter Iunonem et Mineruam et Venerem certamen est ortum, quae Iouem iudicem petierunt. <milestone unit="par" n="3"/> Ille, ne uxorem aut filias offenderet, ad Paridem Alexandrum, filium Priami et Hecubae — qui numquam dicebatur personam accepisse in iudicio — in Ida, monte Phrygiae, pecora pascentem eas misit. <milestone unit="par" n="4"/> Cui cum Iuno regnum Asiae, Minerua omnium artium scientiam, Venus quamcumque uellet mulierem promitterent, Venerem illo malo dignissimam <supplied>iudicauit</supplied>. <milestone unit="par" n="5"/> Quo facto Iuno et Minerua Troianis dicuntur iratae, spretae iniuria formae. </p>
+               <p>
+                  <milestone unit="par" n="1"/>
+                  <supplied>P</supplied>eleus, Aeaci uel Acei filius, <del>cum</del> Thetidem, Nerei
+                  et Doridis nimphae filiam, in matrimonium accepit omnibus diis ad nuptias
+                  inuitatis praeter Discordiam. <milestone unit="par" n="2"/> Quae irata malum
+                  aureum in conuiuium iecit, inscriptum «pulcherrimae deae donum»; quo collecto
+                  inter Iunonem et Mineruam et Venerem certamen est ortum, quae Iouem iudicem
+                  petierunt. <milestone unit="par" n="3"/> Ille, ne uxorem aut filias offenderet, ad
+                  Paridem Alexandrum, filium Priami et Hecubae — qui numquam dicebatur personam
+                  accepisse in iudicio — in Ida, monte Phrygiae, pecora pascentem eas misit.
+                     <milestone unit="par" n="4"/> Cui cum Iuno regnum Asiae, Minerua omnium artium
+                  scientiam, Venus quamcumque uellet mulierem promitterent, Venerem illo malo
+                  dignissimam <supplied>iudicauit</supplied>. <milestone unit="par" n="5"/> Quo
+                  facto Iuno et Minerua Troianis dicuntur iratae, spretae iniuria formae. </p>
             </div>
 
             <div type="cap" n="6-7">
                <head> Fabula de Achille et Agamemnone et mortis Hectoris.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Achilles, Thetidis et Pelei filius, cum quinquaginta nauibus de Larissa ciuitate Agamemnoni et Menelao Atridis auxilium aduersus Troianos tulit. <milestone unit="par" n="2"/> Et cum plerasque per indutias Agamemnon cum exercitu suo armis loca obsederat, Achilles finitimas urbes cum suis Myrmidonibus expugnauit, inter quas Thebas et Larnesum, et pulcherrimas duas Pressidem et Gressidam adiungit sibi. <milestone unit="par" n="3"/> Interea pestilentia Graecorum exercitum inuasit; et m<supplied>onitis</supplied> Calchantis Agamemnon uictus Gressidam patri Heresi, sacerdoti Apollinis, reddidit dicens Achillem id facere debere. <milestone unit="par" n="4"/> Ac propter hoc inter eos <supplied>lis fuit</supplied> usque quo in caedem mutuam uterque exarsit exercitus, ut uix Minerua eorum contentionem sedaret.</p>
                <p>
-                  <milestone unit="par" n="5"/> Post hoc Achilles Troianis feliciter pugnantibus aliquandiu non repugnauit. <milestone unit="par" n="6"/> Ad extremum, uero, cum Hector uictis Graecis etiam naues eorum incenderet et in ipsis castris pugnaret, Patroclus, armiger Achillis, cum armis eius procedens ad pugnam, ab Hectore occisus est armis ablatis. <milestone unit="par" n="7"/> Quo dolore ille incitatus cum uellet pugnare et arma non haberet, a matre Thetide Vulcani arma accepit. <milestone unit="par" n="8"/> Quibus indutus cum se pugnae restituisset et plurimos Troianos occidisset, cum ipso Hectore singulari certamine congressus est. <milestone unit="par" n="9"/> Quem occisum spoliauit armis eiusque corpus currui subligatum circumferri fecit; quod Priamus auro compensatum ad humandum redemit, inermis egressus. </p>
+                  <milestone unit="par" n="1"/> Achilles, Thetidis et Pelei filius, cum quinquaginta
+                  nauibus de Larissa ciuitate Agamemnoni et Menelao Atridis auxilium aduersus
+                  Troianos tulit. <milestone unit="par" n="2"/> Et cum plerasque per indutias
+                  Agamemnon cum exercitu suo armis loca obsederat, Achilles finitimas urbes cum suis
+                  Myrmidonibus expugnauit, inter quas Thebas et Larnesum, et pulcherrimas duas
+                  Pressidem et Gressidam adiungit sibi. <milestone unit="par" n="3"/> Interea
+                  pestilentia Graecorum exercitum inuasit; et m<supplied>onitis</supplied>
+                  Calchantis Agamemnon uictus Gressidam patri Heresi, sacerdoti Apollinis, reddidit
+                  dicens Achillem id facere debere. <milestone unit="par" n="4"/> Ac propter hoc
+                  inter eos <supplied>lis fuit</supplied> usque quo in caedem mutuam uterque exarsit
+                  exercitus, ut uix Minerua eorum contentionem sedaret.</p>
+               <p>
+                  <milestone unit="par" n="5"/> Post hoc Achilles Troianis feliciter pugnantibus
+                  aliquandiu non repugnauit. <milestone unit="par" n="6"/> Ad extremum, uero, cum
+                  Hector uictis Graecis etiam naues eorum incenderet et in ipsis castris pugnaret,
+                  Patroclus, armiger Achillis, cum armis eius procedens ad pugnam, ab Hectore
+                  occisus est armis ablatis. <milestone unit="par" n="7"/> Quo dolore ille incitatus
+                  cum uellet pugnare et arma non haberet, a matre Thetide Vulcani arma accepit.
+                     <milestone unit="par" n="8"/> Quibus indutus cum se pugnae restituisset et
+                  plurimos Troianos occidisset, cum ipso Hectore singulari certamine congressus est.
+                     <milestone unit="par" n="9"/> Quem occisum spoliauit armis eiusque corpus
+                  currui subligatum circumferri fecit; quod Priamus auro compensatum ad humandum
+                  redemit, inermis egressus. </p>
             </div>
 
             <div type="cap" n="8">
                <head> De Troili casu.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Troilu<supplied>s</supplied>, Priami et Hecubae filius, cum equos extra muros exerceret, ab Achille per insidias uulneratur; exanimis in urbem equis religatu<supplied>s refertu</supplied>r. <milestone unit="par" n="2"/> Cui dictum erat quod, si ad annos uiginti peruenisset, Troia euerti non potuisset. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Troilu<supplied>s</supplied>, Priami et Hecubae
+                  filius, cum equos extra muros exerceret, ab Achille per insidias uulneratur;
+                  exanimis in urbem equis religatu<supplied>s refertu</supplied>r. <milestone
+                     unit="par" n="2"/> Cui dictum erat quod, si ad annos uiginti peruenisset, Troia
+                  euerti non potuisset. </p>
             </div>
 
             <div type="cap" n="9">
                <head> De uictoria Hectoris et fuga Palamedis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Achilles noluit expugnare Troiam, quia corruptus erat a Priamo rege promittente sibi filiam suam Polyxenam dare in coniugium. <milestone unit="par" n="2"/> Alio die uenit Diomedes, filius Tydei, et rogauit eum ut in aciem transisset; Achilles autem negabat. <milestone unit="par" n="3"/> Palamedes autem rogauit eum ut currum atque equos suos et habitum suum donaret sibi; Achilles autem donauit. <milestone unit="par" n="4"/> Postquam acies directa fuit ab Hectore, ipse Hector abstulit habitum, currum et equos; inde dicit poeta <hi rend="italic">indutus exuuias</hi>. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Achilles noluit expugnare Troiam, quia corruptus
+                  erat a Priamo rege promittente sibi filiam suam Polyxenam dare in coniugium.
+                     <milestone unit="par" n="2"/> Alio die uenit Diomedes, filius Tydei, et rogauit
+                  eum ut in aciem transisset; Achilles autem negabat. <milestone unit="par" n="3"/>
+                  Palamedes autem rogauit eum ut currum atque equos suos et habitum suum donaret
+                  sibi; Achilles autem donauit. <milestone unit="par" n="4"/> Postquam acies directa
+                  fuit ab Hectore, ipse Hector abstulit habitum, currum et equos; inde dicit poeta
+                     <hi rend="italic">indutus exuuias</hi>. </p>
             </div>
 
             <div type="cap" n="10">
                <head> Historia de Priami filio occiso a patre.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Priamus ex Arisba filium uatem suscepit; qui cum dixisset quadam nocte nasci puerum, per quem Troia posset euerti, contigit ut simul parerent et Thymo<supplied>e</supplied>tae uxor et Hecuba, quae Priami legitima erat. <milestone unit="par" n="2"/> Sed Priamus Thymo<supplied>e</supplied>tae filium uxoremque iussit occidere. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Priamus ex Arisba filium uatem suscepit; qui cum
+                  dixisset quadam nocte nasci puerum, per quem Troia posset euerti, contigit ut
+                  simul parerent et Thymo<supplied>e</supplied>tae uxor et Hecuba, quae Priami
+                  legitima erat. <milestone unit="par" n="2"/> Sed Priamus
+                     Thymo<supplied>e</supplied>tae filium uxoremque iussit occidere. </p>
             </div>
 
             <div type="cap" n="11">
                <head> De morte Priami uaria opinio.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> De morte Priami uarie lectum est. <milestone unit="par" n="2"/> Alii dicunt, quod a Pyrrho in domo quidem sua captus est; sed ad tumulum Achillis tractus occisusque est iuxta Sigeum promunctorium — nam in <supplied>Rhoeteo Aiax</supplied> sepultus est —; tunc eius caput conto fixum circumtulit. <milestone unit="par" n="3"/> Alii uero dicunt, quod iuxta Hercei Iouis aram extinctus est; unde Lucanus: <hi rend="italic">Herceas — monstrator ait — non respicis aras?</hi> 
-                  <milestone unit="par" n="4"/> Et hanc opinionem plene Virgilius sequitur; licet etiam illam praescriptam praelibet. </p>
+               <p>
+                  <milestone unit="par" n="1"/> De morte Priami uarie lectum est. <milestone
+                     unit="par" n="2"/> Alii dicunt, quod a Pyrrho in domo quidem sua captus est;
+                  sed ad tumulum Achillis tractus occisusque est iuxta Sigeum promunctorium — nam in
+                     <supplied>Rhoeteo Aiax</supplied> sepultus est —; tunc eius caput conto fixum
+                  circumtulit. <milestone unit="par" n="3"/> Alii uero dicunt, quod iuxta Hercei
+                  Iouis aram extinctus est; unde Lucanus: <hi rend="italic">Herceas — monstrator ait
+                     — non respicis aras?</hi>
+                  <milestone unit="par" n="4"/> Et hanc opinionem plene Virgilius sequitur; licet
+                  etiam illam praescriptam praelibet. </p>
             </div>
 
             <div type="cap" n="12-13">
                <head> Fabula Didonis et historia <supplied>S</supplied>aturni.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Dido, Metonis filia, quem Virgilius Belum nominat, interfecto Acerbo, coniuge suo, quem Virgilius Sychaeum nominat, a Pygmalione, rege fratreque suo, per fugam elapsa naues ascendit cum magno pondere auri et <supplied>ad</supplied> Africae litora peruenit. <milestone unit="par" n="2"/> Ibi ab Iarba rege Maurorum tantum soli emit, quantum corio bouis posset metiri uel occupare, et fraude urbem uindicauit. <milestone unit="par" n="3"/> Nam corium in tenuissimas corrigias sectum tetendit occupauitque stadia uiginti duo. <milestone unit="par" n="4"/> Ob factum Byssam, postea Carthaginem, uocauit.</p>
                <p>
-                  <milestone unit="par" n="5"/> 
-                  <supplied>S</supplied>aturnus, amissa possessione caeli, cum per totum orbem profugus erraret Iunone sociata, <del>et</del> ne longo taedio lassaret uiae, eam nymphis Africae commendauit alendam. <milestone unit="par" n="6"/> Ergo Carthaginem magnam Iuno semper <supplied>esse uoluit et arma currumque</supplied> ibi habuit. </p>
+                  <milestone unit="par" n="1"/> Dido, Metonis filia, quem Virgilius Belum nominat,
+                  interfecto Acerbo, coniuge suo, quem Virgilius Sychaeum nominat, a Pygmalione,
+                  rege fratreque suo, per fugam elapsa naues ascendit cum magno pondere auri et
+                     <supplied>ad</supplied> Africae litora peruenit. <milestone unit="par" n="2"/>
+                  Ibi ab Iarba rege Maurorum tantum soli emit, quantum corio bouis posset metiri uel
+                  occupare, et fraude urbem uindicauit. <milestone unit="par" n="3"/> Nam corium in
+                  tenuissimas corrigias sectum tetendit occupauitque stadia uiginti duo. <milestone
+                     unit="par" n="4"/> Ob factum Byssam, postea Carthaginem, uocauit.</p>
+               <p>
+                  <milestone unit="par" n="5"/>
+                  <supplied>S</supplied>aturnus, amissa possessione caeli, cum per totum orbem
+                  profugus erraret Iunone sociata, <del>et</del> ne longo taedio lassaret uiae, eam
+                  nymphis Africae commendauit alendam. <milestone unit="par" n="6"/> Ergo
+                  Carthaginem magnam Iuno semper <supplied>esse uoluit et arma currumque</supplied>
+                  ibi habuit. </p>
             </div>
 
             <div type="cap" n="14">
                <head> Item de Didone et condita Carthagine.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Dido cum pertransiret quandam insulam Iunonis, illic accepit oraculum et sacerdotem eius secum abstulit, cum ei parum crederet promittenti sedes Carthaginis. <milestone unit="par" n="2"/> Quo cum uenisset, sacerdos elegit locum faciendae urbi; quo effosso, inuentum est caput bouis. <milestone unit="par" n="3"/> Quod cum displicuisset, quia bos semper subiugatur, alio loco effosso caput equi inuentum est; et placuit, quia hoc animal, licet subiugetur, bellicosum tamen est et uincit et plerumque concordat. <milestone unit="par" n="4"/> Illic ergo Iunoni templa fecerunt; unde et bellicosa est Carthago per equi omen et fertilis per bouis. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Dido cum pertransiret quandam insulam Iunonis, illic
+                  accepit oraculum et sacerdotem eius secum abstulit, cum ei parum crederet
+                  promittenti sedes Carthaginis. <milestone unit="par" n="2"/> Quo cum uenisset,
+                  sacerdos elegit locum faciendae urbi; quo effosso, inuentum est caput bouis.
+                     <milestone unit="par" n="3"/> Quod cum displicuisset, quia bos semper
+                  subiugatur, alio loco effosso caput equi inuentum est; et placuit, quia hoc
+                  animal, licet subiugetur, bellicosum tamen est et uincit et plerumque concordat.
+                     <milestone unit="par" n="4"/> Illic ergo Iunoni templa fecerunt; unde et
+                  bellicosa est Carthago per equi omen et fertilis per bouis. </p>
             </div>
 
             <div type="cap" n="15">
                <head> De Anchise et Venere.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Sciendum Anchisen pastorem fuisse et cum eo amato Venerem concubuisse, unde Aeneas circa Simoin, fluuium Troiae, natus est; deae enim uel nymphae enituntur circa fluuios uel nemora. <milestone unit="par" n="2"/> Quod cum iactaret Anchises, afflatus est fulmine oculoque priuatus. <milestone unit="par" n="3"/> Monoculus enim erat. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Sciendum Anchisen pastorem fuisse et cum eo amato
+                  Venerem concubuisse, unde Aeneas circa Simoin, fluuium Troiae, natus est; deae
+                  enim uel nymphae enituntur circa fluuios uel nemora. <milestone unit="par" n="2"/>
+                  Quod cum iactaret Anchises, afflatus est fulmine oculoque priuatus. <milestone
+                     unit="par" n="3"/> Monoculus enim erat. </p>
             </div>
 
             <div type="cap" n="16">
                <head> Historia Dionysii tyranni.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Dionysius quidam tyrannus Siciliam totam fraude et dolo inuasit et spoliauit penitus, adeo ut etiam simulacra et templa deorum deuastaret. <milestone unit="par" n="2"/> Barba<supplied>m</supplied> etiam barbati Iouis abstulit et simulacrum eius uestibus pretiosissimis indutum spoliauit suisque induit, dicens non debere numen in tam rigidis uestibus frigere. <milestone unit="par" n="3"/> Quadam autem die amicorum suorum que<supplied>m</supplied>dam interrogauit, dicens si esset felix; qui ait: «Quidni?». <milestone unit="par" n="4"/> Ille iussit illum residere in solio suo indutum uestibus regiis et tenentem sceptrum illius ac deinde gladium acutissimum, tenuissimo filo ligatum, super uerticem eius suspendi et interrogauit eum, si uideretur sibi esse beatus. <milestone unit="par" n="5"/> Qui respondit nullo modo se esse beatum, qui aestimaret se casu gladii cito moriturum. <milestone unit="par" n="6"/> Cui Dionysius: «Qualem tu — induit — nunc habes timorem, talem ego assidue patior!». </p>
+               <p>
+                  <milestone unit="par" n="1"/> Dionysius quidam tyrannus Siciliam totam fraude et
+                  dolo inuasit et spoliauit penitus, adeo ut etiam simulacra et templa deorum
+                  deuastaret. <milestone unit="par" n="2"/> Barba<supplied>m</supplied> etiam
+                  barbati Iouis abstulit et simulacrum eius uestibus pretiosissimis indutum
+                  spoliauit suisque induit, dicens non debere numen in tam rigidis uestibus frigere.
+                     <milestone unit="par" n="3"/> Quadam autem die amicorum suorum
+                     que<supplied>m</supplied>dam interrogauit, dicens si esset felix; qui ait:
+                  «Quidni?». <milestone unit="par" n="4"/> Ille iussit illum residere in solio suo
+                  indutum uestibus regiis et tenentem sceptrum illius ac deinde gladium acutissimum,
+                  tenuissimo filo ligatum, super uerticem eius suspendi et interrogauit eum, si
+                  uideretur sibi esse beatus. <milestone unit="par" n="5"/> Qui respondit nullo modo
+                  se esse beatum, qui aestimaret se casu gladii cito moriturum. <milestone
+                     unit="par" n="6"/> Cui Dionysius: «Qualem tu — induit — nunc habes timorem,
+                  talem ego assidue patior!». </p>
             </div>
 
             <div type="cap" n="17">
                <head> Historia Reguli consulis Romanorum.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Regulus consul Romanorum fuit, qui multos Afrorum bello cepit ac uinculis tradidit. <milestone unit="par" n="2"/> Hic aliquando contra eos bellum agens captus est et uinculis mancipatus; quem Romani non parui pendentes dederunt obsides eumque a uinculis soluerunt. <milestone unit="par" n="3"/> Cum uenisset in senatum uxorque cum filiis eum osculari uellent, respondit non debere captiuum a nobili persona osculari. <milestone unit="par" n="4"/> Deinde cum pretio illum redimere uoluissent, summopere interdixit, dicens se nullo modo rei militari digne posse inseruire. <milestone unit="par" n="5"/> Sicque, ut Orosius dicit, redditus est propria uoluntate hostibus et in uincula coniectus excisis palpebris oculorum insomnis periit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Regulus consul Romanorum fuit, qui multos Afrorum
+                  bello cepit ac uinculis tradidit. <milestone unit="par" n="2"/> Hic aliquando
+                  contra eos bellum agens captus est et uinculis mancipatus; quem Romani non parui
+                  pendentes dederunt obsides eumque a uinculis soluerunt. <milestone unit="par"
+                     n="3"/> Cum uenisset in senatum uxorque cum filiis eum osculari uellent,
+                  respondit non debere captiuum a nobili persona osculari. <milestone unit="par"
+                     n="4"/> Deinde cum pretio illum redimere uoluissent, summopere interdixit,
+                  dicens se nullo modo rei militari digne posse inseruire. <milestone unit="par"
+                     n="5"/> Sicque, ut Orosius dicit, redditus est propria uoluntate hostibus et in
+                  uincula coniectus excisis palpebris oculorum insomnis periit. </p>
             </div>
 
             <div type="cap" n="18">
                <head> Historia de uictoria Torquati et parricidio.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Lucius Manlius Torquatus Gallum quendam singulari certamine superauit et eius sibi torquem inposuit, unde nomen accepit. <milestone unit="par" n="2"/> Hic ad urbem pergens, praecepit filio ut tantum castra tueretur; ille nacta occasione bellum aggressus uictoriam consecutus est. <milestone unit="par" n="3"/> Reuersus postea pater laudauit fortunam populi Romani, sed filium, ut dicit Liuius, fustuario necauit propter inoboedientiam. <milestone unit="par" n="4"/> Ergo <hi rend="italic">saeuum securi</hi>, saeuum iure occidendi, non ferri genere; nam securi non animaduertit in filium. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Lucius Manlius Torquatus Gallum quendam singulari
+                  certamine superauit et eius sibi torquem inposuit, unde nomen accepit. <milestone
+                     unit="par" n="2"/> Hic ad urbem pergens, praecepit filio ut tantum castra
+                  tueretur; ille nacta occasione bellum aggressus uictoriam consecutus est.
+                     <milestone unit="par" n="3"/> Reuersus postea pater laudauit fortunam populi
+                  Romani, sed filium, ut dicit Liuius, fustuario necauit propter inoboedientiam.
+                     <milestone unit="par" n="4"/> Ergo <hi rend="italic">saeuum securi</hi>, saeuum
+                  iure occidendi, non ferri genere; nam securi non animaduertit in filium. </p>
             </div>
 
             <div type="cap" n="19">
                <head> Historia de Camilli uictoria.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Brenno duce Galli apud Alliam fluuium deletis legionibus subuerterunt urbem Romam absque Capitolio, pro quo immensam pecuniam acceperunt. <milestone unit="par" n="2"/> Tunc Camillus absens dictator est factus, cum esset apud Ardeam in exilio propter Veientanam praedam non aequo iure diuisam, et Gallos iam abeuntes secutus est. <milestone unit="par" n="3"/> Quibus interemptis aurum recepit et signa, quod cum illic appendisset, ciuitati nomen dedit; nam Pinsaurum dicitur, quod illic aurum pensatum est. <milestone unit="par" n="4"/> Post hoc tamen factum rediit in exilium, unde rogatus reuersus est. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Brenno duce Galli apud Alliam fluuium deletis
+                  legionibus subuerterunt urbem Romam absque Capitolio, pro quo immensam pecuniam
+                  acceperunt. <milestone unit="par" n="2"/> Tunc Camillus absens dictator est
+                  factus, cum esset apud Ardeam in exilio propter Veientanam praedam non aequo iure
+                  diuisam, et Gallos iam abeuntes secutus est. <milestone unit="par" n="3"/> Quibus
+                  interemptis aurum recepit et signa, quod cum illic appendisset, ciuitati nomen
+                  dedit; nam Pinsaurum dicitur, quod illic aurum pensatum est. <milestone unit="par"
+                     n="4"/> Post hoc tamen factum rediit in exilium, unde rogatus reuersus est.
+               </p>
             </div>
 
             <div type="cap" n="20">
                <head> De septem ciuilibus bellis Romanis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> A Caesare consuetudinem fecit populus Romanus bellorum ciuilium; septies enim gesta sunt. <milestone unit="par" n="2"/> Ter a Caesare: primo contra Pompeium in Thessalia; secundo contra eius filium Magnum in Hispania; item contra Iubam et Catonem in Africa. <milestone unit="par" n="3"/> Mortuo Caesare ab Augusto Octauiano contra Cass<supplied>i</supplied>um et Brutum in Philippis ciuitate Thessaliae; et item contra Lucium Antonium in Perusia Tusciae ciuitate; sexto con<supplied>tra</supplied> Sextum Pompeium in Sicilia; septimo contra Marcum Antonium et Cleopatram in Epiro. </p>
+               <p>
+                  <milestone unit="par" n="1"/> A Caesare consuetudinem fecit populus Romanus
+                  bellorum ciuilium; septies enim gesta sunt. <milestone unit="par" n="2"/> Ter a
+                  Caesare: primo contra Pompeium in Thessalia; secundo contra eius filium Magnum in
+                  Hispania; item contra Iubam et Catonem in Africa. <milestone unit="par" n="3"/>
+                  Mortuo Caesare ab Augusto Octauiano contra Cass<supplied>i</supplied>um et Brutum
+                  in Philippis ciuitate Thessaliae; et item contra Lucium Antonium in Perusia
+                  Tusciae ciuitate; sexto con<supplied>tra</supplied> Sextum Pompeium in Sicilia;
+                  septimo contra Marcum Antonium et Cleopatram in Epiro. </p>
             </div>
 
             <div type="cap" n="21">
                <head> Historia de Atilii fortuna.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Atilius quidam senator fuit, qui cum agrum suum coleret euocatus propter uirtutem meruit dictaturam; Serranus autem a serendo dictus est. <milestone unit="par" n="2"/> Hic etiam Quintius Cincinnatus est appellatus. <milestone unit="par" n="3"/> Denique idem caesis hostibus uictor effectus subactos hostes primus prae se egit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Atilius quidam senator fuit, qui cum agrum suum
+                  coleret euocatus propter uirtutem meruit dictaturam; Serranus autem a serendo
+                  dictus est. <milestone unit="par" n="2"/> Hic etiam Quintius Cincinnatus est
+                  appellatus. <milestone unit="par" n="3"/> Denique idem caesis hostibus uictor
+                  effectus subactos hostes primus prae se egit. </p>
             </div>
 
             <div type="cap" n="22">
                <head> De trecentis Fabiis occisis et uno superstite.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Trecenti et sex fuerunt de una familia Fabiorum, qui cum coniurati cum seruis et clientibus suis contra Vihientes dimicarent, insidiis apud Cremeram fluuium interempti sunt. <milestone unit="par" n="2"/> Vnus tantum superstes fuit Fabius Maximus, qui propter teneram adhuc pueritiam in ciuitate remanserat. <milestone unit="par" n="3"/> Hic postea cum Hannibalis inpetum ferre non posset, mora eum elusit et ad Campaniam traxit, ubi deliciis eius uirtus obtorpuit. <milestone unit="par" n="4"/> Ille est, de quo ait Ennius: <hi rend="italic">unus qui nobis cunctando restituit rem</hi>. <milestone unit="par" n="5"/> Sciens enim Virgilius quasi pro exemplo hunc uersum posuit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Trecenti et sex fuerunt de una familia Fabiorum, qui
+                  cum coniurati cum seruis et clientibus suis contra Vihientes dimicarent, insidiis
+                  apud Cremeram fluuium interempti sunt. <milestone unit="par" n="2"/> Vnus tantum
+                  superstes fuit Fabius Maximus, qui propter teneram adhuc pueritiam in ciuitate
+                  remanserat. <milestone unit="par" n="3"/> Hic postea cum Hannibalis inpetum ferre
+                  non posset, mora eum elusit et ad Campaniam traxit, ubi deliciis eius uirtus
+                  obtorpuit. <milestone unit="par" n="4"/> Ille est, de quo ait Ennius: <hi
+                     rend="italic">unus qui nobis cunctando restituit rem</hi>. <milestone
+                     unit="par" n="5"/> Sciens enim Virgilius quasi pro exemplo hunc uersum posuit.
+               </p>
             </div>
 
             <div type="cap" n="23">
                <head> De Marcelli uictoria.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Marcellus Gallos et Poenos equestri certamine superauit. <milestone unit="par" n="2"/> Viridomorum etiam Gallorum ducem manu propria interemit et opima retulit spolia, quae dux detraxerat duci, sicut Cossus Larti Tolumnio. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Marcellus Gallos et Poenos equestri certamine
+                  superauit. <milestone unit="par" n="2"/> Viridomorum etiam Gallorum ducem manu
+                  propria interemit et opima retulit spolia, quae dux detraxerat duci, sicut Cossus
+                  Larti Tolumnio. </p>
             </div>
 
             <div type="cap" n="24">
                <head> De laudibus et morte alterius Marcelli.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Tria secundum carmina Virgilii in iuuentute spectantur: pulchritudo, aetas, uirtus. <milestone unit="par" n="2"/> Significat autem Virgilius Marcellum, filium Octauiae sororis Augusti, quem sibi Augustus adoptauit. <milestone unit="par" n="3"/> Hic sexto decimo anno incidit <supplied>in</supplied> ualetudinem et periit octauo decimo in Baiano et cum aedilitatem gereret. <milestone unit="par" n="4"/> Huius mortem uehementer ciuitas doluit; nam et affabilis fuit et Augusti filius. <milestone unit="par" n="5"/> Ad funeris huius honorem Augustus sescentos electos ire intra ciuitatem iussit — hoc enim apud maiores gloriosum fuerat et dabatur pro qualitate fortunae; nam Sylla sex milia habuit —; igitur cum ingenti pompa allatus et in Campo Martio est sepultus. <milestone unit="par" n="6"/> Ergo in Augusti adulationem quasi epitaphium dicit Virgilius. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Tria secundum carmina Virgilii in iuuentute
+                  spectantur: pulchritudo, aetas, uirtus. <milestone unit="par" n="2"/> Significat
+                  autem Virgilius Marcellum, filium Octauiae sororis Augusti, quem sibi Augustus
+                  adoptauit. <milestone unit="par" n="3"/> Hic sexto decimo anno incidit
+                     <supplied>in</supplied> ualetudinem et periit octauo decimo in Baiano et cum
+                  aedilitatem gereret. <milestone unit="par" n="4"/> Huius mortem uehementer ciuitas
+                  doluit; nam et affabilis fuit et Augusti filius. <milestone unit="par" n="5"/> Ad
+                  funeris huius honorem Augustus sescentos electos ire intra ciuitatem iussit — hoc
+                  enim apud maiores gloriosum fuerat et dabatur pro qualitate fortunae; nam Sylla
+                  sex milia habuit —; igitur cum ingenti pompa allatus et in Campo Martio est
+                  sepultus. <milestone unit="par" n="6"/> Ergo in Augusti adulationem quasi
+                  epitaphium dicit Virgilius. </p>
             </div>
 
             <div type="cap" n="25">
                <head> De deo Fatuo et dea Fatua.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Quidam deus Fatuus; huius uxor Fatua; idem Faunus et eadem Fauna. <milestone unit="par" n="2"/> Dicti sunt autem Faunus et Fauna a uaticinando, unde et fatuos dicimus inconsiderate loquentes. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Quidam deus Fatuus; huius uxor Fatua; idem Faunus et
+                  eadem Fauna. <milestone unit="par" n="2"/> Dicti sunt autem Faunus et Fauna a
+                  uaticinando, unde et fatuos dicimus inconsiderate loquentes. </p>
             </div>
 
             <div type="cap" n="26">
-               <head> 
+               <head>
                   <supplied>De portis somniorum</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Physiologia uero hoc habet, quod per portam corneam oculi significantur, qui et cornei sunt coloris et duriores ceteris membris; nam frigus non sentiunt. <milestone unit="par" n="2"/> Per eburneam uero portam os designatur a dentibus; unde et Aeneas per eburneam emittitur portam. <milestone unit="par" n="3"/> Vel dicitur eburnea quasi ornatior porta, id est ea quae supra fortunam sunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Physiologia uero hoc habet, quod per portam corneam
+                  oculi significantur, qui et cornei sunt coloris et duriores ceteris membris; nam
+                  frigus non sentiunt. <milestone unit="par" n="2"/> Per eburneam uero portam os
+                  designatur a dentibus; unde et Aeneas per eburneam emittitur portam. <milestone
+                     unit="par" n="3"/> Vel dicitur eburnea quasi ornatior porta, id est ea quae
+                  supra fortunam sunt. </p>
             </div>
 
             <div type="cap" n="27">
                <head> Fabula Endymionis et Lunae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Endymion pastor amasse dicitur Lunam seu Dianam; qui spretus pauit pecora candidissima et sic eam in suos illexit amplexus; cuius rei misticam quandam uolunt rationem. <milestone unit="par" n="2"/> Duplo quippe modo amasse dicitur Lunam. <milestone unit="par" n="3"/> Seu quod primus hominum cursum lunae inuenerit, unde et triginta annis dormisse dicitur, quia nihil aliud in uita sua nisi huic repertioni studuit. <milestone unit="par" n="4"/> Siue quod nocturni roris humor, quem tam siderum quam ipsius lunae uapores a<supplied>ni</supplied>mandis herbarum sucis insudant, pastoralibus prosi<del>n</del>t successibus. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Endymion pastor amasse dicitur Lunam seu Dianam; qui
+                  spretus pauit pecora candidissima et sic eam in suos illexit amplexus; cuius rei
+                  misticam quandam uolunt rationem. <milestone unit="par" n="2"/> Duplo quippe modo
+                  amasse dicitur Lunam. <milestone unit="par" n="3"/> Seu quod primus hominum cursum
+                  lunae inuenerit, unde et triginta annis dormisse dicitur, quia nihil aliud in uita
+                  sua nisi huic repertioni studuit. <milestone unit="par" n="4"/> Siue quod nocturni
+                  roris humor, quem tam siderum quam ipsius lunae uapores
+                  a<supplied>ni</supplied>mandis herbarum sucis insudant, pastoralibus
+                     prosi<del>n</del>t successibus. </p>
             </div>
 
             <div type="cap" n="28">
                <head> Fabula Berecynthiae et Attin<supplied>is</supplied>.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Berecynthia, Mater Deorum, Attin puerum formosissimum amasse dicitur, quem zelo succensa castrando semimasculum fecit. <milestone unit="par" n="2"/> Berecynthiam dici uoluerunt quasi montium dominam; ideo Matrem Deorum, quod deos pro superbia nuncupari uoluerunt. <milestone unit="par" n="3"/> Et inde Matrem Deum in modum potentiae ponunt, unde Cibele dicitur quasi cid<del>b</del>os bebeon, id est gloriae firmitas. <milestone unit="par" n="4"/> Ergo potentiae gloria semper et amore torretur et liuore torquetur citoque abscidit quod diligit, dum tamen amputet illud quod odit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Berecynthia, Mater Deorum, Attin puerum
+                  formosissimum amasse dicitur, quem zelo succensa castrando semimasculum fecit.
+                     <milestone unit="par" n="2"/> Berecynthiam dici uoluerunt quasi montium
+                  dominam; ideo Matrem Deorum, quod deos pro superbia nuncupari uoluerunt.
+                     <milestone unit="par" n="3"/> Et inde Matrem Deum in modum potentiae ponunt,
+                  unde Cibele dicitur quasi cid<del>b</del>os bebeon, id est gloriae firmitas.
+                     <milestone unit="par" n="4"/> Ergo potentiae gloria semper et amore torretur et
+                  liuore torquetur citoque abscidit quod diligit, dum tamen amputet illud quod odit.
+               </p>
             </div>
 
             <div type="cap" n="29">
                <head> Fabula Psyche<supplied>s</supplied> et Cupidinis.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Apuleius in libris metamorphoseon scribit in quadam ciuitate regem et reginam habuisse tres filias: duas natu maiores temperata specie fuisse, iuniorem uero, Psyche nomine, tam mirae extitisse elegantiae, ut crederetur Venus esse terrestris. <milestone unit="par" n="2"/> Denique duabus maioribus in coniugium a ui<supplied>r</supplied>is adscitis, illam ueluti deam non quisquam amare ausus erat, sed uenerari atque hostiis eam sibimet deplacare intendebant. <milestone unit="par" n="3"/> Venus ergo succensa inuidia Cupidinem petit, ut in contumacem formam seueriter uindicet; ille ad matris ultionem aduentans uisam puellam adamauit, et ipse se suo telo percussit. <milestone unit="par" n="4"/> Itaque Apollinis denuntiatione iubetur puella in montis cacumine sola dimitti et pennato serpenti sponsa destinari. <milestone unit="par" n="5"/> Perfecto igitur choragio — id est uirginali funere — puella, per montis decliuia Zephyri flantis leni uectura delapsa, in quandam domum auream rapitur et pretiosam, ibique, uocibus sibi tantummodo seruientibus, ignoto utebatur coniugio. <milestone unit="par" n="6"/> Nam nocte adueniens maritus, Veneris proeliis obscure peractis, ut inuise uespertinus aduenerat, ita crepuscolo incognitus etiam discedebat. <milestone unit="par" n="7"/> Sed ad huius mortem deflendam sorores adueniunt montisque conscenso cacumine germanam lugubri uoce flagitabant. <milestone unit="par" n="8"/> Et quamuis ille coniux lucifuga sororios ei comminando uetaret aspectus, tamen consanguineae caritatis inuincibilis ardor euicit ac Zephyri flantis aura uectitante ad semet sororios perducit affectus. <milestone unit="par" n="9"/> Quarum uenenosis consiliis de mariti forma quaerenda <supplied>consentiens</supplied>, curiositatem, suae salutis nouercam, arripuit; denique credens sororibus se marito serpenti coniunctam, uelut bestiam interfectura nouaculam sub puluinari abscondit lucernamque modio contegit. <milestone unit="par" n="10"/> Cumque altum soporem maritus extenderet, illa ferro armata lucernaque eruta, Cupidine cognito, dum immodesto amoris torretur affectu, scintillantis olei ebullitione maritum succendit; fugiensque Cupido multa super curiositate puellae increpitans, domo extorrem ac profugam dereliquit. <milestone unit="par" n="11"/> Tandem multis iactatam Veneris persecutionibus, postea Ioue petente in coniugium accepit. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Apuleius in libris metamorphoseon scribit in quadam
+                  ciuitate regem et reginam habuisse tres filias: duas natu maiores temperata specie
+                  fuisse, iuniorem uero, Psyche nomine, tam mirae extitisse elegantiae, ut
+                  crederetur Venus esse terrestris. <milestone unit="par" n="2"/> Denique duabus
+                  maioribus in coniugium a ui<supplied>r</supplied>is adscitis, illam ueluti deam
+                  non quisquam amare ausus erat, sed uenerari atque hostiis eam sibimet deplacare
+                  intendebant. <milestone unit="par" n="3"/> Venus ergo succensa inuidia Cupidinem
+                  petit, ut in contumacem formam seueriter uindicet; ille ad matris ultionem
+                  aduentans uisam puellam adamauit, et ipse se suo telo percussit. <milestone
+                     unit="par" n="4"/> Itaque Apollinis denuntiatione iubetur puella in montis
+                  cacumine sola dimitti et pennato serpenti sponsa destinari. <milestone unit="par"
+                     n="5"/> Perfecto igitur choragio — id est uirginali funere — puella, per montis
+                  decliuia Zephyri flantis leni uectura delapsa, in quandam domum auream rapitur et
+                  pretiosam, ibique, uocibus sibi tantummodo seruientibus, ignoto utebatur coniugio.
+                     <milestone unit="par" n="6"/> Nam nocte adueniens maritus, Veneris proeliis
+                  obscure peractis, ut inuise uespertinus aduenerat, ita crepuscolo incognitus etiam
+                  discedebat. <milestone unit="par" n="7"/> Sed ad huius mortem deflendam sorores
+                  adueniunt montisque conscenso cacumine germanam lugubri uoce flagitabant.
+                     <milestone unit="par" n="8"/> Et quamuis ille coniux lucifuga sororios ei
+                  comminando uetaret aspectus, tamen consanguineae caritatis inuincibilis ardor
+                  euicit ac Zephyri flantis aura uectitante ad semet sororios perducit affectus.
+                     <milestone unit="par" n="9"/> Quarum uenenosis consiliis de mariti forma
+                  quaerenda <supplied>consentiens</supplied>, curiositatem, suae salutis nouercam,
+                  arripuit; denique credens sororibus se marito serpenti coniunctam, uelut bestiam
+                  interfectura nouaculam sub puluinari abscondit lucernamque modio contegit.
+                     <milestone unit="par" n="10"/> Cumque altum soporem maritus extenderet, illa
+                  ferro armata lucernaque eruta, Cupidine cognito, dum immodesto amoris torretur
+                  affectu, scintillantis olei ebullitione maritum succendit; fugiensque Cupido multa
+                  super curiositate puellae increpitans, domo extorrem ac profugam dereliquit.
+                     <milestone unit="par" n="11"/> Tandem multis iactatam Veneris persecutionibus,
+                  postea Ioue petente in coniugium accepit. </p>
             </div>
 
             <div type="cap" n="30">
                <head> Fabula Perdiccae.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Perdiccas fuit uenator ferarum; qui propriae matris amore correptus, dum utrumque et immodesta libidine ferueret et uerecundia uim noui facinoris reluctaretur, consumptus atque ad extremam tabem deductus esse dicitur. <milestone unit="par" n="2"/> Primus hic etiam serram inuenit iuxta Virgilium. <milestone unit="par" n="3"/> Veritas sic se habet: cum esset uenator et ei ferinae caedis cruenta uastatio et solitudinum uagabunda currilitas displiceret, magis etiam perpendens contirones suos — id est Actaeonem, Adonem, Hippolytum — miserandae necis functos interitu, uenationem execrans agriculturam affectatus est. <milestone unit="par" n="4"/> Ob quam rem matrem, quasi Terram omnium genetricem, amasse dicitur et hoc labore ad maciem perductus. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Perdiccas fuit uenator ferarum; qui propriae matris
+                  amore correptus, dum utrumque et immodesta libidine ferueret et uerecundia uim
+                  noui facinoris reluctaretur, consumptus atque ad extremam tabem deductus esse
+                  dicitur. <milestone unit="par" n="2"/> Primus hic etiam serram inuenit iuxta
+                  Virgilium. <milestone unit="par" n="3"/> Veritas sic se habet: cum esset uenator
+                  et ei ferinae caedis cruenta uastatio et solitudinum uagabunda currilitas
+                  displiceret, magis etiam perpendens contirones suos — id est Actaeonem, Adonem,
+                  Hippolytum — miserandae necis functos interitu, uenationem execrans agriculturam
+                  affectatus est. <milestone unit="par" n="4"/> Ob quam rem matrem, quasi Terram
+                  omnium genetricem, amasse dicitur et hoc labore ad maciem perductus. </p>
             </div>
 
             <div type="cap" n="31">
                <head> Fabula Canis inter sidera<del>s</del> translati.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Canis inter sidera constituti fabula haec est. <milestone unit="par" n="2"/> Hic canis dicitur ab Ioue custos Europae positus esse <supplied>et</supplied> ad Minoa peruenisse; <supplied>quem Procris Cephali uxor laborantem dicitur sanasse et pro eo beneficio canem munere accepisse</supplied> quod illa studiosa fuerit uenationis et quod cani fuerat datum, ne ulla fera praeterire eum posset. <milestone unit="par" n="3"/> Post eius obitum canis ad Cephalum peruenit, cuius uxor fuerat Procris. <milestone unit="par" n="4"/> Quem ille ducens secum, Thebas uenit, ubi erat uulpes, cui datum dicebatur, ut omnes canes effugere posset; itaque cum in unum peruenissent, Iuppiter, nescius quid faceret, ut Istrius ait, utrosque in lapidem conuertit. <milestone unit="par" n="5"/> Nonnulli hunc canem Orionis esse dixerunt et, quod studiosus fuerit uenandi, cum eo canem quoque inter sidera collocatum. <milestone unit="par" n="6"/> Alii autem canem Icari esse dixerunt. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Canis inter sidera constituti fabula haec est.
+                     <milestone unit="par" n="2"/> Hic canis dicitur ab Ioue custos Europae positus
+                  esse <supplied>et</supplied> ad Minoa peruenisse; <supplied>quem Procris Cephali
+                     uxor laborantem dicitur sanasse et pro eo beneficio canem munere
+                     accepisse</supplied> quod illa studiosa fuerit uenationis et quod cani fuerat
+                  datum, ne ulla fera praeterire eum posset. <milestone unit="par" n="3"/> Post eius
+                  obitum canis ad Cephalum peruenit, cuius uxor fuerat Procris. <milestone
+                     unit="par" n="4"/> Quem ille ducens secum, Thebas uenit, ubi erat uulpes, cui
+                  datum dicebatur, ut omnes canes effugere posset; itaque cum in unum peruenissent,
+                  Iuppiter, nescius quid faceret, ut Istrius ait, utrosque in lapidem conuertit.
+                     <milestone unit="par" n="5"/> Nonnulli hunc canem Orionis esse dixerunt et,
+                  quod studiosus fuerit uenandi, cum eo canem quoque inter sidera collocatum.
+                     <milestone unit="par" n="6"/> Alii autem canem Icari esse dixerunt. </p>
             </div>
 
             <div type="cap" n="32">
                <head> De septem Pliadibus.</head>
-               <p> 
-                  <milestone unit="par" n="1"/> Pliadas seu Hyadas septem stellas appellatas nouimus, Pliadae dictae, quod septem filiae ex Plione — quae et Aethra — Oceani filia et Atlante sint natae. <milestone unit="par" n="2"/> Hae numero septem dicuntur, sed nemo amplius sex uidere potest, cuius causa proditur haec: de septem sex cum immortalibus concubuerunt — tres cum Ioue, duae cum Neptuno, una cum Marte —, reliqua autem Sisyphi uxor demonstratur. <milestone unit="par" n="3"/> Quarum ex Electra et Ioue Dardanum, ex Maia Mercurium, ex Ta<supplied>y</supplied>gete Lacedaemona procreatum, ex Alcyone autem et Neptuno Hyrea, ex Celaeno Lycum et Nyctea natum, Martem autem ex Sterop<del>o</del>e Oenomaum procreasse. <milestone unit="par" n="4"/> Merope<del>a</del>m autem, Sisypho nuptam, Glaucum genuisse, quem complures Bellerophontis patrem dixerunt; quare propter reliquas sorores eius inter sidera constitutam, sed quod homini nupserit, stellam eius obscuratam. <milestone unit="par" n="5"/> Alii dicunt Electram non parere pro Troia capta et progenie sua — quae ex Dardano erat — euersa lamentantem. <milestone unit="par" n="6"/> Est et alia earum traditio: cum septem hae sorores iter cum puellis agerent, Orion<del>a</del> conatus est uni earum uim inferre et illa cum sororibus fugit. <milestone unit="par" n="7"/> Oriona autem secutum tradunt eam annis septem neque inuenire potuisse, Iouem autem, puellarum misertum, inter astra constituisse utrosque; itaque adhuc Orion fugientes eas ad occasum sequi uidetur. </p>
+               <p>
+                  <milestone unit="par" n="1"/> Pliadas seu Hyadas septem stellas appellatas
+                  nouimus, Pliadae dictae, quod septem filiae ex Plione — quae et Aethra — Oceani
+                  filia et Atlante sint natae. <milestone unit="par" n="2"/> Hae numero septem
+                  dicuntur, sed nemo amplius sex uidere potest, cuius causa proditur haec: de septem
+                  sex cum immortalibus concubuerunt — tres cum Ioue, duae cum Neptuno, una cum Marte
+                  —, reliqua autem Sisyphi uxor demonstratur. <milestone unit="par" n="3"/> Quarum
+                  ex Electra et Ioue Dardanum, ex Maia Mercurium, ex Ta<supplied>y</supplied>gete
+                  Lacedaemona procreatum, ex Alcyone autem et Neptuno Hyrea, ex Celaeno Lycum et
+                  Nyctea natum, Martem autem ex Sterop<del>o</del>e Oenomaum procreasse. <milestone
+                     unit="par" n="4"/> Merope<del>a</del>m autem, Sisypho nuptam, Glaucum genuisse,
+                  quem complures Bellerophontis patrem dixerunt; quare propter reliquas sorores eius
+                  inter sidera constitutam, sed quod homini nupserit, stellam eius obscuratam.
+                     <milestone unit="par" n="5"/> Alii dicunt Electram non parere pro Troia capta
+                  et progenie sua — quae ex Dardano erat — euersa lamentantem. <milestone unit="par"
+                     n="6"/> Est et alia earum traditio: cum septem hae sorores iter cum puellis
+                  agerent, Orion<del>a</del> conatus est uni earum uim inferre et illa cum sororibus
+                  fugit. <milestone unit="par" n="7"/> Oriona autem secutum tradunt eam annis septem
+                  neque inuenire potuisse, Iouem autem, puellarum misertum, inter astra constituisse
+                  utrosque; itaque adhuc Orion fugientes eas ad occasum sequi uidetur. </p>
             </div>
 
          </div>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -33,13 +33,13 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl>
-            <cRefPattern n="scholia" matchPattern="(\w+).(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
-               <p>This pointer pattern extracts scholiae</p>
+            <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
+            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
+            <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
             <cRefPattern n="book" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
-               <p>This pointer pattern extracts books</p>
+            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+            <p>This pointer pattern extracts books</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>
@@ -88,8 +88,7 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change who="Etienne Ferrandi" when="2021-04-12">Correction du XPath et ajout de la
-            langue</change>
+         <change who="Etienne Ferrandi" when="2021-04-12">Correction du XPath et ajout de la langue</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -1876,6 +1875,7 @@
                      uirgo</hi> dicitur — a matre Latona — et <hi rend="italic">Plutonia
                   coniux</hi>. <milestone unit="par" n="9"/> Graece Hecate dicitur. </p>
             </div>
+
             <div type="cap" n="12">
                <head> Fabula Apollinis uel Solis.</head>
                <p>
@@ -1896,6 +1896,7 @@
                   Philogeus terram amans dicitur, eo quod uespere occasibus sol pro<del>ti</del>nus
                   incumbat. </p>
             </div>
+
             <div type="cap" n="13">
                <head> De nouem Musis.</head>
                <p>
@@ -1910,6 +1911,7 @@
                   instructionem, quae psalterium instituit; Vrania, id est caelestis, quae
                   astrologiam inuenit; Calliope, id est optimae uocis, quae litteras docuit. </p>
             </div>
+
             <div type="cap" n="14">
                <head> Fabula Apollinis et corui et Coronide filie Phlegyae.</head>
                <p>
@@ -1933,6 +1935,7 @@
                   antea candidus, pro incommodo nuntio eum nigrum fecisse et Scin sagittis
                   confixisse. </p>
             </div>
+
             <div type="cap" n="15">
                <head> Fabula Apollinis et Daphni<supplied>di</supplied>s seu lauri.</head>
                <p>
@@ -1947,6 +1950,7 @@
                   disco, ab irato Borea eodem disco est interemptus et mutatus in florem nominis
                      <supplied>sui</supplied>.</p>
             </div>
+
             <div type="cap" n="16">
                <head> Fabula Apollinis et Heridani.</head>
                <p>
@@ -1964,6 +1968,7 @@
                   Qui expulsus boues Admeti regis per quattuor annos pauit super Euphratem fluuium,
                   ubi quam plures habuit filios. </p>
             </div>
+
             <div type="cap" n="17">
                <head> Fabula Mercurii et Maie matris eius.</head>
                <p>
@@ -1989,6 +1994,7 @@
                   capite canino fingunt, haec ratio dicitur, quod inter omnia animalia canis
                   sagacissimum genus et perspicax habeatur. </p>
             </div>
+
             <div type="cap" n="18">
                <head> Fabula Semele et filii eius Liberi patris.</head>
                <p>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -87,6 +87,9 @@
             <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
+      <revisionDesc>
+         <change who="Etienne Ferrandi" when="2021-04-12">Correction du XPath et ajout de la langue</change>
+      </revisionDesc>
    </teiHeader>
    <text>
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0364.stoa001.digilibLT-lat1">

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -33,13 +33,13 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl>
-            <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
-            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
-            <p>This pointer pattern extracts chapters</p>
+            <cRefPattern n="scholia" matchPattern="(\w+).(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
+               <p>This pointer pattern extracts scholiae</p>
             </cRefPattern>
             <cRefPattern n="book" matchPattern="(\w+)"
-            replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
-            <p>This pointer pattern extracts books</p>
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts books</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>
@@ -88,7 +88,8 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change who="Etienne Ferrandi" when="2021-04-12">Correction du XPath et ajout de la langue</change>
+         <change who="Etienne Ferrandi" when="2021-04-12">Correction du XPath et ajout de la
+            langue</change>
       </revisionDesc>
    </teiHeader>
    <text>
@@ -1875,7 +1876,6 @@
                      uirgo</hi> dicitur — a matre Latona — et <hi rend="italic">Plutonia
                   coniux</hi>. <milestone unit="par" n="9"/> Graece Hecate dicitur. </p>
             </div>
-
             <div type="cap" n="12">
                <head> Fabula Apollinis uel Solis.</head>
                <p>
@@ -1896,7 +1896,6 @@
                   Philogeus terram amans dicitur, eo quod uespere occasibus sol pro<del>ti</del>nus
                   incumbat. </p>
             </div>
-
             <div type="cap" n="13">
                <head> De nouem Musis.</head>
                <p>
@@ -1911,7 +1910,6 @@
                   instructionem, quae psalterium instituit; Vrania, id est caelestis, quae
                   astrologiam inuenit; Calliope, id est optimae uocis, quae litteras docuit. </p>
             </div>
-
             <div type="cap" n="14">
                <head> Fabula Apollinis et corui et Coronide filie Phlegyae.</head>
                <p>
@@ -1935,7 +1933,6 @@
                   antea candidus, pro incommodo nuntio eum nigrum fecisse et Scin sagittis
                   confixisse. </p>
             </div>
-
             <div type="cap" n="15">
                <head> Fabula Apollinis et Daphni<supplied>di</supplied>s seu lauri.</head>
                <p>
@@ -1950,7 +1947,6 @@
                   disco, ab irato Borea eodem disco est interemptus et mutatus in florem nominis
                      <supplied>sui</supplied>.</p>
             </div>
-
             <div type="cap" n="16">
                <head> Fabula Apollinis et Heridani.</head>
                <p>
@@ -1968,7 +1964,6 @@
                   Qui expulsus boues Admeti regis per quattuor annos pauit super Euphratem fluuium,
                   ubi quam plures habuit filios. </p>
             </div>
-
             <div type="cap" n="17">
                <head> Fabula Mercurii et Maie matris eius.</head>
                <p>
@@ -1994,7 +1989,6 @@
                   capite canino fingunt, haec ratio dicitur, quod inter omnia animalia canis
                   sagacissimum genus et perspicax habeatur. </p>
             </div>
-
             <div type="cap" n="18">
                <head> Fabula Semele et filii eius Liberi patris.</head>
                <p>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -33,14 +33,14 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl>
-         <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
+            <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
             replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
             <p>This pointer pattern extracts chapters</p>
-         </cRefPattern>
-         <cRefPattern n="book" matchPattern="(\w+)"
+            </cRefPattern>
+            <cRefPattern n="book" matchPattern="(\w+)"
             replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
             <p>This pointer pattern extracts books</p>
-         </cRefPattern>
+            </cRefPattern>
          </refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>

--- a/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0364/stoa001/stoa0364.stoa001.digilibLT-lat1.xml
@@ -32,7 +32,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl>
+         <refsDecl n="CTS">
             <cRefPattern n="chapter" matchPattern="(\w+).(\w+)"
             replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])">
             <p>This pointer pattern extracts chapters</p>
@@ -3495,7 +3495,7 @@
                   facto Iuno et Minerua Troianis dicuntur iratae, spretae iniuria formae. </p>
             </div>
 
-            <div type="cap" n="6-7">
+            <div type="cap" n="6ff">
                <head> Fabula de Achille et Agamemnone et mortis Hectoris.</head>
                <p>
                   <milestone unit="par" n="1"/> Achilles, Thetidis et Pelei filius, cum quinquaginta
@@ -3570,7 +3570,7 @@
                   etiam illam praescriptam praelibet. </p>
             </div>
 
-            <div type="cap" n="12-13">
+            <div type="cap" n="12ff">
                <head> Fabula Didonis et historia <supplied>S</supplied>aturni.</head>
                <p>
                   <milestone unit="par" n="1"/> Dido, Metonis filia, quem Virgilius Belum nominat,


### PR DESCRIPTION
**Issue #50 **

**Fichier XML CapiTainS 4/5 corrigé pour la validation du cours de GIT du master HN :**

"stoa0364.stoa001.digilibLT-lat1.xml" : Mythographus Vaticanus I.

Afin de rendre le document compatible avec CapiTainS, j'ai effectué les corrections suivantes :

- Modification du `refsDecl`

- suppresion des espaces blancs

- modification du `profileDesc`

- ajout d'un `revisionDesc`