### PR TITLE
3/5: Correction du fichier "stoa0044.stoa002.digilibLT-lat1.xml"

### DIFF
--- a/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
@@ -1,515 +1,1501 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title> Liber de uiris illustribus urbis Romae</title>
-                <author> Aurelius Victor Ps.</author>
-                <respStmt>
-                    <resp>Correzione linguistica</resp>
-                    <name>Valentina Rinaldi</name>
-                </respStmt>
-                <respStmt>
-                    <resp>Codifica XML</resp>
-                    <name>Valentina Rinaldi</name>
-                </respStmt>
-            </titleStmt>
-            <publicationStmt>
-                <publisher>digilibLT</publisher>
-                <pubPlace>Vercelli</pubPlace>
-                <date>2012</date>
-                <availability>
-                    <p>
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title> Liber de uiris illustribus urbis Romae</title>
+            <author> Aurelius Victor Ps.</author>
+            <respStmt>
+               <resp>Correzione linguistica</resp>
+               <name>Valentina Rinaldi</name>
+            </respStmt>
+            <respStmt>
+               <resp>Codifica XML</resp>
+               <name>Valentina Rinaldi</name>
+            </respStmt>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>digilibLT</publisher>
+            <pubPlace>Vercelli</pubPlace>
+            <date>2012</date>
+            <availability>
+               <p>
                   <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
                </p>
-                </availability>
-                <idno>dlt000031</idno>
-            </publicationStmt>
-            <sourceDesc>
-                <p>Sexti Aureli Victoris, Liber de Caesaribus. Praecedunt Origo gentis Romanae et Liber de uiris illustribus urbis Romae, subsequitur Epitome de Caesaribus, edidit F. Pichlmayr,  Teubner, Leipzig 1911, 1970 (con aggiunte di R. Gruendel).</p>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
-            <projectDesc>
-                <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-                <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
-            </projectDesc>
-            <editorialDecl>
-                                
-                <p>
+            </availability>
+            <idno>dlt000031</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Sexti Aureli Victoris, Liber de Caesaribus. Praecedunt Origo gentis Romanae et Liber
+               de uiris illustribus urbis Romae, subsequitur Epitome de Caesaribus, edidit F.
+               Pichlmayr, Teubner, Leipzig 1911, 1970 (con aggiunte di R. Gruendel).</p>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="unknown" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts unknown</p>
+            </cRefPattern>
+         </refsDecl>
+         <projectDesc>
+            <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
+         </projectDesc>
+         <editorialDecl>
+
+            <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
-                <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-                    l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-                    e commenti e ogni altro contenuto redatto da editori moderni. </p>
-                <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-                    correttezza di trascrizione</p>
-                <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-                    distinzione u/v minuscole.</p>
-                <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-                <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-                    grassetto, corsivo, spaziatura espansa.</p>
-                <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-                    &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-                    <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-                    si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-                    [...]<lb/> lacuna integrata dagli editori:
-                    &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-                </p>
-                <p>Sono stati marcati i termini in lingua greca
-                    &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-                </p>
-                <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-                    [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
+            <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
+            <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
+               grassetto, corsivo, spaziatura espansa.</p>
+            <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
-            </editorialDecl>
-           
-        </encodingDesc>
-        <profileDesc>
-            <langUsage>
-                <language ident="la">Latino</language>
-            </langUsage>
-        </profileDesc>
-    </teiHeader>
+         </editorialDecl>
 
-    <text>
-        <body xml:lang="lat" n="urn:cts:latinLit:stoa0044.stoa002.digilibLT-lat1">
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="la">Latino</language>
+         </langUsage>
+      </profileDesc>
+   </teiHeader>
+
+   <text>
+      <body xml:lang="lat" n="urn:cts:latinLit:stoa0044.stoa002.digilibLT-lat1">
          <div type="cap" n="1">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Proca</hi>, rex Albanorum, Amulium et Numitorem filios habuit, quibus regnum annuis vicibus habendum reliquit <del>ut alternis imperarent</del>. Sed Amulius fratri imperium non dedit et ut eum subole privaret, filiam eius, Rheam Silviam, Vestae sacerdotem praefecit, ut virginitate perpetua teneretur, quae a Marte compressa Remum et Romulum edidit. <milestone unit="par" n="2"/> Amulius ipsam in vincula compegit, parvulos in Tiberim abiecit, quos aqua in sicco reliquit. <milestone unit="par" n="3"/> Ad vagitum lupa accurrit eosque uberibus suis aluit. Mox Faustulus pastor collectos Accae Laurentiae coniugi educandos dedit. <milestone unit="par" n="4"/> Qui postea Amulio interfecto Numitori avo regnum restituerunt; ipsi pastoribus adunatis civitatem condiderunt, quam Romulus augurio victor, quod ipse XII, Remus VI vultures viderat, Romam vocavit; et ut eam prius legibus muniret quam moenibus, edixit, ne quis vallum transiliret; quod Remus irridens transilivit et a Celere centurione rastro fertur occisus. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Proca</hi>, rex Albanorum, Amulium et Numitorem filios habuit,
+               quibus regnum annuis vicibus habendum reliquit <del>ut alternis imperarent</del>. Sed
+               Amulius fratri imperium non dedit et ut eum subole privaret, filiam eius, Rheam
+               Silviam, Vestae sacerdotem praefecit, ut virginitate perpetua teneretur, quae a Marte
+               compressa Remum et Romulum edidit. <milestone unit="par" n="2"/> Amulius ipsam in
+               vincula compegit, parvulos in Tiberim abiecit, quos aqua in sicco reliquit.
+                  <milestone unit="par" n="3"/> Ad vagitum lupa accurrit eosque uberibus suis aluit.
+               Mox Faustulus pastor collectos Accae Laurentiae coniugi educandos dedit. <milestone
+                  unit="par" n="4"/> Qui postea Amulio interfecto Numitori avo regnum restituerunt;
+               ipsi pastoribus adunatis civitatem condiderunt, quam Romulus augurio victor, quod
+               ipse XII, Remus VI vultures viderat, Romam vocavit; et ut eam prius legibus muniret
+               quam moenibus, edixit, ne quis vallum transiliret; quod Remus irridens transilivit et
+               a Celere centurione rastro fertur occisus. </p>
          </div>
-            <div type="cap" n="2">
+         <div type="cap" n="2">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Romulus</hi> asylum convenis patefecit et magno exercitu facto, cum videret coniugia deesse, per legatos a finitimis civitatibus petiit. <milestone unit="par" n="2"/> Quibus negatis ludos Consualia simulavit; ad quos cum utriusque sexus multitudo venisset, dato suis signo virgines raptae sunt. Ex quibus cum una pulcherrima cum magna omnium admiratione duceretur, Talassio eam duci responsum est. <milestone unit="par" n="3"/> Quae nuptiae quia feliciter cesserant, institutum est, ut in omnibus nuptiis Talassii nomen iteretur. Cum feminas finitimorum Romani vi rapuissent, primi Caeninenses contra eos bellum sumpserunt. Adversus quos Romulus processit et exercitum eorum ac ducem Acronem singulari proelio devicit. <milestone unit="par" n="4"/> Spolia opima Iovi Feretrio in Capitolio consecravit. Sabini ob raptas bellum adversus Romanos sumpserunt. <milestone unit="par" n="5"/> Et cum Romae appropinquarent, Tarpeiam virginem nacti, quae aquae causa sacrorum hauriendae descenderat, ei T. Tatius optionem muneris dedit, si exercitum suum in arcem perduxisset. <milestone unit="par" n="6"/> Illa petiit, quod illi in sinistris manibus gerebant, videlicet anulos et armillas; quibus dolose repromissis Sabinos in arcem perduxit, ubi Tatius scutis eam obrui praecepit; nam et ea in laevis habuerant. <milestone unit="par" n="7"/> Romulus adversus Tatium, qui montem Tarpeium tenebat, processit et in eo loco, ubi nunc forum Romanum est, pugnam conseruit: ibi Hostus Hostilius fortissime dimicans cecidit, cuius interitu consternati Romani fugere coeperunt. <milestone unit="par" n="8"/> Tunc Romulus Iovi Statori aedem vovit, et exercitus seu forte seu divinitus restitit. <milestone unit="par" n="9"/> Tunc raptae in medium processerunt et hinc patres inde coniuges deprecatae pacem conciliarunt. <milestone unit="par" n="10"/> Romulus foedus percussit et Sabinos in urbem recepit, populum a Curibus, oppido Sabinorum, Quirites vocavit. Centum senatores a pietate patres appellavit. <milestone unit="par" n="11"/> Tres equitum centurias instituit, quas suo nomine Ramnes, a Tito Tatio Tatienses, a luci communione Luceres appellavit. <milestone unit="par" n="12"/> Plebem in triginta curias distribuit easque raptarum nominibus appellavit. <milestone unit="par" n="13"/> Cum ad Caprae paludem exercitum lustraret, nusquam comparuit; unde inter patres et populum seditione orta Iulius Proculus, vir nobilis, in contionem processit et iureiurando firmavit Romulum a se in colle Quirinali visum augustiore forma, cum ad deos abiret; eundemque praecipere, ut seditionibus abstinerent, virtutem colerent; futurum, ut omnium gentium domini exsisterent. <milestone unit="par" n="14"/> Huius auctoritati creditum est. Aedes in colle Quirinali Romulo constituta, ipse pro deo cultus et Quirinus est appellatus. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Romulus</hi> asylum convenis patefecit et magno exercitu facto,
+               cum videret coniugia deesse, per legatos a finitimis civitatibus petiit. <milestone
+                  unit="par" n="2"/> Quibus negatis ludos Consualia simulavit; ad quos cum utriusque
+               sexus multitudo venisset, dato suis signo virgines raptae sunt. Ex quibus cum una
+               pulcherrima cum magna omnium admiratione duceretur, Talassio eam duci responsum est.
+                  <milestone unit="par" n="3"/> Quae nuptiae quia feliciter cesserant, institutum
+               est, ut in omnibus nuptiis Talassii nomen iteretur. Cum feminas finitimorum Romani vi
+               rapuissent, primi Caeninenses contra eos bellum sumpserunt. Adversus quos Romulus
+               processit et exercitum eorum ac ducem Acronem singulari proelio devicit. <milestone
+                  unit="par" n="4"/> Spolia opima Iovi Feretrio in Capitolio consecravit. Sabini ob
+               raptas bellum adversus Romanos sumpserunt. <milestone unit="par" n="5"/> Et cum Romae
+               appropinquarent, Tarpeiam virginem nacti, quae aquae causa sacrorum hauriendae
+               descenderat, ei T. Tatius optionem muneris dedit, si exercitum suum in arcem
+               perduxisset. <milestone unit="par" n="6"/> Illa petiit, quod illi in sinistris
+               manibus gerebant, videlicet anulos et armillas; quibus dolose repromissis Sabinos in
+               arcem perduxit, ubi Tatius scutis eam obrui praecepit; nam et ea in laevis habuerant.
+                  <milestone unit="par" n="7"/> Romulus adversus Tatium, qui montem Tarpeium
+               tenebat, processit et in eo loco, ubi nunc forum Romanum est, pugnam conseruit: ibi
+               Hostus Hostilius fortissime dimicans cecidit, cuius interitu consternati Romani
+               fugere coeperunt. <milestone unit="par" n="8"/> Tunc Romulus Iovi Statori aedem
+               vovit, et exercitus seu forte seu divinitus restitit. <milestone unit="par" n="9"/>
+               Tunc raptae in medium processerunt et hinc patres inde coniuges deprecatae pacem
+               conciliarunt. <milestone unit="par" n="10"/> Romulus foedus percussit et Sabinos in
+               urbem recepit, populum a Curibus, oppido Sabinorum, Quirites vocavit. Centum
+               senatores a pietate patres appellavit. <milestone unit="par" n="11"/> Tres equitum
+               centurias instituit, quas suo nomine Ramnes, a Tito Tatio Tatienses, a luci
+               communione Luceres appellavit. <milestone unit="par" n="12"/> Plebem in triginta
+               curias distribuit easque raptarum nominibus appellavit. <milestone unit="par" n="13"
+               /> Cum ad Caprae paludem exercitum lustraret, nusquam comparuit; unde inter patres et
+               populum seditione orta Iulius Proculus, vir nobilis, in contionem processit et
+               iureiurando firmavit Romulum a se in colle Quirinali visum augustiore forma, cum ad
+               deos abiret; eundemque praecipere, ut seditionibus abstinerent, virtutem colerent;
+               futurum, ut omnium gentium domini exsisterent. <milestone unit="par" n="14"/> Huius
+               auctoritati creditum est. Aedes in colle Quirinali Romulo constituta, ipse pro deo
+               cultus et Quirinus est appellatus. </p>
          </div>
-            <div type="cap" n="3">
+         <div type="cap" n="3">
             <p>
-               <milestone unit="par" n="1"/> Post consecrationem Romuli, cum diu interregnum esset et seditiones orirentur, <hi rend="expanded">Numa Pompilius</hi>, Pomponii filius, Curibus, oppido Sabinorum, accitus, cum addicentibus avibus Romam venisset, ut populum ferum religione molliret, sacra plurima instituit. Aedem Vestae fecit, virgines Vestales legit, flamines tres, Dialem Martialem Quirinalem, Salios, Martis sacerdotes, quorum primus praesul vocatur, XII instituit, pontificem maximum creavit, portas Iano gemino aedificavit. Annum in XII menses distribuit additis Ianuario et Februario. <milestone unit="par" n="2"/> Leges quoque plures et utiles tulit, omnia, quae gerebat, iussu Egeriae nymphae, uxoris suae, se facere simulans. Ob hanc tantam iustitiam bellum ei nemo intulit. Morbo solutus in Ianiculo sepultus est, ubi post annos arcula cum libris a Terentio quodam exarata; qui libri, quia leves quasdam sacrorum causas continebant, ex auctoritate patrum cremati sunt. </p>
+               <milestone unit="par" n="1"/> Post consecrationem Romuli, cum diu interregnum esset
+               et seditiones orirentur, <hi rend="expanded">Numa Pompilius</hi>, Pomponii filius,
+               Curibus, oppido Sabinorum, accitus, cum addicentibus avibus Romam venisset, ut
+               populum ferum religione molliret, sacra plurima instituit. Aedem Vestae fecit,
+               virgines Vestales legit, flamines tres, Dialem Martialem Quirinalem, Salios, Martis
+               sacerdotes, quorum primus praesul vocatur, XII instituit, pontificem maximum creavit,
+               portas Iano gemino aedificavit. Annum in XII menses distribuit additis Ianuario et
+               Februario. <milestone unit="par" n="2"/> Leges quoque plures et utiles tulit, omnia,
+               quae gerebat, iussu Egeriae nymphae, uxoris suae, se facere simulans. Ob hanc tantam
+               iustitiam bellum ei nemo intulit. Morbo solutus in Ianiculo sepultus est, ubi post
+               annos arcula cum libris a Terentio quodam exarata; qui libri, quia leves quasdam
+               sacrorum causas continebant, ex auctoritate patrum cremati sunt. </p>
          </div>
-            <div type="cap" n="4">
+         <div type="cap" n="4">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Tullus Hostilius</hi>, quia bonam operam adversum Sabinos navaverat, rex creatus bellum Albanis indixit, quod trigeminorum certatione finivit. <milestone unit="par" n="2"/> Albam propter perfidiam ducis Mettii Fufetii diruit, Albanos Romam transire iussit. <milestone unit="par" n="3"/> Curiam Hostiliam constituit. Montem Coelium urbi addidit. <milestone unit="par" n="4"/> Et dum Numam Pompilium sacrificiis imitatur, Iovi Elicio litare non potuit, fulmine ictus cum regia conflagravit. </p>
-                <p>
-               <milestone unit="par" n="5"/> Cum inter Romanos et Albanos bellum fuisset exortum, ducibus Hostilio et Fufetio placuit rem paucorum certamine finire. <milestone unit="par" n="6"/> Erant apud Romanos trigemini Horatii, tres apud Albanos Curiatii; quibus foedere icto concurrentibus statim duo Romanorum ceciderunt, tres Albanorum vulnerati. <milestone unit="par" n="7"/> Vnus Horatius quamvis integer, quia tribus impar erat, fugam simulavit et singulos per intervalla, ut vulnerum dolor patiebatur, insequentes interfecit. <milestone unit="par" n="8"/> Et cum spoliis onustus rediret, sororem obviam habuit, quae viso paludamento sponsi sui, qui unus ex Curiatiis erat, flere coepit. Frater eam occidit. <milestone unit="par" n="9"/> Qua re apud duumviros condemnatus ad populum provocavit; ubi patris lacrimis condonatus ab eo expiandi gratia sub tigillum missus; quod nunc quoque viae superpositum Sororium appellatur. </p>
-                <p>
-               <milestone unit="par" n="10"/> Mettius Fufetius, dux Albanorum, cum se invidiosum apud cives videret, quod bellum sola trigeminorum certatione finisset, ut rem corrigeret, Veientes et Fidenates adversum Romanos incitavit. <milestone unit="par" n="11"/> Ipse ab Tullo in auxilium arcessitus aciem in collem subduxit, ut fortunam sequeretur. Qua re Tullus intellecta magna voce ait suo illud iussu Mettium facere. <milestone unit="par" n="12"/> Qua re hostes territi et victi sunt. <milestone unit="par" n="13"/> Postera die Mettius cum ad gratulandum Tullo venisset, iussu ipsius quadrigis religatus et in diversa distractus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Tullus Hostilius</hi>, quia bonam operam adversum Sabinos
+               navaverat, rex creatus bellum Albanis indixit, quod trigeminorum certatione finivit.
+                  <milestone unit="par" n="2"/> Albam propter perfidiam ducis Mettii Fufetii diruit,
+               Albanos Romam transire iussit. <milestone unit="par" n="3"/> Curiam Hostiliam
+               constituit. Montem Coelium urbi addidit. <milestone unit="par" n="4"/> Et dum Numam
+               Pompilium sacrificiis imitatur, Iovi Elicio litare non potuit, fulmine ictus cum
+               regia conflagravit. </p>
+            <p>
+               <milestone unit="par" n="5"/> Cum inter Romanos et Albanos bellum fuisset exortum,
+               ducibus Hostilio et Fufetio placuit rem paucorum certamine finire. <milestone
+                  unit="par" n="6"/> Erant apud Romanos trigemini Horatii, tres apud Albanos
+               Curiatii; quibus foedere icto concurrentibus statim duo Romanorum ceciderunt, tres
+               Albanorum vulnerati. <milestone unit="par" n="7"/> Vnus Horatius quamvis integer,
+               quia tribus impar erat, fugam simulavit et singulos per intervalla, ut vulnerum dolor
+               patiebatur, insequentes interfecit. <milestone unit="par" n="8"/> Et cum spoliis
+               onustus rediret, sororem obviam habuit, quae viso paludamento sponsi sui, qui unus ex
+               Curiatiis erat, flere coepit. Frater eam occidit. <milestone unit="par" n="9"/> Qua
+               re apud duumviros condemnatus ad populum provocavit; ubi patris lacrimis condonatus
+               ab eo expiandi gratia sub tigillum missus; quod nunc quoque viae superpositum
+               Sororium appellatur. </p>
+            <p>
+               <milestone unit="par" n="10"/> Mettius Fufetius, dux Albanorum, cum se invidiosum
+               apud cives videret, quod bellum sola trigeminorum certatione finisset, ut rem
+               corrigeret, Veientes et Fidenates adversum Romanos incitavit. <milestone unit="par"
+                  n="11"/> Ipse ab Tullo in auxilium arcessitus aciem in collem subduxit, ut
+               fortunam sequeretur. Qua re Tullus intellecta magna voce ait suo illud iussu Mettium
+               facere. <milestone unit="par" n="12"/> Qua re hostes territi et victi sunt.
+                  <milestone unit="par" n="13"/> Postera die Mettius cum ad gratulandum Tullo
+               venisset, iussu ipsius quadrigis religatus et in diversa distractus est. </p>
          </div>
-            <div type="cap" n="5">
+         <div type="cap" n="5">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Ancus Marcius</hi>, Numae Pompilii ex filia nepos, aequitate et religione avo similis, Latinos bello domuit. <milestone unit="par" n="2"/> Murcium et Ianiculum montes urbi addidit, nova moenia oppido circumdedit. Silvas ad usum navium publicavit. Salinarum vectigal instituit. <milestone unit="par" n="3"/> Carcerem primus aedificavit. Ostiam coloniam maritimis commeatibus opportunam in ostio Tiberis deduxit. <milestone unit="par" n="4"/> Ius fetiale, quo legati ad res repetundas uterentur, ab Aequiculis transtulit, quod primus fertur Rhesus excogitasse. <milestone unit="par" n="5"/> His rebus confectis intra paucos dies immatura morte praereptus non potuit praestare qualem promiserat regem. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Ancus Marcius</hi>, Numae Pompilii ex filia nepos, aequitate et
+               religione avo similis, Latinos bello domuit. <milestone unit="par" n="2"/> Murcium et
+               Ianiculum montes urbi addidit, nova moenia oppido circumdedit. Silvas ad usum navium
+               publicavit. Salinarum vectigal instituit. <milestone unit="par" n="3"/> Carcerem
+               primus aedificavit. Ostiam coloniam maritimis commeatibus opportunam in ostio Tiberis
+               deduxit. <milestone unit="par" n="4"/> Ius fetiale, quo legati ad res repetundas
+               uterentur, ab Aequiculis transtulit, quod primus fertur Rhesus excogitasse.
+                  <milestone unit="par" n="5"/> His rebus confectis intra paucos dies immatura morte
+               praereptus non potuit praestare qualem promiserat regem. </p>
          </div>
-            <div type="cap" n="6">
+         <div type="cap" n="6">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Tarquinius Priscus</hi>, Demarati Corinthii filius, eius, qui Cypseli tyrannidem fugiens in Etruriam commigravit. <milestone unit="par" n="2"/> Ipse Lucumo dictus, urbe Tarquiniis profectus Romam petiit. <milestone unit="par" n="3"/> Advenienti aquila pilleum sustulit et, cum alte subvolasset, reposuit. <milestone unit="par" n="4"/> Tanaquil coniux, auguriorum perita, regnum ei portendi intellexit. <milestone unit="par" n="5"/> Tarquinius pecunia et industria dignitatem atque etiam Anci regis familiaritatem consecutus est; a quo tutor liberis relictus regnum intercepit et ita administravit, quasi iure adeptus fuisset. <milestone unit="par" n="6"/> Centum patres in curiam legit, qui minorum gentium sunt appellati. <milestone unit="par" n="7"/> Equitum centurias numero duplicavit, nomina mutare non potuit Atti Nevii auguris auctoritate deterritus, qui fidem artis suae novacula et cote firmavit. <milestone unit="par" n="8"/> Latinos bello domuit. Circum maximum aedificavit. Ludos magnos instituit. De Sabinis et priscis Latinis triumphavit. Murum lapideum urbi circumdedit. <milestone unit="par" n="9"/> Filium XIII annorum, quod in proelio hostem percussisset, praetexta bullaque donavit, unde haec puerorum ingenuorum insignia esse coeperunt. <milestone unit="par" n="10"/> Post ab Anci liberis immissis percussoribus per dolum regia excitus et interfectus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Tarquinius Priscus</hi>, Demarati Corinthii filius, eius,
+               qui Cypseli tyrannidem fugiens in Etruriam commigravit. <milestone unit="par" n="2"/>
+               Ipse Lucumo dictus, urbe Tarquiniis profectus Romam petiit. <milestone unit="par"
+                  n="3"/> Advenienti aquila pilleum sustulit et, cum alte subvolasset, reposuit.
+                  <milestone unit="par" n="4"/> Tanaquil coniux, auguriorum perita, regnum ei
+               portendi intellexit. <milestone unit="par" n="5"/> Tarquinius pecunia et industria
+               dignitatem atque etiam Anci regis familiaritatem consecutus est; a quo tutor liberis
+               relictus regnum intercepit et ita administravit, quasi iure adeptus fuisset.
+                  <milestone unit="par" n="6"/> Centum patres in curiam legit, qui minorum gentium
+               sunt appellati. <milestone unit="par" n="7"/> Equitum centurias numero duplicavit,
+               nomina mutare non potuit Atti Nevii auguris auctoritate deterritus, qui fidem artis
+               suae novacula et cote firmavit. <milestone unit="par" n="8"/> Latinos bello domuit.
+               Circum maximum aedificavit. Ludos magnos instituit. De Sabinis et priscis Latinis
+               triumphavit. Murum lapideum urbi circumdedit. <milestone unit="par" n="9"/> Filium
+               XIII annorum, quod in proelio hostem percussisset, praetexta bullaque donavit, unde
+               haec puerorum ingenuorum insignia esse coeperunt. <milestone unit="par" n="10"/> Post
+               ab Anci liberis immissis percussoribus per dolum regia excitus et interfectus est.
+            </p>
          </div>
-            <div type="cap" n="7">
+         <div type="cap" n="7">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Servius Tullius</hi>, Tullii Corniculani et Ocresiae captivae filius, cum in domo Tarquinii Prisci educaretur, flammae species caput eius amplexa est. <milestone unit="par" n="2"/> Hoc visu Tanaquil summam dignitatem portendi intellexit. <milestone unit="par" n="3"/> Coniugi suasit, ut eum ita ut liberos suos educaret. <milestone unit="par" n="4"/> Qui cum adolevisset, gener a Tarquinio assumptus est, et cum rex occisus esset, Tanaquil ex altiore loco ad populum despiciens ait Priscum gravi quidem, sed non letali vulnere accepto petere, ut interim, dum convalescit, Servio Tullio dicto audientes essent. <milestone unit="par" n="5"/> Servius Tullius quasi precario regnare coepit, sed recte imperium administravit. <milestone unit="par" n="6"/> Etruscos saepe domuit, collem Quirinalem et Viminalem et Esquilias urbi addidit, aggerem fossasque fecit. <milestone unit="par" n="7"/> Populum in quattuor tribus distribuit ac post plebi distribuit annonam. <milestone unit="par" n="8"/> Mensuras pondera classes centuriasque constituit. <milestone unit="par" n="9"/> Latinorum populis persuasit, uti exemplo eorum, qui Dianae Ephesiae aedem fecissent, et ipsi aedem Dianae in Aventino aedificarent. <milestone unit="par" n="10"/> Quo facto bos cuidam Latino mirae magnitudinis nata, et responsum somnio datum eum populum summam imperii habiturum, cuius civis bovem illam Dianae immolasset. <milestone unit="par" n="11"/> Latinus bovem in Aventinum egit et causam sacerdoti Romano exposuit. <milestone unit="par" n="12"/> Ille callide dixit prius eum vivo flumine manus abluere debere. <milestone unit="par" n="13"/> Latinus dum ad Tiberim descendit, sacerdos bovem immolavit. <milestone unit="par" n="14"/> Ita imperium civibus, sibi gloriam facto consilioque quaesivit. </p>
-                <p>
-               <milestone unit="par" n="15"/> 
-               <hi rend="expanded">Servius Tullius</hi> filiam alteram ferocem, mitem alteram habens, cum Tarquinii filios pari animo videret, ut omnium mentes morum diversitate leniret, ferocem miti, mitem feroci in matrimonium dedit. <milestone unit="par" n="16"/> Sed mites seu forte seu fraude perierunt: feroces morum similitudo coniunxit. <milestone unit="par" n="17"/> Statim Tarquinius Superbus a Tullia incitatus advocato senatu regnum patrium repetere coepit. <milestone unit="par" n="18"/> Qua re audita Servius, dum ad curiam properat, iussu Tarquinii gradibus deiectus et domum refugiens interfectus est. <milestone unit="par" n="19"/> Tullia statim in forum properavit et prima coniugem regem salutavit, a quo iussa turba decedere, cum domum rediret, viso patris corpore mulionem evitantem super ipsum corpus carpentum agere praecepit: unde vicus ille Sceleratus dictus. Postea Tullia cum coniuge in exilium acta est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Servius Tullius</hi>, Tullii Corniculani et Ocresiae captivae
+               filius, cum in domo Tarquinii Prisci educaretur, flammae species caput eius amplexa
+               est. <milestone unit="par" n="2"/> Hoc visu Tanaquil summam dignitatem portendi
+               intellexit. <milestone unit="par" n="3"/> Coniugi suasit, ut eum ita ut liberos suos
+               educaret. <milestone unit="par" n="4"/> Qui cum adolevisset, gener a Tarquinio
+               assumptus est, et cum rex occisus esset, Tanaquil ex altiore loco ad populum
+               despiciens ait Priscum gravi quidem, sed non letali vulnere accepto petere, ut
+               interim, dum convalescit, Servio Tullio dicto audientes essent. <milestone unit="par"
+                  n="5"/> Servius Tullius quasi precario regnare coepit, sed recte imperium
+               administravit. <milestone unit="par" n="6"/> Etruscos saepe domuit, collem Quirinalem
+               et Viminalem et Esquilias urbi addidit, aggerem fossasque fecit. <milestone
+                  unit="par" n="7"/> Populum in quattuor tribus distribuit ac post plebi distribuit
+               annonam. <milestone unit="par" n="8"/> Mensuras pondera classes centuriasque
+               constituit. <milestone unit="par" n="9"/> Latinorum populis persuasit, uti exemplo
+               eorum, qui Dianae Ephesiae aedem fecissent, et ipsi aedem Dianae in Aventino
+               aedificarent. <milestone unit="par" n="10"/> Quo facto bos cuidam Latino mirae
+               magnitudinis nata, et responsum somnio datum eum populum summam imperii habiturum,
+               cuius civis bovem illam Dianae immolasset. <milestone unit="par" n="11"/> Latinus
+               bovem in Aventinum egit et causam sacerdoti Romano exposuit. <milestone unit="par"
+                  n="12"/> Ille callide dixit prius eum vivo flumine manus abluere debere.
+                  <milestone unit="par" n="13"/> Latinus dum ad Tiberim descendit, sacerdos bovem
+               immolavit. <milestone unit="par" n="14"/> Ita imperium civibus, sibi gloriam facto
+               consilioque quaesivit. </p>
+            <p>
+               <milestone unit="par" n="15"/>
+               <hi rend="expanded">Servius Tullius</hi> filiam alteram ferocem, mitem alteram
+               habens, cum Tarquinii filios pari animo videret, ut omnium mentes morum diversitate
+               leniret, ferocem miti, mitem feroci in matrimonium dedit. <milestone unit="par"
+                  n="16"/> Sed mites seu forte seu fraude perierunt: feroces morum similitudo
+               coniunxit. <milestone unit="par" n="17"/> Statim Tarquinius Superbus a Tullia
+               incitatus advocato senatu regnum patrium repetere coepit. <milestone unit="par"
+                  n="18"/> Qua re audita Servius, dum ad curiam properat, iussu Tarquinii gradibus
+               deiectus et domum refugiens interfectus est. <milestone unit="par" n="19"/> Tullia
+               statim in forum properavit et prima coniugem regem salutavit, a quo iussa turba
+               decedere, cum domum rediret, viso patris corpore mulionem evitantem super ipsum
+               corpus carpentum agere praecepit: unde vicus ille Sceleratus dictus. Postea Tullia
+               cum coniuge in exilium acta est. </p>
          </div>
-            <div type="cap" n="8">
+         <div type="cap" n="8">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Tarquinius Superbus</hi> cognomen moribus meruit. Occiso Servio Tullio regnum sceleste occupavit. <milestone unit="par" n="2"/> Tamen bello strenuus Latinos Sabinosque domuit; Suessam Pometiam Etruscis eripuit; Gabios per Sextum filium simulato transfugio in potestatem redegit et ferias Latinas primus instituit. <milestone unit="par" n="3"/> 
-               <unclear/>Ludos in circo et cloacam maximam fecit, ubi totius populi viribus usus est, unde illae fossae Quiritium sunt dictae. <milestone unit="par" n="4"/> Cum Capitolium inciperet, caput hominis invenit, unde cognitum eam urbem caput gentium futuram. <milestone unit="par" n="5"/> Et cum in obsidione Ardeae filius eius Lucretiae stuprum intulisset, cum eo in exilium actus ad Porsennam, Etruriae regem, confugit, cuius ope regnum retinere tentavit. <milestone unit="par" n="6"/> Pulsus Cumas concessit, ubi per summam ignominiam reliquum vitae tempus exegit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Tarquinius Superbus</hi> cognomen moribus meruit. Occiso Servio
+               Tullio regnum sceleste occupavit. <milestone unit="par" n="2"/> Tamen bello strenuus
+               Latinos Sabinosque domuit; Suessam Pometiam Etruscis eripuit; Gabios per Sextum
+               filium simulato transfugio in potestatem redegit et ferias Latinas primus instituit.
+                  <milestone unit="par" n="3"/>
+               <unclear/>Ludos in circo et cloacam maximam fecit, ubi totius populi viribus usus
+               est, unde illae fossae Quiritium sunt dictae. <milestone unit="par" n="4"/> Cum
+               Capitolium inciperet, caput hominis invenit, unde cognitum eam urbem caput gentium
+               futuram. <milestone unit="par" n="5"/> Et cum in obsidione Ardeae filius eius
+               Lucretiae stuprum intulisset, cum eo in exilium actus ad Porsennam, Etruriae regem,
+               confugit, cuius ope regnum retinere tentavit. <milestone unit="par" n="6"/> Pulsus
+               Cumas concessit, ubi per summam ignominiam reliquum vitae tempus exegit. </p>
          </div>
-            <div type="cap" n="9">
+         <div type="cap" n="9">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Tarquinius Collatinus</hi>, sorore Tarquinii Superbi genitus, in contubernio iuvenum regiorum Ardeae erat; ubi cum forte in liberiore convivio coniugem suam unusquisque laudaret, placuit experiri. Itaque equis Romam petunt. Regias nurus in convivio et luxu deprehendunt. <milestone unit="par" n="2"/> Inde Collatiam petunt. Lucretiam inter ancillas in lanificio offendunt: itaque ea pudicissima iudicatur. <milestone unit="par" n="3"/> Ad quam corrumpendam Tarquinius Sextus nocte Collatiam rediit et iure propinquitatis in domum Collatini venit et cubiculum Lucretiae irrupit, pudicitiam expugnavit. <milestone unit="par" n="4"/> Illa postero die advocatis patre et coniuge rem exposuit et se cultro, quem veste texerat, occidit. <milestone unit="par" n="5"/> Illi in exitium regum coniurarunt eorumque exilio necem Lucretiae vindicaverunt. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Tarquinius Collatinus</hi>, sorore Tarquinii Superbi genitus, in
+               contubernio iuvenum regiorum Ardeae erat; ubi cum forte in liberiore convivio
+               coniugem suam unusquisque laudaret, placuit experiri. Itaque equis Romam petunt.
+               Regias nurus in convivio et luxu deprehendunt. <milestone unit="par" n="2"/> Inde
+               Collatiam petunt. Lucretiam inter ancillas in lanificio offendunt: itaque ea
+               pudicissima iudicatur. <milestone unit="par" n="3"/> Ad quam corrumpendam Tarquinius
+               Sextus nocte Collatiam rediit et iure propinquitatis in domum Collatini venit et
+               cubiculum Lucretiae irrupit, pudicitiam expugnavit. <milestone unit="par" n="4"/>
+               Illa postero die advocatis patre et coniuge rem exposuit et se cultro, quem veste
+               texerat, occidit. <milestone unit="par" n="5"/> Illi in exitium regum coniurarunt
+               eorumque exilio necem Lucretiae vindicaverunt. </p>
          </div>
-            <div type="cap" n="10">
+         <div type="cap" n="10">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Iunius Brutus</hi> sorore Tarquinii Superbi genitus cum eandem fortunam timeret, in quam frater inciderat, qui ob divitias et prudentiam ab avunculo fuerat occisus, stultitiam finxit, unde Brutus dictus. <milestone unit="par" n="2"/> Iuvenibus regiis Delphos euntibus deridiculi gratia comes adscitus baculo sambuceo aurum infusum deo donum tulit. <milestone unit="par" n="3"/> Vbi responsum est eum Romae summam potestatem habiturum, qui primus matrem oscularetur, ipse terram osculatus est. <milestone unit="par" n="4"/> Deinde propter Lucretiae stuprum cum Tricipitino et Collatino in exitium regum coniuravit. <milestone unit="par" n="5"/> Quibus in exilium actis primus consul creatus filios suos, quod cum Aquiliis et Vitelliis ad recipiendos in urbem Tarquinios coniurarant, virgis caesos securi percussit. <milestone unit="par" n="6"/> Deinde in proelio, quod adversus eos gerebat, singulari certamine cum Arunte filio Tarquinii congressus est, ubi ambo mutuis vulneribus ceciderunt. <milestone unit="par" n="7"/> Cuius corpus in foro positum a collega laudatum matronae anno luxerunt. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Iunius Brutus</hi> sorore Tarquinii Superbi genitus cum eandem
+               fortunam timeret, in quam frater inciderat, qui ob divitias et prudentiam ab avunculo
+               fuerat occisus, stultitiam finxit, unde Brutus dictus. <milestone unit="par" n="2"/>
+               Iuvenibus regiis Delphos euntibus deridiculi gratia comes adscitus baculo sambuceo
+               aurum infusum deo donum tulit. <milestone unit="par" n="3"/> Vbi responsum est eum
+               Romae summam potestatem habiturum, qui primus matrem oscularetur, ipse terram
+               osculatus est. <milestone unit="par" n="4"/> Deinde propter Lucretiae stuprum cum
+               Tricipitino et Collatino in exitium regum coniuravit. <milestone unit="par" n="5"/>
+               Quibus in exilium actis primus consul creatus filios suos, quod cum Aquiliis et
+               Vitelliis ad recipiendos in urbem Tarquinios coniurarant, virgis caesos securi
+               percussit. <milestone unit="par" n="6"/> Deinde in proelio, quod adversus eos
+               gerebat, singulari certamine cum Arunte filio Tarquinii congressus est, ubi ambo
+               mutuis vulneribus ceciderunt. <milestone unit="par" n="7"/> Cuius corpus in foro
+               positum a collega laudatum matronae anno luxerunt. </p>
          </div>
-            <div type="cap" n="11">
+         <div type="cap" n="11">
             <p>
-               <milestone unit="par" n="1"/> Porsenna rex Etruscorum cum Tarquinios in urbem restituere temptaret et primo impetu Ianiculum cepisset, <hi rend="expanded">Horatius Cocles</hi> (illo cognomine, quod in alio proelio oculum amiserat) pro ponte sublicio stetit et aciem hostium solus sustinuit, donec pons a tergo interrumperetur, cum quo in Tiberim decidit et armatus ad suos transnavit. <milestone unit="par" n="2"/> Ob hoc ei tantum agri publice datum, quantum uno die ambire <supplied>vomere</supplied> potuisset. Statua quoque ei in Vulcanali posita. </p>
+               <milestone unit="par" n="1"/> Porsenna rex Etruscorum cum Tarquinios in urbem
+               restituere temptaret et primo impetu Ianiculum cepisset, <hi rend="expanded">Horatius
+                  Cocles</hi> (illo cognomine, quod in alio proelio oculum amiserat) pro ponte
+               sublicio stetit et aciem hostium solus sustinuit, donec pons a tergo interrumperetur,
+               cum quo in Tiberim decidit et armatus ad suos transnavit. <milestone unit="par" n="2"
+               /> Ob hoc ei tantum agri publice datum, quantum uno die ambire
+                  <supplied>vomere</supplied> potuisset. Statua quoque ei in Vulcanali posita. </p>
          </div>
-            <div type="cap" n="12">
+         <div type="cap" n="12">
             <p>
-               <milestone unit="par" n="1"/> Cum Porsenna rex urbem obsideret, <hi rend="expanded">Mucius Cordus</hi>, vir Romanae constantiae, senatum adiit et veniam transfugiendi petiit necem regis repromittens. <milestone unit="par" n="2"/> Accepta potestate in castra Porsennae venit ibique purpuratum pro rege deceptus occidit. <milestone unit="par" n="3"/> Apprehensus et ad regem pertractus dextram aris imposuit, hoc supplicii a rea exigens, quod in caede peccasset. <milestone unit="par" n="4"/> Vnde cum misericordia regis abstraheretur, quasi beneficium referens ait trecentos adversus eum similes coniurasse. <milestone unit="par" n="5"/> Qua re ille territus bellum acceptis obsidibus deposuit. <milestone unit="par" n="6"/> Mucio prata trans Tiberim data, ab eo Mucia appellata. <milestone unit="par" n="7"/> Statua quoque ei honoris gratia constituta est. </p>
+               <milestone unit="par" n="1"/> Cum Porsenna rex urbem obsideret, <hi rend="expanded"
+                  >Mucius Cordus</hi>, vir Romanae constantiae, senatum adiit et veniam
+               transfugiendi petiit necem regis repromittens. <milestone unit="par" n="2"/> Accepta
+               potestate in castra Porsennae venit ibique purpuratum pro rege deceptus occidit.
+                  <milestone unit="par" n="3"/> Apprehensus et ad regem pertractus dextram aris
+               imposuit, hoc supplicii a rea exigens, quod in caede peccasset. <milestone unit="par"
+                  n="4"/> Vnde cum misericordia regis abstraheretur, quasi beneficium referens ait
+               trecentos adversus eum similes coniurasse. <milestone unit="par" n="5"/> Qua re ille
+               territus bellum acceptis obsidibus deposuit. <milestone unit="par" n="6"/> Mucio
+               prata trans Tiberim data, ab eo Mucia appellata. <milestone unit="par" n="7"/> Statua
+               quoque ei honoris gratia constituta est. </p>
          </div>
-            <div type="cap" n="13">
+         <div type="cap" n="13">
             <p>
-               <milestone unit="par" n="1"/> Porsenna <hi rend="expanded">Cloeliam</hi> nobilem virginem inter obsides accepit, quae deceptis custodibus noctu castris eius egressa equum, quem fors dederat, arripuit et Tiberim traiecit. <milestone unit="par" n="2"/> A Porsenna per legatos repetita reddita est. <milestone unit="par" n="3"/> Cuius ille virtutem admiratus cum quibus optasset in patriam redire permisit. <milestone unit="par" n="4"/> Illa virgines puerosque elegit, quorum aetatem iniuriae obnoxiam sciebat. Huic statua equestris in foro posita. </p>
+               <milestone unit="par" n="1"/> Porsenna <hi rend="expanded">Cloeliam</hi> nobilem
+               virginem inter obsides accepit, quae deceptis custodibus noctu castris eius egressa
+               equum, quem fors dederat, arripuit et Tiberim traiecit. <milestone unit="par" n="2"/>
+               A Porsenna per legatos repetita reddita est. <milestone unit="par" n="3"/> Cuius ille
+               virtutem admiratus cum quibus optasset in patriam redire permisit. <milestone
+                  unit="par" n="4"/> Illa virgines puerosque elegit, quorum aetatem iniuriae
+               obnoxiam sciebat. Huic statua equestris in foro posita. </p>
          </div>
-            <div type="cap" n="14">
+         <div type="cap" n="14">
             <p>
-               <milestone unit="par" n="1"/> Romani cum adversus Veientes bellarent, eos sibi hostes <hi rend="expanded">familia Fabiorum</hi> privato nomine depoposcit; et profecti trecenti sex duce Fabio consule. <milestone unit="par" n="2"/> Cum saepe victores exstitissent, apud Cremeram fluvium castra posuere. <milestone unit="par" n="3"/> Veientes ad dolos conversi pecora ex diverso in conspectu illorum protulerunt, ad quae progressi Fabii in insidias delapsi usque ad unum occisione perierunt. <milestone unit="par" n="4"/> Dies, quo id factum est, inter nefastos relatus. <milestone unit="par" n="5"/> Porta, qua profecti erant, Scelerata est appellata. <milestone unit="par" n="6"/> Vnus ex ea gente propter impuberem aetatem domi relictus genus propagavit ad Q. Fabium Maximum, qui Hannibalem mora fregit, Cunctator ab obtrectatoribus dictus. </p>
+               <milestone unit="par" n="1"/> Romani cum adversus Veientes bellarent, eos sibi hostes
+                  <hi rend="expanded">familia Fabiorum</hi> privato nomine depoposcit; et profecti
+               trecenti sex duce Fabio consule. <milestone unit="par" n="2"/> Cum saepe victores
+               exstitissent, apud Cremeram fluvium castra posuere. <milestone unit="par" n="3"/>
+               Veientes ad dolos conversi pecora ex diverso in conspectu illorum protulerunt, ad
+               quae progressi Fabii in insidias delapsi usque ad unum occisione perierunt.
+                  <milestone unit="par" n="4"/> Dies, quo id factum est, inter nefastos relatus.
+                  <milestone unit="par" n="5"/> Porta, qua profecti erant, Scelerata est appellata.
+                  <milestone unit="par" n="6"/> Vnus ex ea gente propter impuberem aetatem domi
+               relictus genus propagavit ad Q. Fabium Maximum, qui Hannibalem mora fregit, Cunctator
+               ab obtrectatoribus dictus. </p>
          </div>
-            <div type="cap" n="15">
+         <div type="cap" n="15">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Valerius</hi>, Volesi filius, primo de Veientibus, iterum de Sabinis, tertio de utrisque gentibus triumphavit. <milestone unit="par" n="2"/> Hic, quia in locum Tricipitini collegae consulem non subrogaverat et domum in Velia tutissimo loco habebat, in suspicionem regni affectati venit. <milestone unit="par" n="3"/> Quo cognito apud populum questus est, quod de se tale aliquid timuissent, et immisit, qui domum suam diruerent. <milestone unit="par" n="4"/> Secures etiam fascibus dempsit eosque in populi contione submisit. <milestone unit="par" n="5"/> Legem de provocatione a magistratibus ad populum tulit. <milestone unit="par" n="6"/> Hinc Publicola dictus. Cum diem obisset, publice sepultus et annuo matronarum luctu honoratus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Valerius</hi>, Volesi filius, primo de Veientibus, iterum
+               de Sabinis, tertio de utrisque gentibus triumphavit. <milestone unit="par" n="2"/>
+               Hic, quia in locum Tricipitini collegae consulem non subrogaverat et domum in Velia
+               tutissimo loco habebat, in suspicionem regni affectati venit. <milestone unit="par"
+                  n="3"/> Quo cognito apud populum questus est, quod de se tale aliquid timuissent,
+               et immisit, qui domum suam diruerent. <milestone unit="par" n="4"/> Secures etiam
+               fascibus dempsit eosque in populi contione submisit. <milestone unit="par" n="5"/>
+               Legem de provocatione a magistratibus ad populum tulit. <milestone unit="par" n="6"/>
+               Hinc Publicola dictus. Cum diem obisset, publice sepultus et annuo matronarum luctu
+               honoratus est. </p>
          </div>
-            <div type="cap" n="16">
+         <div type="cap" n="16">
             <p>
-               <milestone unit="par" n="1"/> Tarquinius eiectus ad Mamilium Tusculanum generum suum confugit; qui cum Latio concitato Romanos graviter urgeret, <hi rend="expanded">A. Postumius</hi> dictator dictus apud Regilli lacum cum hostibus conflixit. <milestone unit="par" n="2"/> Vbi cum victoria nutaret, magister equitum equis frenos detrahi iussit, ut irrevocabili impetu ferrentur; ubi et aciem Latinorum fuderunt et castra ceperunt. <milestone unit="par" n="3"/> Sed inter eos duo iuvenes candidis equis insigni virtute apparuerunt, quos dictator quaesitos, ut dignis muneribus honoraret, non reperit: Castorem et Pollucem ratus communi titulo dedicavit. </p>
+               <milestone unit="par" n="1"/> Tarquinius eiectus ad Mamilium Tusculanum generum suum
+               confugit; qui cum Latio concitato Romanos graviter urgeret, <hi rend="expanded">A.
+                  Postumius</hi> dictator dictus apud Regilli lacum cum hostibus conflixit.
+                  <milestone unit="par" n="2"/> Vbi cum victoria nutaret, magister equitum equis
+               frenos detrahi iussit, ut irrevocabili impetu ferrentur; ubi et aciem Latinorum
+               fuderunt et castra ceperunt. <milestone unit="par" n="3"/> Sed inter eos duo iuvenes
+               candidis equis insigni virtute apparuerunt, quos dictator quaesitos, ut dignis
+               muneribus honoraret, non reperit: Castorem et Pollucem ratus communi titulo
+               dedicavit. </p>
          </div>
-            <div type="cap" n="17">
+         <div type="cap" n="17">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Quinctius Cincinnatus</hi> filium Caesonem petulantissimum abdicavit, qui et a censoribus notatus ad Volscos et Sabinos confugit, qui duce Cloelio Graccho bellum adversus Romanos gerebant et Q. Minucium consulem in Algido monte cum exercitu obsidebant. Quinctius dictator dictus, ad quem missi legati nudum eum arantem trans Tiberim offenderunt; qui insignibus sumptis consulem obsidio liberavit. <milestone unit="par" n="2"/> Quare a Minucio et eius exercitu corona aurea <del>et</del> obsidionali donatus est. <milestone unit="par" n="3"/> Vicit hostes; ducem eorum in deditionem accepit et triumphi die ante currum egit. <milestone unit="par" n="4"/> Sextodecimo die dictaturam, quam acceperat, deposuit et ad agricultum reversus est. <milestone unit="par" n="5"/> Iterum post viginti annos dictator dictus Spurium Maelium regnum affectantem a Servilio Ahala magistro equitum occidi iussit; domum eius solo aequavit: unde locus <del>ille</del> Aequimelium dicitur. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Quinctius Cincinnatus</hi> filium Caesonem petulantissimum
+               abdicavit, qui et a censoribus notatus ad Volscos et Sabinos confugit, qui duce
+               Cloelio Graccho bellum adversus Romanos gerebant et Q. Minucium consulem in Algido
+               monte cum exercitu obsidebant. Quinctius dictator dictus, ad quem missi legati nudum
+               eum arantem trans Tiberim offenderunt; qui insignibus sumptis consulem obsidio
+               liberavit. <milestone unit="par" n="2"/> Quare a Minucio et eius exercitu corona
+               aurea <del>et</del> obsidionali donatus est. <milestone unit="par" n="3"/> Vicit
+               hostes; ducem eorum in deditionem accepit et triumphi die ante currum egit.
+                  <milestone unit="par" n="4"/> Sextodecimo die dictaturam, quam acceperat, deposuit
+               et ad agricultum reversus est. <milestone unit="par" n="5"/> Iterum post viginti
+               annos dictator dictus Spurium Maelium regnum affectantem a Servilio Ahala magistro
+               equitum occidi iussit; domum eius solo aequavit: unde locus <del>ille</del>
+               Aequimelium dicitur. </p>
          </div>
-            <div type="cap" n="18">
+         <div type="cap" n="18">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Menenius Agrippa</hi> cognomento Lanatus dux electus adversus Sabinos de his triumphavit. <milestone unit="par" n="2"/> Et cum populus a patribus secessisset, quod tributum et militiam toleraret, nec revocari posset, Agrippa apud eum: <hi rend="italic">Olim</hi>, inquit, <hi rend="italic">humani artus, cum ventrem otiosum cernerent, ab eo discordarunt et suum illi ministerium negaverunt. <milestone unit="par" n="3"/> Cum eo pacto et ipsi deficerent, intellexerunt ventrem acceptos cibos per omnia membra disserere et cum eo in gratiam redierunt. <milestone unit="par" n="4"/> Sic senatus et populus quasi unum corpus discordia pereunt, concordia valent.</hi> 
-               <milestone unit="par" n="5"/> Hac fabula populus regressus est. <milestone unit="par" n="6"/> Creavit tamen tribunos plebis, qui libertatem suam adversum nobilitatis superbiam defenderent. <milestone unit="par" n="7"/> Menenius autem tanta paupertate decessit, ut eum populus collatis quadrantibus sepeliret, locum sepulcro senatus publice daret. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Menenius Agrippa</hi> cognomento Lanatus dux electus adversus
+               Sabinos de his triumphavit. <milestone unit="par" n="2"/> Et cum populus a patribus
+               secessisset, quod tributum et militiam toleraret, nec revocari posset, Agrippa apud
+               eum: <hi rend="italic">Olim</hi>, inquit, <hi rend="italic">humani artus, cum ventrem
+                  otiosum cernerent, ab eo discordarunt et suum illi ministerium negaverunt.
+                     <milestone unit="par" n="3"/> Cum eo pacto et ipsi deficerent, intellexerunt
+                  ventrem acceptos cibos per omnia membra disserere et cum eo in gratiam redierunt.
+                     <milestone unit="par" n="4"/> Sic senatus et populus quasi unum corpus
+                  discordia pereunt, concordia valent.</hi>
+               <milestone unit="par" n="5"/> Hac fabula populus regressus est. <milestone unit="par"
+                  n="6"/> Creavit tamen tribunos plebis, qui libertatem suam adversum nobilitatis
+               superbiam defenderent. <milestone unit="par" n="7"/> Menenius autem tanta paupertate
+               decessit, ut eum populus collatis quadrantibus sepeliret, locum sepulcro senatus
+               publice daret. </p>
          </div>
-            <div type="cap" n="19">
+         <div type="cap" n="19">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gnaeus Marcius</hi>, captis Coriolis urbe Volscorum Coriolanus dictus, ob egregia militiae facinora a Postumio optionem munerum accipiens equum tantum et hospitem sumpsit, virtutis et pietatis exemplum. <milestone unit="par" n="2"/> Hic consul gravi annona advectum e Sicilia frumentum magno pretio populo dandum curavit, ut hac iniuria plebs agros, non seditiones coleret. <milestone unit="par" n="3"/> Ergo a tribuno plebis Decio die dicta ad Volscos concessit eosque duce Tito Tatio adversus Romanos concitavit et ad quartum ab urbe lapidem castra posuit. <milestone unit="par" n="4"/> Cumque nullis civium legationibus flecteretur, a Veturia matre et Volumnia uxore matronarum numero comitatis motus omisso bello ut proditor occisus. <milestone unit="par" n="5"/> Ibi templum Fortunae muliebri constitutum est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gnaeus Marcius</hi>, captis Coriolis urbe Volscorum Coriolanus
+               dictus, ob egregia militiae facinora a Postumio optionem munerum accipiens equum
+               tantum et hospitem sumpsit, virtutis et pietatis exemplum. <milestone unit="par"
+                  n="2"/> Hic consul gravi annona advectum e Sicilia frumentum magno pretio populo
+               dandum curavit, ut hac iniuria plebs agros, non seditiones coleret. <milestone
+                  unit="par" n="3"/> Ergo a tribuno plebis Decio die dicta ad Volscos concessit
+               eosque duce Tito Tatio adversus Romanos concitavit et ad quartum ab urbe lapidem
+               castra posuit. <milestone unit="par" n="4"/> Cumque nullis civium legationibus
+               flecteretur, a Veturia matre et Volumnia uxore matronarum numero comitatis motus
+               omisso bello ut proditor occisus. <milestone unit="par" n="5"/> Ibi templum Fortunae
+               muliebri constitutum est. </p>
          </div>
-            <div type="cap" n="20">
+         <div type="cap" n="20">
             <p>
-               <milestone unit="par" n="1"/> Fabius Ambustus ex duabus filiabus alteram <hi rend="expanded">Licinio Stoloni</hi> plebeio, alteram Aulo Sulpicio patricio coniugem dedit. Quarum plebeia cum sororem salutaret, cuius vir tribunus militaris consulari potestate erat, fasces lictorios foribus appositos indecenter expavit. A sorore irrisa marito questa est; qui adiuvante socero, ut primum tribunatum plebis aggressus est, legem tulit, ut alter consul ex plebe crearetur. Lex resistente Appio Claudio tamen lata; <milestone unit="par" n="2"/> et primus Licinius Stolo consul factus. <milestone unit="par" n="3"/> Idem lege cavit, ne cui plus quingenta iugera agri habere liceret. <milestone unit="par" n="4"/> Et ipse cum iugera quingenta haberet, altera emancipati filii nomine possideret, in iudicium vocatus et primus omnium sua lege punitus est. </p>
+               <milestone unit="par" n="1"/> Fabius Ambustus ex duabus filiabus alteram <hi
+                  rend="expanded">Licinio Stoloni</hi> plebeio, alteram Aulo Sulpicio patricio
+               coniugem dedit. Quarum plebeia cum sororem salutaret, cuius vir tribunus militaris
+               consulari potestate erat, fasces lictorios foribus appositos indecenter expavit. A
+               sorore irrisa marito questa est; qui adiuvante socero, ut primum tribunatum plebis
+               aggressus est, legem tulit, ut alter consul ex plebe crearetur. Lex resistente Appio
+               Claudio tamen lata; <milestone unit="par" n="2"/> et primus Licinius Stolo consul
+               factus. <milestone unit="par" n="3"/> Idem lege cavit, ne cui plus quingenta iugera
+               agri habere liceret. <milestone unit="par" n="4"/> Et ipse cum iugera quingenta
+               haberet, altera emancipati filii nomine possideret, in iudicium vocatus et primus
+               omnium sua lege punitus est. </p>
          </div>
-            <div type="cap" n="21">
+         <div type="cap" n="21">
             <p>
-               <milestone unit="par" n="1"/> Populus Romanus cum seditiosos magistratus ferre non posset, <hi rend="expanded">decemviros</hi> legibus scribendis creavit, qui eas ex libris Solonis translatas duodecim tabulis exposuerunt. <milestone unit="par" n="2"/> Sed cum pacto dominationis magistratum sibi prorogarent, unus ex his Appius Claudius Virginiam, Virginii centurionis filiam in Algido militantis, adamavit. Quam cum corrumpere non posset, clientem subornavit, qui eam in servitium deposceret, facile victurus, cum ipse esset et accusator et iudex. <milestone unit="par" n="3"/> Pater re cognita cum ipso die iudicii supervenisset et filiam iam addictam videret, ultimo eius colloquio impetrato eam in secretum abduxit et occidit; et corpus eius humeris gerens ad exercitum profugit et milites ad vindicandum facinus accendit; qui creatis decem tribunis Aventinum occuparunt, decemviros abdicare se magistratu coegerunt eosque omnes aut morte aut exilio punierunt. Appius Claudius in carcere necatus est. </p>
+               <milestone unit="par" n="1"/> Populus Romanus cum seditiosos magistratus ferre non
+               posset, <hi rend="expanded">decemviros</hi> legibus scribendis creavit, qui eas ex
+               libris Solonis translatas duodecim tabulis exposuerunt. <milestone unit="par" n="2"/>
+               Sed cum pacto dominationis magistratum sibi prorogarent, unus ex his Appius Claudius
+               Virginiam, Virginii centurionis filiam in Algido militantis, adamavit. Quam cum
+               corrumpere non posset, clientem subornavit, qui eam in servitium deposceret, facile
+               victurus, cum ipse esset et accusator et iudex. <milestone unit="par" n="3"/> Pater
+               re cognita cum ipso die iudicii supervenisset et filiam iam addictam videret, ultimo
+               eius colloquio impetrato eam in secretum abduxit et occidit; et corpus eius humeris
+               gerens ad exercitum profugit et milites ad vindicandum facinus accendit; qui creatis
+               decem tribunis Aventinum occuparunt, decemviros abdicare se magistratu coegerunt
+               eosque omnes aut morte aut exilio punierunt. Appius Claudius in carcere necatus est.
+            </p>
          </div>
-            <div type="cap" n="22">
+         <div type="cap" n="22">
             <p>
-               <milestone unit="par" n="1"/> Romani ob pestilentiam responso monente ad <hi rend="expanded">Aesculapium</hi> Epidauro arcessendum decem legatos principe Q. Ogulnio miserunt. <milestone unit="par" n="2"/> Qui cum eo venissent et simulacrum ingens mirarentur, anguis e sedibus eius elapsus venerabilis, non horribilis, per mediam urbem cum admiratione omnium ad navem Romanam perrexit et se in Ogulnii tabernaculo conspiravit. <milestone unit="par" n="3"/> Legati deum vehentes Antium pervecti, ubi per mollitiem maris anguis proximum Aesculapii fanum petiit et post paucos dies ad navem rediit; et cum adverso Tiberi subveheretur, in proximam insulam desilivit, ubi templum ei constitutum et pestilentia mira celeritate sedata est. </p>
+               <milestone unit="par" n="1"/> Romani ob pestilentiam responso monente ad <hi
+                  rend="expanded">Aesculapium</hi> Epidauro arcessendum decem legatos principe Q.
+               Ogulnio miserunt. <milestone unit="par" n="2"/> Qui cum eo venissent et simulacrum
+               ingens mirarentur, anguis e sedibus eius elapsus venerabilis, non horribilis, per
+               mediam urbem cum admiratione omnium ad navem Romanam perrexit et se in Ogulnii
+               tabernaculo conspiravit. <milestone unit="par" n="3"/> Legati deum vehentes Antium
+               pervecti, ubi per mollitiem maris anguis proximum Aesculapii fanum petiit et post
+               paucos dies ad navem rediit; et cum adverso Tiberi subveheretur, in proximam insulam
+               desilivit, ubi templum ei constitutum et pestilentia mira celeritate sedata est. </p>
          </div>
-            <div type="cap" n="23">
+         <div type="cap" n="23">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Furius Camillus</hi> cum Faliscos obsideret ac ludi litterarii magister principum filios ad eum adduxisset, vinctum eum iisdem pueris in urbem redigendum et verberandum tradidit. <milestone unit="par" n="2"/> Statim Falisci se ei ob tantam iustitiam dediderunt. <milestone unit="par" n="3"/> Veios hieme obsidio domuit deque his triumphavit. <milestone unit="par" n="4"/> Postmodum crimini datum, quod albis equis triumphasset et praedam inique divisisset: die dicta ab Apuleio Saturnino tribuno plebis damnatus Ardeam concessit. <milestone unit="par" n="5"/> Mox cum Galli Senones relictis ob sterilitatem agris suis Clusium Italiae oppidum obsiderent, missi sunt Roma tres Fabii, qui Gallos monerent, ut ab oppugnatione desisterent. <milestone unit="par" n="6"/> Ex his unus contra ius gentium in aciem processit et ducem Senonum interfecit. <milestone unit="par" n="7"/> Quo commoti Galli petitis in deditionem legatis nec impetratis Romam petierunt et exercitum Romanum apud Alliam fluvium ceciderunt, die XVI Kal. August.; qui dies inter nefastos relatus, Alliensis dictus. <milestone unit="par" n="8"/> Victores Galli urbem intraverunt, ubi nobilissimos senum in curulibus et honorum insignibus primo ut deos venerati, deinde ut homines despicati interfecere. <milestone unit="par" n="9"/> Reliqua iuventus cum Manlio in Capitolium fugit, ubi obsessa Camilli virtute est servata. Qui absens dictator dictus collectis reliquiis Gallos improvisos internecione occidit. <milestone unit="par" n="10"/> Populum Romanum migrare Veios volentem retinuit. Sic et oppidum civibus et cives oppido reddidit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Furius Camillus</hi> cum Faliscos obsideret ac ludi litterarii
+               magister principum filios ad eum adduxisset, vinctum eum iisdem pueris in urbem
+               redigendum et verberandum tradidit. <milestone unit="par" n="2"/> Statim Falisci se
+               ei ob tantam iustitiam dediderunt. <milestone unit="par" n="3"/> Veios hieme obsidio
+               domuit deque his triumphavit. <milestone unit="par" n="4"/> Postmodum crimini datum,
+               quod albis equis triumphasset et praedam inique divisisset: die dicta ab Apuleio
+               Saturnino tribuno plebis damnatus Ardeam concessit. <milestone unit="par" n="5"/> Mox
+               cum Galli Senones relictis ob sterilitatem agris suis Clusium Italiae oppidum
+               obsiderent, missi sunt Roma tres Fabii, qui Gallos monerent, ut ab oppugnatione
+               desisterent. <milestone unit="par" n="6"/> Ex his unus contra ius gentium in aciem
+               processit et ducem Senonum interfecit. <milestone unit="par" n="7"/> Quo commoti
+               Galli petitis in deditionem legatis nec impetratis Romam petierunt et exercitum
+               Romanum apud Alliam fluvium ceciderunt, die XVI Kal. August.; qui dies inter nefastos
+               relatus, Alliensis dictus. <milestone unit="par" n="8"/> Victores Galli urbem
+               intraverunt, ubi nobilissimos senum in curulibus et honorum insignibus primo ut deos
+               venerati, deinde ut homines despicati interfecere. <milestone unit="par" n="9"/>
+               Reliqua iuventus cum Manlio in Capitolium fugit, ubi obsessa Camilli virtute est
+               servata. Qui absens dictator dictus collectis reliquiis Gallos improvisos
+               internecione occidit. <milestone unit="par" n="10"/> Populum Romanum migrare Veios
+               volentem retinuit. Sic et oppidum civibus et cives oppido reddidit. </p>
          </div>
-            <div type="cap" n="24">
+         <div type="cap" n="24">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Manlius</hi> ob defensum Capitolium Capitolinus dictus sedecim annorum voluntarium militem se obtulit. <milestone unit="par" n="2"/> Triginta septem militaribus donis a suis ducibus ornatus viginti tres cicatrices in corpore habuit. <milestone unit="par" n="3"/> Capta urbe auctor in Capitolium confugiendi fuit. <milestone unit="par" n="4"/> Quadam nocte clangore anseris excitatus Gallos ascendentes deiecit. Patronus a civibus appellatus et farre donatus. <milestone unit="par" n="5"/> Domum etiam in Capitolio publice accepit. Qua superbia elatus cum a senatu suppressisse Gallicos thesauros argueretur et addictos propria pecunia liberaret, regni affectati <supplied>suspectus</supplied> in carcerem coniectus populi consensu liberatus est. <milestone unit="par" n="6"/> Rursus cum in eadem culpa et gravius perseveraret, reus factus et ob conspectum Capitolii ampliatus est. Alio deinde loco damnatus et de saxo Tarpeio praecipitatus, domus diruta, bona publicata. <milestone unit="par" n="7"/> Gentilitas eius Manlii cognomen eiuravit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Manlius</hi> ob defensum Capitolium Capitolinus dictus sedecim
+               annorum voluntarium militem se obtulit. <milestone unit="par" n="2"/> Triginta septem
+               militaribus donis a suis ducibus ornatus viginti tres cicatrices in corpore habuit.
+                  <milestone unit="par" n="3"/> Capta urbe auctor in Capitolium confugiendi fuit.
+                  <milestone unit="par" n="4"/> Quadam nocte clangore anseris excitatus Gallos
+               ascendentes deiecit. Patronus a civibus appellatus et farre donatus. <milestone
+                  unit="par" n="5"/> Domum etiam in Capitolio publice accepit. Qua superbia elatus
+               cum a senatu suppressisse Gallicos thesauros argueretur et addictos propria pecunia
+               liberaret, regni affectati <supplied>suspectus</supplied> in carcerem coniectus
+               populi consensu liberatus est. <milestone unit="par" n="6"/> Rursus cum in eadem
+               culpa et gravius perseveraret, reus factus et ob conspectum Capitolii ampliatus est.
+               Alio deinde loco damnatus et de saxo Tarpeio praecipitatus, domus diruta, bona
+               publicata. <milestone unit="par" n="7"/> Gentilitas eius Manlii cognomen eiuravit.
+            </p>
          </div>
-            <div type="cap" n="25">
+         <div type="cap" n="25">
             <p>
-               <milestone unit="par" n="1"/> Fidenates, veteres Romanorum hostes, ut sine spe veniae fortius dimicarent, legatos ad se missos interfecerunt; ad quos Quinctius Cincinnatus dictator missus magistrum equitum habuit <hi rend="expanded">Cornelium Cossum</hi>, qui Lartem Tolumnium ducem sua manu interfecit. <milestone unit="par" n="2"/> De eo spolia opima Iovi Feretrio secundus a Romulo consecravit. </p>
+               <milestone unit="par" n="1"/> Fidenates, veteres Romanorum hostes, ut sine spe veniae
+               fortius dimicarent, legatos ad se missos interfecerunt; ad quos Quinctius Cincinnatus
+               dictator missus magistrum equitum habuit <hi rend="expanded">Cornelium Cossum</hi>,
+               qui Lartem Tolumnium ducem sua manu interfecit. <milestone unit="par" n="2"/> De eo
+               spolia opima Iovi Feretrio secundus a Romulo consecravit. </p>
          </div>
-            <div type="cap" n="26">
+         <div type="cap" n="26">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Publius Decius Mus</hi> bello Samnitico sub Valerio Maximo et Cornelio Cosso consulibus tribunus militum exercitu in angustiis Gauri montis insidiis hostium clauso, accepto quod postulaverat praesidio in superiorem locum evasit, hostes terruit. <milestone unit="par" n="2"/> Ipse intempesta nocte per medias custodias somno oppressas incolumis evasit. <milestone unit="par" n="3"/> Ob hoc ab exercitu civica corona donatus est. <milestone unit="par" n="4"/> Consul bello Latino collega Manlio Torquato positis apud Veserim fluvium castris, cum utrique consuli somnio obvenisset eos victores futuros, quorum dux in proelio cecidisset, <milestone unit="par" n="5"/> tum collato cum collega somnio cum convenisset, ut, cuius cornu in acie laboraret, diis se manibus voveret, inclinante sua parte se et hostes per Valerium pontificem diis manibus devovit. Impetu in hostes facto victoriam suis reliquit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Publius Decius Mus</hi> bello Samnitico sub Valerio Maximo et
+               Cornelio Cosso consulibus tribunus militum exercitu in angustiis Gauri montis
+               insidiis hostium clauso, accepto quod postulaverat praesidio in superiorem locum
+               evasit, hostes terruit. <milestone unit="par" n="2"/> Ipse intempesta nocte per
+               medias custodias somno oppressas incolumis evasit. <milestone unit="par" n="3"/> Ob
+               hoc ab exercitu civica corona donatus est. <milestone unit="par" n="4"/> Consul bello
+               Latino collega Manlio Torquato positis apud Veserim fluvium castris, cum utrique
+               consuli somnio obvenisset eos victores futuros, quorum dux in proelio cecidisset,
+                  <milestone unit="par" n="5"/> tum collato cum collega somnio cum convenisset, ut,
+               cuius cornu in acie laboraret, diis se manibus voveret, inclinante sua parte se et
+               hostes per Valerium pontificem diis manibus devovit. Impetu in hostes facto victoriam
+               suis reliquit. </p>
          </div>
-            <div type="cap" n="27">
+         <div type="cap" n="27">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Publius Decius</hi> Decii filius primo consul de Samnitibus triumphans spolia ex his Cereri consecravit. <milestone unit="par" n="2"/> Iterum et tertio consul multa domi militiaeque gessit. <milestone unit="par" n="3"/> Quarto consulatu cum Fabio Maximo, cum Galli, Samnites, Vmbri, Tusci contra Romanos conspirassent, ibi exercitu in aciem ducto et cornu inclinante exemplum patris imitatus advocato Marco Livio pontifice hastae insistens et solemnia verba respondens se et hostes diis manibus devovit. <milestone unit="par" n="4"/> Impetu in hostes facto victoriam suis reliquit. <milestone unit="par" n="5"/> Corpus a collega laudatum magnifice sepultum est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Publius Decius</hi> Decii filius primo consul de Samnitibus
+               triumphans spolia ex his Cereri consecravit. <milestone unit="par" n="2"/> Iterum et
+               tertio consul multa domi militiaeque gessit. <milestone unit="par" n="3"/> Quarto
+               consulatu cum Fabio Maximo, cum Galli, Samnites, Vmbri, Tusci contra Romanos
+               conspirassent, ibi exercitu in aciem ducto et cornu inclinante exemplum patris
+               imitatus advocato Marco Livio pontifice hastae insistens et solemnia verba respondens
+               se et hostes diis manibus devovit. <milestone unit="par" n="4"/> Impetu in hostes
+               facto victoriam suis reliquit. <milestone unit="par" n="5"/> Corpus a collega
+               laudatum magnifice sepultum est. </p>
          </div>
-            <div type="cap" n="28">
+         <div type="cap" n="28">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Titus Manlius Torquatus</hi> ob ingenii et linguae tarditatem a patre rus relegatus, cum audisset ei diem dictam a Pomponio tribuno plebis, nocte urbem petiit. <milestone unit="par" n="2"/> Secretum colloquium a tribuno impetravit et gladio stricto omittere eum accusationem terrore multo compulit. <milestone unit="par" n="3"/> Sulpicio dictatore tribunus militum Gallum provocatorem occidit. Torquem ei detractum cervici suae indidit. <milestone unit="par" n="4"/> Consul bello Latino filium suum, quod contra imperium pugnasset, securi percussit. Latinos apud Veserim fluvium Decii collegae devotione superavit. <milestone unit="par" n="5"/> Consulatum recusavit, quod diceret neque se populi vitia neque illum severitatem suam posse sufferre. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Titus Manlius Torquatus</hi> ob ingenii et linguae tarditatem a
+               patre rus relegatus, cum audisset ei diem dictam a Pomponio tribuno plebis, nocte
+               urbem petiit. <milestone unit="par" n="2"/> Secretum colloquium a tribuno impetravit
+               et gladio stricto omittere eum accusationem terrore multo compulit. <milestone
+                  unit="par" n="3"/> Sulpicio dictatore tribunus militum Gallum provocatorem
+               occidit. Torquem ei detractum cervici suae indidit. <milestone unit="par" n="4"/>
+               Consul bello Latino filium suum, quod contra imperium pugnasset, securi percussit.
+               Latinos apud Veserim fluvium Decii collegae devotione superavit. <milestone
+                  unit="par" n="5"/> Consulatum recusavit, quod diceret neque se populi vitia neque
+               illum severitatem suam posse sufferre. </p>
          </div>
-            <div type="cap" n="29">
+         <div type="cap" n="29">
             <p>
-               <milestone unit="par" n="1"/> Reliquias Senonum Camillus persequebatur. Adversum ingentem Gallum provocatorem solus <hi rend="expanded">Valerius</hi> tribunus militum omnibus territis processit. <milestone unit="par" n="2"/> Corvus ab ortu solis galeae eius insedit et inter pugnandum ora oculosque Galli everberavit. Hoste victo Valerius Corvinus dictus. <milestone unit="par" n="3"/> Hinc cum ingens multitudo aere alieno oppressa Capuam occupare tentasset et ducem sibi Quinctium necessitate compulsum fecisset, sublato aere alieno seditionem compressit. </p>
+               <milestone unit="par" n="1"/> Reliquias Senonum Camillus persequebatur. Adversum
+               ingentem Gallum provocatorem solus <hi rend="expanded">Valerius</hi> tribunus militum
+               omnibus territis processit. <milestone unit="par" n="2"/> Corvus ab ortu solis galeae
+               eius insedit et inter pugnandum ora oculosque Galli everberavit. Hoste victo Valerius
+               Corvinus dictus. <milestone unit="par" n="3"/> Hinc cum ingens multitudo aere alieno
+               oppressa Capuam occupare tentasset et ducem sibi Quinctium necessitate compulsum
+               fecisset, sublato aere alieno seditionem compressit. </p>
          </div>
-            <div type="cap" n="30">
+         <div type="cap" n="30">
             <p>
-               <milestone unit="par" n="1"/> Titus Veturius et Spurius Postumius consules bellum adversum Samnitas gerentes a <hi rend="expanded">Pontio Telesino</hi> duce hostium in insidias inducti sunt. <milestone unit="par" n="2"/> Nam ille simulatos transfugas misit, qui Romanis dicerent Luceriam Apulam a Samnitibus obsideri, quo duo itinera ducebant, aliud longius et tutius, aliud brevius et periculosius. <milestone unit="par" n="3"/> Festinatio brevius eligit; itaque cum insidias statuisset (qui locus Furculae Caudinae vocatur), Pontius accitum patrem Herennium rogavit, quid fieri placeret. <milestone unit="par" n="4"/> Ille ait aut omnes occidendos, ut vires frangerentur, aut omnes dimittendos, ut beneficio obligarentur. Vtroque improbato consilio omnes sub iugum misit icto foedere, quod a Romanis postea improbatum est. <milestone unit="par" n="5"/> Postumius Samnitibus deditus nec receptus est. </p>
+               <milestone unit="par" n="1"/> Titus Veturius et Spurius Postumius consules bellum
+               adversum Samnitas gerentes a <hi rend="expanded">Pontio Telesino</hi> duce hostium in
+               insidias inducti sunt. <milestone unit="par" n="2"/> Nam ille simulatos transfugas
+               misit, qui Romanis dicerent Luceriam Apulam a Samnitibus obsideri, quo duo itinera
+               ducebant, aliud longius et tutius, aliud brevius et periculosius. <milestone
+                  unit="par" n="3"/> Festinatio brevius eligit; itaque cum insidias statuisset (qui
+               locus Furculae Caudinae vocatur), Pontius accitum patrem Herennium rogavit, quid
+               fieri placeret. <milestone unit="par" n="4"/> Ille ait aut omnes occidendos, ut vires
+               frangerentur, aut omnes dimittendos, ut beneficio obligarentur. Vtroque improbato
+               consilio omnes sub iugum misit icto foedere, quod a Romanis postea improbatum est.
+                  <milestone unit="par" n="5"/> Postumius Samnitibus deditus nec receptus est. </p>
          </div>
-            <div type="cap" n="31">
+         <div type="cap" n="31">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Papirius</hi>, a velocitate Cursor, cum consulem se adversis ominibus adversum Samnites progressum esse sensisset, ad auspicia repetenda Romam regressus edixit Fabio Rullo, quem exercitui praeponebat, ne manum cum hoste consereret. <milestone unit="par" n="2"/> Sed ille opportunitate ductus pugnavit. Reversus Papirius securi eum ferire voluit; ille in urbem confugit nec supplicem tribuni tuebantur. <milestone unit="par" n="3"/> Deinde pater lacrimis, populus precibus veniam impetrarunt. <milestone unit="par" n="4"/> Papirius de Samnitibus triumphavit. Idem cum Praenestinum praetorem gravissime increpuisset: Expedi, inquit, lictor, secures. <milestone unit="par" n="5"/> Et cum eum metu mortis attonitum vidisset, incommodam ambulantibus radicem excidi iussit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Papirius</hi>, a velocitate Cursor, cum consulem se
+               adversis ominibus adversum Samnites progressum esse sensisset, ad auspicia repetenda
+               Romam regressus edixit Fabio Rullo, quem exercitui praeponebat, ne manum cum hoste
+               consereret. <milestone unit="par" n="2"/> Sed ille opportunitate ductus pugnavit.
+               Reversus Papirius securi eum ferire voluit; ille in urbem confugit nec supplicem
+               tribuni tuebantur. <milestone unit="par" n="3"/> Deinde pater lacrimis, populus
+               precibus veniam impetrarunt. <milestone unit="par" n="4"/> Papirius de Samnitibus
+               triumphavit. Idem cum Praenestinum praetorem gravissime increpuisset: Expedi, inquit,
+               lictor, secures. <milestone unit="par" n="5"/> Et cum eum metu mortis attonitum
+               vidisset, incommodam ambulantibus radicem excidi iussit. </p>
          </div>
-            <div type="cap" n="32">
+         <div type="cap" n="32">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Fabius Rullus</hi>, primus ex ea familia ob virtutem Maximus, magister equitum a Papirio ob Samnitem victoriam securi paene percussus, primum de Apulis et Nucerinis, iterum de Samnitibus, tertio de Gallis Vmbris Marsis atque Tuscis triumphavit. <milestone unit="par" n="2"/> Censor libertinos tribubus amovit. Iterum censor fieri noluit dicens non esse ex usu reipublicae eosdem censores saepius fieri. <milestone unit="par" n="3"/> Hic primus instituit, uti equites Romani Idibus Quinctilibus ab aede Honoris equis insidentes in Capitolium transirent. <milestone unit="par" n="4"/> Mortuo huic tantum aeris populi liberalitate congestum est, ut inde filius viscerationem et epulum publice daret. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Fabius Rullus</hi>, primus ex ea familia ob virtutem
+               Maximus, magister equitum a Papirio ob Samnitem victoriam securi paene percussus,
+               primum de Apulis et Nucerinis, iterum de Samnitibus, tertio de Gallis Vmbris Marsis
+               atque Tuscis triumphavit. <milestone unit="par" n="2"/> Censor libertinos tribubus
+               amovit. Iterum censor fieri noluit dicens non esse ex usu reipublicae eosdem censores
+               saepius fieri. <milestone unit="par" n="3"/> Hic primus instituit, uti equites Romani
+               Idibus Quinctilibus ab aede Honoris equis insidentes in Capitolium transirent.
+                  <milestone unit="par" n="4"/> Mortuo huic tantum aeris populi liberalitate
+               congestum est, ut inde filius viscerationem et epulum publice daret. </p>
          </div>
-            <div type="cap" n="33">
+         <div type="cap" n="33">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Curius Dentatus</hi> primo de Samnitibus triumphavit, quos usque ad mare superum perpacavit. <milestone unit="par" n="2"/> Regressus in contione ait: Tantum agri cepi, ut solitudo futura fuerit, nisi tantum hominum cepissem; tantum porro hominum cepi, ut fame perituri fuerint, nisi tantum agri cepissem. <milestone unit="par" n="3"/> Iterum de Sabinis triumphavit. Tertio de Lucanis ovans urbem introiit. <milestone unit="par" n="4"/> Pyrrhum Epirotam Italia expulit. <milestone unit="par" n="5"/> Quaterna dena agri iugera viritim populo divisit. <milestone unit="par" n="6"/> Sibi deinde totidem constituit dicens neminem esse debere, cui non tantum sufficeret. <milestone unit="par" n="7"/> Legatis Samnitum aurum offerentibus, cum ipse in foco rapas torreret: Malo, inquit, haec in fictilibus meis esse et aurum habentibus imperare. <milestone unit="par" n="8"/> Cum interversae pecuniae argueretur, gutum ligneum, quo uti ad sacrificia consueverat, in medium protulit iuravitque se nihil amplius de praeda hostili domum suam convertisse. <milestone unit="par" n="9"/> Aquam Anienem de manubiis hostium in urbem induxit. <milestone unit="par" n="10"/> Tribunus plebis patres auctores fieri coegit comitiis, quibus plebei magistratus creabantur. Ob haec merita domus ei apud Tiphatam et agri iugera quingenta publice data. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Curius Dentatus</hi> primo de Samnitibus triumphavit, quos
+               usque ad mare superum perpacavit. <milestone unit="par" n="2"/> Regressus in contione
+               ait: Tantum agri cepi, ut solitudo futura fuerit, nisi tantum hominum cepissem;
+               tantum porro hominum cepi, ut fame perituri fuerint, nisi tantum agri cepissem.
+                  <milestone unit="par" n="3"/> Iterum de Sabinis triumphavit. Tertio de Lucanis
+               ovans urbem introiit. <milestone unit="par" n="4"/> Pyrrhum Epirotam Italia expulit.
+                  <milestone unit="par" n="5"/> Quaterna dena agri iugera viritim populo divisit.
+                  <milestone unit="par" n="6"/> Sibi deinde totidem constituit dicens neminem esse
+               debere, cui non tantum sufficeret. <milestone unit="par" n="7"/> Legatis Samnitum
+               aurum offerentibus, cum ipse in foco rapas torreret: Malo, inquit, haec in fictilibus
+               meis esse et aurum habentibus imperare. <milestone unit="par" n="8"/> Cum interversae
+               pecuniae argueretur, gutum ligneum, quo uti ad sacrificia consueverat, in medium
+               protulit iuravitque se nihil amplius de praeda hostili domum suam convertisse.
+                  <milestone unit="par" n="9"/> Aquam Anienem de manubiis hostium in urbem induxit.
+                  <milestone unit="par" n="10"/> Tribunus plebis patres auctores fieri coegit
+               comitiis, quibus plebei magistratus creabantur. Ob haec merita domus ei apud Tiphatam
+               et agri iugera quingenta publice data. </p>
          </div>
-            <div type="cap" n="34">
+         <div type="cap" n="34">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Appius Claudius Caecus</hi> in censura libertinos quoque in senatum legit. Epulandi cantandique ius tibicinibus in publico ademit. <milestone unit="par" n="2"/> 
-               <del>Duae familiae ad Herculis sacra sunt destinatae, Potitiorum et Pinariorum.</del> Potitios Herculis sacerdotes pretio corrupit, ut sacra Herculea servos publicos edocerent: unde caecatus est, gens Potitiorum funditus periit. <milestone unit="par" n="3"/> Ne consulatus cum plebeiis communicaretur, acerrime restitit. <milestone unit="par" n="4"/> Ne Fabius solus ad bellum mitteretur, contradixit. <milestone unit="par" n="5"/> Sabinos, Samnitas, Etruscos bello domuit. <milestone unit="par" n="6"/> Viam usque Brundisium lapide stravit, unde illa Appia dicitur. <milestone unit="par" n="7"/> Aquam Anienem in urbem induxit. <milestone unit="par" n="8"/> Censuram solus omnium quinquennio obtinuit. <milestone unit="par" n="9"/> Cum de pace Pyrrhi ageretur et gratia potentum per legatum Cineam pretio quaereretur, senex et caecus lectica in senatum latus turpissimas condiciones magnifica oratione discussit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Appius Claudius Caecus</hi> in censura libertinos quoque in
+               senatum legit. Epulandi cantandique ius tibicinibus in publico ademit. <milestone
+                  unit="par" n="2"/>
+               <del>Duae familiae ad Herculis sacra sunt destinatae, Potitiorum et Pinariorum.</del>
+               Potitios Herculis sacerdotes pretio corrupit, ut sacra Herculea servos publicos
+               edocerent: unde caecatus est, gens Potitiorum funditus periit. <milestone unit="par"
+                  n="3"/> Ne consulatus cum plebeiis communicaretur, acerrime restitit. <milestone
+                  unit="par" n="4"/> Ne Fabius solus ad bellum mitteretur, contradixit. <milestone
+                  unit="par" n="5"/> Sabinos, Samnitas, Etruscos bello domuit. <milestone unit="par"
+                  n="6"/> Viam usque Brundisium lapide stravit, unde illa Appia dicitur. <milestone
+                  unit="par" n="7"/> Aquam Anienem in urbem induxit. <milestone unit="par" n="8"/>
+               Censuram solus omnium quinquennio obtinuit. <milestone unit="par" n="9"/> Cum de pace
+               Pyrrhi ageretur et gratia potentum per legatum Cineam pretio quaereretur, senex et
+               caecus lectica in senatum latus turpissimas condiciones magnifica oratione discussit.
+            </p>
          </div>
-            <div type="cap" n="35">
+         <div type="cap" n="35">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Pyrrhus</hi> rex Epirotarum, materno genere ab Achille, paterno ab Hercule oriundus, cum imperium orbis agitaret et Romanos potentes videret, Apollinem de bello consuluit. <milestone unit="par" n="2"/> Ille ambigue respondit: </p>
-                <p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Pyrrhus</hi> rex Epirotarum, materno genere ab Achille, paterno
+               ab Hercule oriundus, cum imperium orbis agitaret et Romanos potentes videret,
+               Apollinem de bello consuluit. <milestone unit="par" n="2"/> Ille ambigue respondit: </p>
+            <p>
                <hi rend="italic">Aio te, Aeacida, Romanos vincere posse.</hi>
             </p>
-                <p>
-               <milestone unit="par" n="3"/> Hoc dicto in voluntatem tracto auxilio Tarentinorum bellum Romanis intulit. Laevinum consulem apud Heracleam elephantorum novitate turbavit. <milestone unit="par" n="4"/> Cumque Romanos adversis vulneribus occisos videret: Ego, inquit, talibus militibus brevi orbem terrarum subigere potuissem. <milestone unit="par" n="5"/> Amicis gratulantibus: Quid mihi cum tali victoria, inquit, ubi exercitus robur amittam? <milestone unit="par" n="6"/> Ad vicesimum ab urbe lapidem castra posuit; captivos Fabricio gratis reddidit. <milestone unit="par" n="7"/> Viso Laevini exercitu eandem sibi ait adversum Romanos, quam Herculi adversus hydram, fuisse fortunam. <milestone unit="par" n="8"/> A Curio et Fabricio superatus Tarentum refugit, in Siciliam traiecit. <milestone unit="par" n="9"/> Mox in Italiam Locros regressus pecuniam Proserpinae avehere tentavit, sed ea naufragio relata est. <milestone unit="par" n="10"/> Tum in Graeciam regressus, dum Argos oppugnaret, ictu tegulae prostratus est. <milestone unit="par" n="11"/> Corpus ad Antigonum regem Macedoniae relatum magnifice sepultum. </p>
-         </div>
-            <div type="cap" n="36">
             <p>
-               <milestone unit="par" n="1"/> Vulsinii, Etruriae nobile oppidum, luxuria paene perierunt. Nam cum temere servos manumitterent, dein in curiam legerent, consensu eorum oppressi. <milestone unit="par" n="2"/> Cum multa indigna paterentur, clam a Roma auxilium petierunt, missusque <hi rend="expanded">Decius Mus</hi> libertinos omnes aut in carcere necavit aut dominis in servitutem restituit. </p>
+               <milestone unit="par" n="3"/> Hoc dicto in voluntatem tracto auxilio Tarentinorum
+               bellum Romanis intulit. Laevinum consulem apud Heracleam elephantorum novitate
+               turbavit. <milestone unit="par" n="4"/> Cumque Romanos adversis vulneribus occisos
+               videret: Ego, inquit, talibus militibus brevi orbem terrarum subigere potuissem.
+                  <milestone unit="par" n="5"/> Amicis gratulantibus: Quid mihi cum tali victoria,
+               inquit, ubi exercitus robur amittam? <milestone unit="par" n="6"/> Ad vicesimum ab
+               urbe lapidem castra posuit; captivos Fabricio gratis reddidit. <milestone unit="par"
+                  n="7"/> Viso Laevini exercitu eandem sibi ait adversum Romanos, quam Herculi
+               adversus hydram, fuisse fortunam. <milestone unit="par" n="8"/> A Curio et Fabricio
+               superatus Tarentum refugit, in Siciliam traiecit. <milestone unit="par" n="9"/> Mox
+               in Italiam Locros regressus pecuniam Proserpinae avehere tentavit, sed ea naufragio
+               relata est. <milestone unit="par" n="10"/> Tum in Graeciam regressus, dum Argos
+               oppugnaret, ictu tegulae prostratus est. <milestone unit="par" n="11"/> Corpus ad
+               Antigonum regem Macedoniae relatum magnifice sepultum. </p>
          </div>
-            <div type="cap" n="37">
+         <div type="cap" n="36">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Appius Claudius</hi> victis Vulsiniensibus cognomento Caudex dictus frater Caeci fuit. <milestone unit="par" n="2"/> Consul ad Mamertinos liberandos missus, quorum arcem Carthaginienses et Hiero rex Syracusanus obsidebant. <milestone unit="par" n="3"/> Primo ad explorandos hostes fretum piscatoria nave traiecit et cum duce Carthaginiensium egit, ut praesidium arce deduceret. <milestone unit="par" n="4"/> Regium regressus quinqueremem hostium copiis pedestribus cepit; ea legionem in Siciliam traduxit. Carthaginienses Messana expulit. <milestone unit="par" n="5"/> Hieronem proelio apud Syracusas in deditionem accepit, qui eo periculo territus Romanorum amicitiam petiit iisque postea fidelissimus fuit. </p>
+               <milestone unit="par" n="1"/> Vulsinii, Etruriae nobile oppidum, luxuria paene
+               perierunt. Nam cum temere servos manumitterent, dein in curiam legerent, consensu
+               eorum oppressi. <milestone unit="par" n="2"/> Cum multa indigna paterentur, clam a
+               Roma auxilium petierunt, missusque <hi rend="expanded">Decius Mus</hi> libertinos
+               omnes aut in carcere necavit aut dominis in servitutem restituit. </p>
          </div>
-            <div type="cap" n="38">
+         <div type="cap" n="37">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gnaeus Duellius</hi> primo Punico bello dux contra Carthaginienses missus, cum videret eos multum mari posse, classem validam fabrefecit et manus ferreas cum irrisu hostium primus instituit; sic inter pugnandum hostium naves apprehendit, qui victi et capti sunt. <milestone unit="par" n="2"/> Himilco dux classis Carthaginem fugit et a senatu quaesivit, quid faciendum censerent. <milestone unit="par" n="3"/> Omnibus, ut pugnaret, acclamantibus: Feci, inquit, et victus sum. Sic poenam crucis effugit; nam apud Poenos dux male re gesta puniebatur. <milestone unit="par" n="4"/> Duellio concessum est, ut praelucente funali et praecinente tibicine a cena publice rediret. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Appius Claudius</hi> victis Vulsiniensibus cognomento Caudex
+               dictus frater Caeci fuit. <milestone unit="par" n="2"/> Consul ad Mamertinos
+               liberandos missus, quorum arcem Carthaginienses et Hiero rex Syracusanus obsidebant.
+                  <milestone unit="par" n="3"/> Primo ad explorandos hostes fretum piscatoria nave
+               traiecit et cum duce Carthaginiensium egit, ut praesidium arce deduceret. <milestone
+                  unit="par" n="4"/> Regium regressus quinqueremem hostium copiis pedestribus cepit;
+               ea legionem in Siciliam traduxit. Carthaginienses Messana expulit. <milestone
+                  unit="par" n="5"/> Hieronem proelio apud Syracusas in deditionem accepit, qui eo
+               periculo territus Romanorum amicitiam petiit iisque postea fidelissimus fuit. </p>
          </div>
-            <div type="cap" n="39">
+         <div type="cap" n="38">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Atilius Calatinus</hi>, dux adversum Carthaginienses missus, ex maximis et munitissimis civitatibus Enna Drepano Lilybaeo hostilia praesidia deiecit. <milestone unit="par" n="2"/> Panormum cepit. Totamque Siciliam pervagatus paucis navibus magnam hostium classem duce Hamilcare superavit. <milestone unit="par" n="3"/> Sed cum ad Catinam ab hostibus obsessam festinaret, a Poenis in angustiis clausus est, ubi tribunus militum Calpurnius Flamma acceptis trecentis sociis in superiorem locum evasit, consulem liberavit; ipse cum trecentis pugnans cecidit. <milestone unit="par" n="4"/> Postea ab Atilio semianimis inventus et sanatus magno postea terrori hostibus fuit. Atilius gloriose triumphavit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gnaeus Duellius</hi> primo Punico bello dux contra
+               Carthaginienses missus, cum videret eos multum mari posse, classem validam fabrefecit
+               et manus ferreas cum irrisu hostium primus instituit; sic inter pugnandum hostium
+               naves apprehendit, qui victi et capti sunt. <milestone unit="par" n="2"/> Himilco dux
+               classis Carthaginem fugit et a senatu quaesivit, quid faciendum censerent. <milestone
+                  unit="par" n="3"/> Omnibus, ut pugnaret, acclamantibus: Feci, inquit, et victus
+               sum. Sic poenam crucis effugit; nam apud Poenos dux male re gesta puniebatur.
+                  <milestone unit="par" n="4"/> Duellio concessum est, ut praelucente funali et
+               praecinente tibicine a cena publice rediret. </p>
          </div>
-            <div type="cap" n="40">
+         <div type="cap" n="39">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Atilius Regulus</hi> consul fusis Sallentinis triumphavit primusque Romanorum ducum in Africam classem traiecit. Ea quassata de Hamilcare naves longas tres et sexaginta cepit. <milestone unit="par" n="2"/> Oppida ducenta et hominum ducenta milia cepit. Absente eo coniugi eius et liberis ob paupertatem sumptus publice dati. <milestone unit="par" n="3"/> Mox arte Xanthippi Lacedaemonii mercenarii militis captus in carcerem missus. <milestone unit="par" n="4"/> Legatus de permutandis captivis Romam missus dato iureiurando, ut, si impetrasset, ita demum non rediret, in senatu condicionem dissuasit reiectisque ab amplexu coniuge et liberis Carthaginem regressus, ubi in arcam ligneam coniectus clavis introrsum adactis vigiliis ac dolore punitus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Atilius Calatinus</hi>, dux adversum Carthaginienses missus, ex
+               maximis et munitissimis civitatibus Enna Drepano Lilybaeo hostilia praesidia deiecit.
+                  <milestone unit="par" n="2"/> Panormum cepit. Totamque Siciliam pervagatus paucis
+               navibus magnam hostium classem duce Hamilcare superavit. <milestone unit="par" n="3"
+               /> Sed cum ad Catinam ab hostibus obsessam festinaret, a Poenis in angustiis clausus
+               est, ubi tribunus militum Calpurnius Flamma acceptis trecentis sociis in superiorem
+               locum evasit, consulem liberavit; ipse cum trecentis pugnans cecidit. <milestone
+                  unit="par" n="4"/> Postea ab Atilio semianimis inventus et sanatus magno postea
+               terrori hostibus fuit. Atilius gloriose triumphavit. </p>
          </div>
-            <div type="cap" n="41">
+         <div type="cap" n="40">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Lutatius Catulus</hi> primo Punico bello trecentis navibus adversum Poenos profectus sexcentas eorum naves commeatibus et aliis oneribus impeditas duce Hannone apud Aegatas insulas inter Siciliam et Africam depressit aut cepit finemque bello imposuit. <milestone unit="par" n="2"/> Pacem petentibus hac condicione concessit, ut Sicilia, Sardinia et ceteris insulis inter Italiam Africamque decederent, Hispania citra Hiberum abstinerent. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Atilius Regulus</hi> consul fusis Sallentinis triumphavit
+               primusque Romanorum ducum in Africam classem traiecit. Ea quassata de Hamilcare naves
+               longas tres et sexaginta cepit. <milestone unit="par" n="2"/> Oppida ducenta et
+               hominum ducenta milia cepit. Absente eo coniugi eius et liberis ob paupertatem
+               sumptus publice dati. <milestone unit="par" n="3"/> Mox arte Xanthippi Lacedaemonii
+               mercenarii militis captus in carcerem missus. <milestone unit="par" n="4"/> Legatus
+               de permutandis captivis Romam missus dato iureiurando, ut, si impetrasset, ita demum
+               non rediret, in senatu condicionem dissuasit reiectisque ab amplexu coniuge et
+               liberis Carthaginem regressus, ubi in arcam ligneam coniectus clavis introrsum
+               adactis vigiliis ac dolore punitus est. </p>
          </div>
-            <div type="cap" n="42">
+         <div type="cap" n="41">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Hannibal</hi>, Hamilcaris filius, novem annos natus, a patre aris admotus odium in Romanos perenne iuravit. <milestone unit="par" n="2"/> Exinde socius et miles in castris patri fuit. Mortuo eo causam belli quaerens Saguntum Romanis foederatam intra sex menses evertit. Tum Alpibus patefactis in Italiam traiecit. <milestone unit="par" n="3"/> P. Scipionem apud Ticinum, Sempronium Longum apud Trebiam, <milestone unit="par" n="4"/> Flaminium apud Trasimenum, Paullum et Varronem apud Cannas superavit. <milestone unit="par" n="5"/> Cumque urbem capere posset, in Campaniam devertit, cuius deliciis elanguit. <milestone unit="par" n="6"/> Et cum ad tertium ab urbe lapidem castra posuisset, tempestatibus repulsus, primum a Fabio Maximo frustratus, deinde a Valerio Flacco repulsus, a Graccho et Marcello fugatus, in Africam revocatus, a Scipione superatus, ad Antiochum regem Syriae confugit eumque hostem Romanis fecit; quo victo ad Prusiam regem Bithyniae concessit; unde Romana legatione repetitus hausto, quod sub gemma anuli habebat, veneno absumptus est, positus apud Libyssam in arca lapidea, in qua hodieque inscriptum est: <hi rend="expanded">Hannibal hic situs est</hi>. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Lutatius Catulus</hi> primo Punico bello trecentis
+               navibus adversum Poenos profectus sexcentas eorum naves commeatibus et aliis oneribus
+               impeditas duce Hannone apud Aegatas insulas inter Siciliam et Africam depressit aut
+               cepit finemque bello imposuit. <milestone unit="par" n="2"/> Pacem petentibus hac
+               condicione concessit, ut Sicilia, Sardinia et ceteris insulis inter Italiam
+               Africamque decederent, Hispania citra Hiberum abstinerent. </p>
          </div>
-            <div type="cap" n="43">
+         <div type="cap" n="42">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Fabius Maximus Cunctator</hi>, Verrucosus a verruca in labris sita, Ovicula a clementia morum dictus, consul de Liguribus triumphavit. <milestone unit="par" n="2"/> Hannibalem mora fregit. <milestone unit="par" n="3"/> Minucium magistrum equitum imperio sibi aequari passus est; nihilo minus periclitanti subvenit. <milestone unit="par" n="4"/> Hannibalem in agro Falerno inclusit. <milestone unit="par" n="5"/> Marium Statilium transfugere ad hostes volentem equo et armis donatis retinuit, et Lucano cuidam fortissimo ob amorem mulieris infrequenti eandem emptam dono dedit. <milestone unit="par" n="6"/> Tarentum ab hostibus recepit, Herculis signum inde translatum in Capitolio dedicavit. De redemptione captivorum cum hostibus pepigit; <milestone unit="par" n="7"/> quod pactum cum a senatu improbaretur, fundum suum ducentis milibus vendidit et fidei satisfecit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Hannibal</hi>, Hamilcaris filius, novem annos natus, a patre aris
+               admotus odium in Romanos perenne iuravit. <milestone unit="par" n="2"/> Exinde socius
+               et miles in castris patri fuit. Mortuo eo causam belli quaerens Saguntum Romanis
+               foederatam intra sex menses evertit. Tum Alpibus patefactis in Italiam traiecit.
+                  <milestone unit="par" n="3"/> P. Scipionem apud Ticinum, Sempronium Longum apud
+               Trebiam, <milestone unit="par" n="4"/> Flaminium apud Trasimenum, Paullum et Varronem
+               apud Cannas superavit. <milestone unit="par" n="5"/> Cumque urbem capere posset, in
+               Campaniam devertit, cuius deliciis elanguit. <milestone unit="par" n="6"/> Et cum ad
+               tertium ab urbe lapidem castra posuisset, tempestatibus repulsus, primum a Fabio
+               Maximo frustratus, deinde a Valerio Flacco repulsus, a Graccho et Marcello fugatus,
+               in Africam revocatus, a Scipione superatus, ad Antiochum regem Syriae confugit eumque
+               hostem Romanis fecit; quo victo ad Prusiam regem Bithyniae concessit; unde Romana
+               legatione repetitus hausto, quod sub gemma anuli habebat, veneno absumptus est,
+               positus apud Libyssam in arca lapidea, in qua hodieque inscriptum est: <hi
+                  rend="expanded">Hannibal hic situs est</hi>. </p>
          </div>
-            <div type="cap" n="44">
+         <div type="cap" n="43">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Publius Scipio Nasica</hi>, a senatu vir optimus iudicatus, Matrem deum hospitio recepit. <milestone unit="par" n="2"/> Is cum adversum auspicia consulem se a Graccho nominatum comperisset, magistratu se abdicavit. <milestone unit="par" n="3"/> Censor statuas, quas sibi quisque in foro per ambitionem ponebat, sustulit. <milestone unit="par" n="4"/> Consul Delminium urbem Dalmatarum expugnavit. <milestone unit="par" n="5"/> Imperatoris nomen a militibus et a senatu triumphum oblatum recusavit. Eloquentia primus, iuris scientia consultissimus, ingenio sapientissimus, unde vulgo Corculum dictus. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Fabius Maximus Cunctator</hi>, Verrucosus a verruca in
+               labris sita, Ovicula a clementia morum dictus, consul de Liguribus triumphavit.
+                  <milestone unit="par" n="2"/> Hannibalem mora fregit. <milestone unit="par" n="3"
+               /> Minucium magistrum equitum imperio sibi aequari passus est; nihilo minus
+               periclitanti subvenit. <milestone unit="par" n="4"/> Hannibalem in agro Falerno
+               inclusit. <milestone unit="par" n="5"/> Marium Statilium transfugere ad hostes
+               volentem equo et armis donatis retinuit, et Lucano cuidam fortissimo ob amorem
+               mulieris infrequenti eandem emptam dono dedit. <milestone unit="par" n="6"/> Tarentum
+               ab hostibus recepit, Herculis signum inde translatum in Capitolio dedicavit. De
+               redemptione captivorum cum hostibus pepigit; <milestone unit="par" n="7"/> quod
+               pactum cum a senatu improbaretur, fundum suum ducentis milibus vendidit et fidei
+               satisfecit. </p>
          </div>
-            <div type="cap" n="45">
+         <div type="cap" n="44">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Marcellus</hi> Viridomarum, Gallorum ducem, singulari proelio fudit. <milestone unit="par" n="2"/> Spolia opima Iovi Feretrio tertius a Romulo consecravit. <milestone unit="par" n="3"/> Primus docuit, quomodo milites cederent nec terga praeberent. <milestone unit="par" n="4"/> Hannibalem apud Nolam locorum angustia adiutus vinci docuit. <milestone unit="par" n="5"/> Syracusas per tres annos expugnavit. <milestone unit="par" n="6"/> Et cum per calumniam triumphus a senatu negaretur, de sua sententia in Albano monte triumphavit. <milestone unit="par" n="7"/> Quinquies consul insidiis Hannibalis deceptus et magnifice sepultus. <milestone unit="par" n="8"/> Ossa Romam remissa a praedonibus intercepta perierunt. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Publius Scipio Nasica</hi>, a senatu vir optimus iudicatus,
+               Matrem deum hospitio recepit. <milestone unit="par" n="2"/> Is cum adversum auspicia
+               consulem se a Graccho nominatum comperisset, magistratu se abdicavit. <milestone
+                  unit="par" n="3"/> Censor statuas, quas sibi quisque in foro per ambitionem
+               ponebat, sustulit. <milestone unit="par" n="4"/> Consul Delminium urbem Dalmatarum
+               expugnavit. <milestone unit="par" n="5"/> Imperatoris nomen a militibus et a senatu
+               triumphum oblatum recusavit. Eloquentia primus, iuris scientia consultissimus,
+               ingenio sapientissimus, unde vulgo Corculum dictus. </p>
          </div>
-            <div type="cap" n="46">
+         <div type="cap" n="45">
             <p>
-               <milestone unit="par" n="1"/> Hannibale Italiam devastante ex responso librorum Sibyllinorum Mater deum a Pessinunte arcessita cum adverso Tiberi veheretur, repente in alto stetit. Et cum moveri nullis viribus posset, ex libris cognitum castissimae demum feminae manu moveri posse. <milestone unit="par" n="2"/> Tum <hi rend="expanded">Claudia</hi> virgo Vestalis falso incesti suspecta deam oravit, ut, si pudicam sciret, sequeretur, et zona imposita navem movit. <milestone unit="par" n="3"/> Simulacrum Matris deum, dum templum aedificatur, Nasicae, qui vir optimus iudicabatur, quasi hospiti datum. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Marcellus</hi> Viridomarum, Gallorum ducem, singulari
+               proelio fudit. <milestone unit="par" n="2"/> Spolia opima Iovi Feretrio tertius a
+               Romulo consecravit. <milestone unit="par" n="3"/> Primus docuit, quomodo milites
+               cederent nec terga praeberent. <milestone unit="par" n="4"/> Hannibalem apud Nolam
+               locorum angustia adiutus vinci docuit. <milestone unit="par" n="5"/> Syracusas per
+               tres annos expugnavit. <milestone unit="par" n="6"/> Et cum per calumniam triumphus a
+               senatu negaretur, de sua sententia in Albano monte triumphavit. <milestone unit="par"
+                  n="7"/> Quinquies consul insidiis Hannibalis deceptus et magnifice sepultus.
+                  <milestone unit="par" n="8"/> Ossa Romam remissa a praedonibus intercepta
+               perierunt. </p>
          </div>
-            <div type="cap" n="47">
+         <div type="cap" n="46">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Porcius Cato</hi>, genere Tusculanus, a Valerio Flacco Romam sollicitatus, tribunus militum in Sicilia, quaestor sub Scipione fortissimus, praetor iustissimus fuit: in praetura Sardiniam subegit, ubi ab Ennio Graecis litteris institutus. <milestone unit="par" n="2"/> Consul Celtiberos domuit et, ne rebellare possent, litteras ad singulas civitates misit, ut muros diruerent. <milestone unit="par" n="3"/> Cum unaquaeque sibi soli imperari putaret, fecerunt. Syriaco bello tribunus militum sub M. Acilio Glabrione occupatis Thermopylarum iugis praesidium hostium depulit. <milestone unit="par" n="4"/> Censor L. Flaminium consularem senatu movit, quod ille in Gallia ad cuiusdam scorti spectaculum eiectum quendam e carcere in convivio iugulari iussisset. <milestone unit="par" n="5"/> Basilicam suo nomine primus fecit. <milestone unit="par" n="6"/> Matronis ornamenta erepta Oppia lege repetentibus restitit. <milestone unit="par" n="7"/> Accusator assiduus malorum Galbam octogenarius accusavit, ipse quadragies quater accusatus gloriose absolutus. <milestone unit="par" n="8"/> Carthaginem delendam censuit. <milestone unit="par" n="9"/> Post octoginta annos filium genuit. Imago huius funeris gratia produci solet. </p>
+               <milestone unit="par" n="1"/> Hannibale Italiam devastante ex responso librorum
+               Sibyllinorum Mater deum a Pessinunte arcessita cum adverso Tiberi veheretur, repente
+               in alto stetit. Et cum moveri nullis viribus posset, ex libris cognitum castissimae
+               demum feminae manu moveri posse. <milestone unit="par" n="2"/> Tum <hi
+                  rend="expanded">Claudia</hi> virgo Vestalis falso incesti suspecta deam oravit,
+               ut, si pudicam sciret, sequeretur, et zona imposita navem movit. <milestone
+                  unit="par" n="3"/> Simulacrum Matris deum, dum templum aedificatur, Nasicae, qui
+               vir optimus iudicabatur, quasi hospiti datum. </p>
          </div>
-            <div type="cap" n="48">
+         <div type="cap" n="47">
             <p>
-               <milestone unit="par" n="1"/> Hasdrubal, frater Hannibalis, ingentibus copiis in Italiam traiecit, actumque erat de Romano imperio, si iungere se Hannibali potuisset. <milestone unit="par" n="2"/> Sed <hi rend="expanded">Claudius Nero</hi>, qui in Apulia cum Hannibale castra coniunxerat, relicta in castris parte cum delectis ad Hasdrubalem properavit et se Livio collegae apud Senam oppidum et Metaurum flumen coniunxit amboque Hasdrubalem vicerunt. <milestone unit="par" n="3"/> Nero regressus pari celeritate, qua venerat, caput Hasdrubalis ante vallum Hannibalis proiecit. <milestone unit="par" n="4"/> Quo ille viso vinci se fortuna Carthaginis confessus. <milestone unit="par" n="5"/> Ob haec Livius triumphans, Nero ovans urbem introierunt. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Porcius Cato</hi>, genere Tusculanus, a Valerio Flacco
+               Romam sollicitatus, tribunus militum in Sicilia, quaestor sub Scipione fortissimus,
+               praetor iustissimus fuit: in praetura Sardiniam subegit, ubi ab Ennio Graecis
+               litteris institutus. <milestone unit="par" n="2"/> Consul Celtiberos domuit et, ne
+               rebellare possent, litteras ad singulas civitates misit, ut muros diruerent.
+                  <milestone unit="par" n="3"/> Cum unaquaeque sibi soli imperari putaret, fecerunt.
+               Syriaco bello tribunus militum sub M. Acilio Glabrione occupatis Thermopylarum iugis
+               praesidium hostium depulit. <milestone unit="par" n="4"/> Censor L. Flaminium
+               consularem senatu movit, quod ille in Gallia ad cuiusdam scorti spectaculum eiectum
+               quendam e carcere in convivio iugulari iussisset. <milestone unit="par" n="5"/>
+               Basilicam suo nomine primus fecit. <milestone unit="par" n="6"/> Matronis ornamenta
+               erepta Oppia lege repetentibus restitit. <milestone unit="par" n="7"/> Accusator
+               assiduus malorum Galbam octogenarius accusavit, ipse quadragies quater accusatus
+               gloriose absolutus. <milestone unit="par" n="8"/> Carthaginem delendam censuit.
+                  <milestone unit="par" n="9"/> Post octoginta annos filium genuit. Imago huius
+               funeris gratia produci solet. </p>
          </div>
-            <div type="cap" n="49">
+         <div type="cap" n="48">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Publius Scipio</hi> ex virtute Africanus dictus, Iovis filius creditus: nam antequam conciperetur, serpens in lecto matris eius apparuit, et ipsi parvulo draco circumfusus nihil nocuit. <milestone unit="par" n="2"/> In Capitolium intempesta nocte euntem nunquam canes latraverunt. <milestone unit="par" n="3"/> Nec hic quicquam prius coepit, quam in cella Iovis diutissime sedisset, quasi divinam mentem acciperet. <milestone unit="par" n="4"/> Decem et octo annorum patrem apud Ticinum singulari virtute servavit. <milestone unit="par" n="5"/> Clade Cannensi nobilissimos iuvenes Italiam deserere cupientes sua auctoritate compescuit. <milestone unit="par" n="6"/> Reliquias incolumes per media hostium castra Canusium perduxit. <milestone unit="par" n="7"/> Viginti quattuor annorum praetor in Hispaniam missus Carthaginem, qua die venit, cepit. <milestone unit="par" n="8"/> Virginem pulcherrimam, ad cuius adspectum concurrebatur, ad se vetuit adduci patrique eius sponsor astitit. <milestone unit="par" n="9"/> Hasdrubalem Magonemque, fratres Hannibalis, Hispania expulit. <milestone unit="par" n="10"/> Amicitiam cum Syphace, Maurorum rege, coniunxit. <milestone unit="par" n="11"/> Massinissam in societatem recepit. <milestone unit="par" n="12"/> Victor domum regressus consul ante annos factus concedente collega in Africam classem traiecit. <milestone unit="par" n="13"/> Hasdrubalis et Syphacis castra una nocte perrupit. <milestone unit="par" n="14"/> Revocatum ex Italia Hannibalem superavit. <milestone unit="par" n="15"/> Victis Carthaginiensibus leges imposuit. <milestone unit="par" n="16"/> Bello Antiochi legatus fratri fuit; captum filium gratis recepit. <milestone unit="par" n="17"/> A Petillio Actaeo tribuno plebis repetundarum accusatus librum rationum in conspectu populi scidit: Hac die, inquit, Carthaginem vici; quare, bonum factum, in Capitolium eamus et diis supplicemus! <milestone unit="par" n="18"/> Inde in voluntarium exilium concessit, ubi reliquam egit aetatem. <milestone unit="par" n="19"/> Moriens ab uxore petiit, ne corpus suum Romam referretur. </p>
+               <milestone unit="par" n="1"/> Hasdrubal, frater Hannibalis, ingentibus copiis in
+               Italiam traiecit, actumque erat de Romano imperio, si iungere se Hannibali potuisset.
+                  <milestone unit="par" n="2"/> Sed <hi rend="expanded">Claudius Nero</hi>, qui in
+               Apulia cum Hannibale castra coniunxerat, relicta in castris parte cum delectis ad
+               Hasdrubalem properavit et se Livio collegae apud Senam oppidum et Metaurum flumen
+               coniunxit amboque Hasdrubalem vicerunt. <milestone unit="par" n="3"/> Nero regressus
+               pari celeritate, qua venerat, caput Hasdrubalis ante vallum Hannibalis proiecit.
+                  <milestone unit="par" n="4"/> Quo ille viso vinci se fortuna Carthaginis
+               confessus. <milestone unit="par" n="5"/> Ob haec Livius triumphans, Nero ovans urbem
+               introierunt. </p>
          </div>
-            <div type="cap" n="50">
+         <div type="cap" n="49">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Livius Salinator</hi> primo consul de Illyriis triumphavit, deinde ex invidia peculatus reus ab omnibus tribubus excepta Metia condemnatus. <milestone unit="par" n="2"/> Iterum cum Claudio Nerone inimico suo consul, ne respublica discordia male administraretur, amicitiam cum eo iunxit et de Hasdrubale triumphavit. <milestone unit="par" n="3"/> Censor cum eodem collega omnes tribus excepta Metia aerarias fecit, stipendio privavit eo crimine, quod aut prius se iniuste condemnassent aut postea tantos honores non recte tribuissent. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Publius Scipio</hi> ex virtute Africanus dictus, Iovis filius
+               creditus: nam antequam conciperetur, serpens in lecto matris eius apparuit, et ipsi
+               parvulo draco circumfusus nihil nocuit. <milestone unit="par" n="2"/> In Capitolium
+               intempesta nocte euntem nunquam canes latraverunt. <milestone unit="par" n="3"/> Nec
+               hic quicquam prius coepit, quam in cella Iovis diutissime sedisset, quasi divinam
+               mentem acciperet. <milestone unit="par" n="4"/> Decem et octo annorum patrem apud
+               Ticinum singulari virtute servavit. <milestone unit="par" n="5"/> Clade Cannensi
+               nobilissimos iuvenes Italiam deserere cupientes sua auctoritate compescuit.
+                  <milestone unit="par" n="6"/> Reliquias incolumes per media hostium castra
+               Canusium perduxit. <milestone unit="par" n="7"/> Viginti quattuor annorum praetor in
+               Hispaniam missus Carthaginem, qua die venit, cepit. <milestone unit="par" n="8"/>
+               Virginem pulcherrimam, ad cuius adspectum concurrebatur, ad se vetuit adduci patrique
+               eius sponsor astitit. <milestone unit="par" n="9"/> Hasdrubalem Magonemque, fratres
+               Hannibalis, Hispania expulit. <milestone unit="par" n="10"/> Amicitiam cum Syphace,
+               Maurorum rege, coniunxit. <milestone unit="par" n="11"/> Massinissam in societatem
+               recepit. <milestone unit="par" n="12"/> Victor domum regressus consul ante annos
+               factus concedente collega in Africam classem traiecit. <milestone unit="par" n="13"/>
+               Hasdrubalis et Syphacis castra una nocte perrupit. <milestone unit="par" n="14"/>
+               Revocatum ex Italia Hannibalem superavit. <milestone unit="par" n="15"/> Victis
+               Carthaginiensibus leges imposuit. <milestone unit="par" n="16"/> Bello Antiochi
+               legatus fratri fuit; captum filium gratis recepit. <milestone unit="par" n="17"/> A
+               Petillio Actaeo tribuno plebis repetundarum accusatus librum rationum in conspectu
+               populi scidit: Hac die, inquit, Carthaginem vici; quare, bonum factum, in Capitolium
+               eamus et diis supplicemus! <milestone unit="par" n="18"/> Inde in voluntarium exilium
+               concessit, ubi reliquam egit aetatem. <milestone unit="par" n="19"/> Moriens ab uxore
+               petiit, ne corpus suum Romam referretur. </p>
          </div>
-            <div type="cap" n="51">
+         <div type="cap" n="50">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Flaminius</hi>, Flaminii, qui apud Trasumenum periit, filius, consul Macedoniam sortitus, ducibus Charopae principis pastoribus provinciam ingressus regem Philippum proelio fudit, castris exuit. <milestone unit="par" n="2"/> Filium eius Demetrium obsidem accepit, quem pecunia mulctatum in regnum restituit. <milestone unit="par" n="3"/> A Nabide quoque Lacedaemonio filium obsidem accepit. <milestone unit="par" n="4"/> 
-               <unclear/>Ludos Iunonis Samiae per praeconem pronuntiavit. <milestone unit="par" n="5"/> Legatus etiam ad Prusiam, ut Hannibalem repeteret, missus. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Livius Salinator</hi> primo consul de Illyriis triumphavit,
+               deinde ex invidia peculatus reus ab omnibus tribubus excepta Metia condemnatus.
+                  <milestone unit="par" n="2"/> Iterum cum Claudio Nerone inimico suo consul, ne
+               respublica discordia male administraretur, amicitiam cum eo iunxit et de Hasdrubale
+               triumphavit. <milestone unit="par" n="3"/> Censor cum eodem collega omnes tribus
+               excepta Metia aerarias fecit, stipendio privavit eo crimine, quod aut prius se
+               iniuste condemnassent aut postea tantos honores non recte tribuissent. </p>
          </div>
-            <div type="cap" n="52">
+         <div type="cap" n="51">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Fulvius Nobilior</hi> consul Vettonas Oretanosque superavit, unde ovans urbem introiit. <milestone unit="par" n="2"/> Consul Aetolos, qui bello Macedonico Romanis affuerant, post ad Antiochum defecerant, proeliis frequentibus victos et in Ambraciam oppidum coactos in deditionem accepit, tamen signis tabulisque pictis spoliavit; de quibus triumphavit. <milestone unit="par" n="3"/> Quam victoriam per se magnificam Ennius amicus eius insigni laude celebravit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Flaminius</hi>, Flaminii, qui apud Trasumenum periit,
+               filius, consul Macedoniam sortitus, ducibus Charopae principis pastoribus provinciam
+               ingressus regem Philippum proelio fudit, castris exuit. <milestone unit="par" n="2"/>
+               Filium eius Demetrium obsidem accepit, quem pecunia mulctatum in regnum restituit.
+                  <milestone unit="par" n="3"/> A Nabide quoque Lacedaemonio filium obsidem accepit.
+                  <milestone unit="par" n="4"/>
+               <unclear/>Ludos Iunonis Samiae per praeconem pronuntiavit. <milestone unit="par"
+                  n="5"/> Legatus etiam ad Prusiam, ut Hannibalem repeteret, missus. </p>
          </div>
-            <div type="cap" n="53">
+         <div type="cap" n="52">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Scipio Asiaticus</hi>, frater Africani, infirmo corpore, tamen in Africa virtutis nomine a fratre laudatus, consul Antiochum regem Syriae legato fratre apud Sipylum montem, cum arcus hostium pluvia hebetati fuissent, vicit et regni parte privavit: hinc Asiaticus dictus. <milestone unit="par" n="2"/> Post reus pecuniae interceptae, ne in carcerem duceretur, Gracchus pater tribunus plebis, inimicus eius, intercessit. M. Cato censor equum ei ignominiae causa ademit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Fulvius Nobilior</hi> consul Vettonas Oretanosque
+               superavit, unde ovans urbem introiit. <milestone unit="par" n="2"/> Consul Aetolos,
+               qui bello Macedonico Romanis affuerant, post ad Antiochum defecerant, proeliis
+               frequentibus victos et in Ambraciam oppidum coactos in deditionem accepit, tamen
+               signis tabulisque pictis spoliavit; de quibus triumphavit. <milestone unit="par"
+                  n="3"/> Quam victoriam per se magnificam Ennius amicus eius insigni laude
+               celebravit. </p>
          </div>
-            <div type="cap" n="54">
+         <div type="cap" n="53">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Antiochus</hi>, rex Syriae, nimia opum fiducia bellum Romanis intulit, specie Lysimachiae repetundae, quam a maioribus suis in Thracia conditam Romani possidebant, statimque Graeciam insulasque eius occupavit. In Euboea luxuria elanguit. <milestone unit="par" n="2"/> Adventu M. Acilii Glabrionis excitatus Thermopylas occupavit, unde industria Marci Catonis eiectus in Asiam refugit. <milestone unit="par" n="3"/> Navali proelio, cui Hannibalem praefecerat, a L. Aemilio Regillo superatus filium Scipionis Africani, quem inter navigandum ceperat, patri remisit, qui ei quasi pro reddenda gratia suasit, ut amicitiam Romanam peteret. <milestone unit="par" n="4"/> Antiochus spreto consilio apud Sipylum montem cum L. Scipione conflixit. Victus et ultra Taurum montem relegatus a sodalibus, quos temulentus in convivio pulsarat, occisus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Scipio Asiaticus</hi>, frater Africani, infirmo corpore, tamen in
+               Africa virtutis nomine a fratre laudatus, consul Antiochum regem Syriae legato fratre
+               apud Sipylum montem, cum arcus hostium pluvia hebetati fuissent, vicit et regni parte
+               privavit: hinc Asiaticus dictus. <milestone unit="par" n="2"/> Post reus pecuniae
+               interceptae, ne in carcerem duceretur, Gracchus pater tribunus plebis, inimicus eius,
+               intercessit. M. Cato censor equum ei ignominiae causa ademit. </p>
          </div>
-            <div type="cap" n="55">
+         <div type="cap" n="54">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Manlius Vulso</hi> missus ad ordinandam Scipionis Asiatici provinciam cupidine triumphi bellum Pisidis et Gallograecis, qui Antiocho affuerant, intulit. <milestone unit="par" n="2"/> His facile victis inter captivos uxor regis Orgiagontis centurioni cuidam in custodiam data; a quo vi stuprata de iniuria tacuit et post impetrata redemptione marito adulterum interficiendum tradidit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Antiochus</hi>, rex Syriae, nimia opum fiducia bellum Romanis
+               intulit, specie Lysimachiae repetundae, quam a maioribus suis in Thracia conditam
+               Romani possidebant, statimque Graeciam insulasque eius occupavit. In Euboea luxuria
+               elanguit. <milestone unit="par" n="2"/> Adventu M. Acilii Glabrionis excitatus
+               Thermopylas occupavit, unde industria Marci Catonis eiectus in Asiam refugit.
+                  <milestone unit="par" n="3"/> Navali proelio, cui Hannibalem praefecerat, a L.
+               Aemilio Regillo superatus filium Scipionis Africani, quem inter navigandum ceperat,
+               patri remisit, qui ei quasi pro reddenda gratia suasit, ut amicitiam Romanam peteret.
+                  <milestone unit="par" n="4"/> Antiochus spreto consilio apud Sipylum montem cum L.
+               Scipione conflixit. Victus et ultra Taurum montem relegatus a sodalibus, quos
+               temulentus in convivio pulsarat, occisus est. </p>
          </div>
-            <div type="cap" n="56">
+         <div type="cap" n="55">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Aemilius Paullus</hi>, filius eius, qui apud Cannas cecidit, primo consulatu, quem post tres repulsas adeptus erat, de Liguribus triumphavit. <milestone unit="par" n="2"/> Rerum gestarum ordinem in tabula pictum publice posuit. <milestone unit="par" n="3"/> Iterum consul Persen Philippi filium regem Macedonum apud Samothracas deos cepit; quem victum flevit et assidere sibi iussit, tamen in triumphum duxit. <milestone unit="par" n="4"/> In hac laetitia duos filios amisit et progressus ad populum gratias fortunae egit, quod, si quid adversi reipublicae imminebat, sua esset calamitate decisum. <milestone unit="par" n="5"/> Ob haec omnia ei a populo et a senatu concessum est, ut ludis Circensibus triumphali veste uteretur. <milestone unit="par" n="6"/> Ob huius continentiam et paupertatem post mortem eius dos uxori nisi venditis possessionibus non potuit exsolvi. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Manlius Vulso</hi> missus ad ordinandam Scipionis Asiatici
+               provinciam cupidine triumphi bellum Pisidis et Gallograecis, qui Antiocho affuerant,
+               intulit. <milestone unit="par" n="2"/> His facile victis inter captivos uxor regis
+               Orgiagontis centurioni cuidam in custodiam data; a quo vi stuprata de iniuria tacuit
+               et post impetrata redemptione marito adulterum interficiendum tradidit. </p>
          </div>
-            <div type="cap" n="57">
+         <div type="cap" n="56">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Tiberius Sempronius Gracchus</hi> nobilissima familia ortus Scipionem Asiaticum quamvis inimicum duci in carcerem non est passus. <milestone unit="par" n="2"/> Praetor Galliam domuit, consul Hispaniam, altero consulatu Sardiniam; tantumque captivorum adduxit, ut longa venditione res in proverbium veniret „Sardi venales‟. <milestone unit="par" n="3"/> Censor libertinos, qui rusticas tribus occuparant, in quattuor urbanas divisit; ob quod a populo collega eius Claudius (nam ipsum auctoritas tuebatur) reus factus; et cum eum duae classes condemnassent, Tiberius iuravit se cum illo in exilium iturum: ita reus absolutus est. <milestone unit="par" n="4"/> Cum in domo Tiberii duo angues e geniali toro erepsissent, responso dato eum de dominis periturum, cuius sexus anguis fuisset occisus, amore Corneliae coniugis marem iussit interfici. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Aemilius Paullus</hi>, filius eius, qui apud Cannas
+               cecidit, primo consulatu, quem post tres repulsas adeptus erat, de Liguribus
+               triumphavit. <milestone unit="par" n="2"/> Rerum gestarum ordinem in tabula pictum
+               publice posuit. <milestone unit="par" n="3"/> Iterum consul Persen Philippi filium
+               regem Macedonum apud Samothracas deos cepit; quem victum flevit et assidere sibi
+               iussit, tamen in triumphum duxit. <milestone unit="par" n="4"/> In hac laetitia duos
+               filios amisit et progressus ad populum gratias fortunae egit, quod, si quid adversi
+               reipublicae imminebat, sua esset calamitate decisum. <milestone unit="par" n="5"/> Ob
+               haec omnia ei a populo et a senatu concessum est, ut ludis Circensibus triumphali
+               veste uteretur. <milestone unit="par" n="6"/> Ob huius continentiam et paupertatem
+               post mortem eius dos uxori nisi venditis possessionibus non potuit exsolvi. </p>
          </div>
-            <div type="cap" n="58">
+         <div type="cap" n="57">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Publius Scipio Aemilianus</hi>, Paulli Macedonici filius, a Scipione Africano adoptatus, in Macedonia cum patre agens victum Persen tam pertinaciter persecutus est, ut media nocte in castra redierit. <milestone unit="par" n="2"/> Lucullo in Hispania legatus apud Intercatiam oppidum provocatorem singulari proelio vicit. <milestone unit="par" n="3"/> Muros hostilis civitatis primus ascendit. <milestone unit="par" n="4"/> Tribunus in Africa sub T. Manilio imperatore octo cohortes obsidione vallatas consilio et virtute servavit, a quibus corona obsidionali aurea donatus. <milestone unit="par" n="5"/> Cum aedilitatem peteret, consul ante annos ultro factus Carthaginem intra sex menses delevit. <milestone unit="par" n="6"/> Numantiam in Hispania correcta prius militum disciplina fame vicit; hinc Numantinus. <milestone unit="par" n="7"/> Gaio Laelio plurimum usus; ad reges adeundos missus duos secum praeter eum servos duxit. <milestone unit="par" n="8"/> Ob res gestas superbus Gracchum iure caesum videri respondit; obstrepente populo: Taceant, inquit, quibus Italia noverca, non mater est; et addidit: Quos ego sub corona vendidi. <milestone unit="par" n="9"/> Censor Mummio collega segniore in senatu ait: Vtinam mihi collegam aut dedissetis aut non dedissetis. <milestone unit="par" n="10"/> Suscepta agrariorum causa domi repente exanimis inventus obvoluto capite elatus, ne livor in ore appareret. <milestone unit="par" n="11"/> Huius patrimonium tam exiguum <supplied>fuit</supplied>, ut XXXII libras argenti, duas et semilibram auri reliquerit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Tiberius Sempronius Gracchus</hi> nobilissima familia ortus
+               Scipionem Asiaticum quamvis inimicum duci in carcerem non est passus. <milestone
+                  unit="par" n="2"/> Praetor Galliam domuit, consul Hispaniam, altero consulatu
+               Sardiniam; tantumque captivorum adduxit, ut longa venditione res in proverbium
+               veniret „Sardi venales‟. <milestone unit="par" n="3"/> Censor libertinos, qui
+               rusticas tribus occuparant, in quattuor urbanas divisit; ob quod a populo collega
+               eius Claudius (nam ipsum auctoritas tuebatur) reus factus; et cum eum duae classes
+               condemnassent, Tiberius iuravit se cum illo in exilium iturum: ita reus absolutus
+               est. <milestone unit="par" n="4"/> Cum in domo Tiberii duo angues e geniali toro
+               erepsissent, responso dato eum de dominis periturum, cuius sexus anguis fuisset
+               occisus, amore Corneliae coniugis marem iussit interfici. </p>
          </div>
-            <div type="cap" n="59">
+         <div type="cap" n="58">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Aulus Hostilius Mancinus</hi> praetor adversum Numantinos vetantibus avibus et nescio qua voce revocante profectus, cum ad Numantiam venisset, exercitum Pompei acceptum prius corrigere decrevit et solitudinem petiit. <milestone unit="par" n="2"/> Eo die Numantinis forte sollemni nuptum filias locabant; et unam speciosam duobus competentibus pater puellae condicionem tulit, ut ei illa nuberet, qui hostis dexteram attulisset. <milestone unit="par" n="3"/> Profecti iuvenes abscessum Romanorum in modum fugae properantium cognoscunt, rem ad suos referunt. Illi statim quattuor milibus suorum viginti milia Romanorum ceciderunt. <milestone unit="par" n="4"/> Mancinus auctore Tiberio Graccho quaestore suo in leges hostium foedus percussit; quo per senatum improbato Mancinus Numantinis deditus nec receptus, augurio in castra deductus, praeturam postea consecutus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Publius Scipio Aemilianus</hi>, Paulli Macedonici filius, a
+               Scipione Africano adoptatus, in Macedonia cum patre agens victum Persen tam
+               pertinaciter persecutus est, ut media nocte in castra redierit. <milestone unit="par"
+                  n="2"/> Lucullo in Hispania legatus apud Intercatiam oppidum provocatorem
+               singulari proelio vicit. <milestone unit="par" n="3"/> Muros hostilis civitatis
+               primus ascendit. <milestone unit="par" n="4"/> Tribunus in Africa sub T. Manilio
+               imperatore octo cohortes obsidione vallatas consilio et virtute servavit, a quibus
+               corona obsidionali aurea donatus. <milestone unit="par" n="5"/> Cum aedilitatem
+               peteret, consul ante annos ultro factus Carthaginem intra sex menses delevit.
+                  <milestone unit="par" n="6"/> Numantiam in Hispania correcta prius militum
+               disciplina fame vicit; hinc Numantinus. <milestone unit="par" n="7"/> Gaio Laelio
+               plurimum usus; ad reges adeundos missus duos secum praeter eum servos duxit.
+                  <milestone unit="par" n="8"/> Ob res gestas superbus Gracchum iure caesum videri
+               respondit; obstrepente populo: Taceant, inquit, quibus Italia noverca, non mater est;
+               et addidit: Quos ego sub corona vendidi. <milestone unit="par" n="9"/> Censor Mummio
+               collega segniore in senatu ait: Vtinam mihi collegam aut dedissetis aut non
+               dedissetis. <milestone unit="par" n="10"/> Suscepta agrariorum causa domi repente
+               exanimis inventus obvoluto capite elatus, ne livor in ore appareret. <milestone
+                  unit="par" n="11"/> Huius patrimonium tam exiguum <supplied>fuit</supplied>, ut
+               XXXII libras argenti, duas et semilibram auri reliquerit. </p>
          </div>
-            <div type="cap" n="60">
+         <div type="cap" n="59">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Mummius</hi>, devicta Achaia Achaicus dictus, consul adversum Corinthios missus victoriam alieno labore quaesitam intercepit. <milestone unit="par" n="2"/> Nam cum illos Metellus Macedonicus apud Heracleam fudisset et duce Critolao privasset, cum lictoribus et paucis equitibus in Metelli castra properavit et Corinthios apud Leucopetram vicit duce Diaeo, qui domum refugit eamque incendit, coniugem interfecit et in ignem praecipitavit, ipse veneno interiit. <milestone unit="par" n="3"/> Mummius Corinthum signis tabulisque spoliavit; quibus cum totam replesset Italiam, in domum suam nihil contulit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Aulus Hostilius Mancinus</hi> praetor adversum Numantinos
+               vetantibus avibus et nescio qua voce revocante profectus, cum ad Numantiam venisset,
+               exercitum Pompei acceptum prius corrigere decrevit et solitudinem petiit. <milestone
+                  unit="par" n="2"/> Eo die Numantinis forte sollemni nuptum filias locabant; et
+               unam speciosam duobus competentibus pater puellae condicionem tulit, ut ei illa
+               nuberet, qui hostis dexteram attulisset. <milestone unit="par" n="3"/> Profecti
+               iuvenes abscessum Romanorum in modum fugae properantium cognoscunt, rem ad suos
+               referunt. Illi statim quattuor milibus suorum viginti milia Romanorum ceciderunt.
+                  <milestone unit="par" n="4"/> Mancinus auctore Tiberio Graccho quaestore suo in
+               leges hostium foedus percussit; quo per senatum improbato Mancinus Numantinis deditus
+               nec receptus, augurio in castra deductus, praeturam postea consecutus est. </p>
          </div>
-            <div type="cap" n="61">
+         <div type="cap" n="60">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Caecilius Metellus</hi>, domita Macedonia <hi rend="expanded">Macedonicus</hi> dictus, praetor Pseudophilippum, qui idem Andriscus dictus est, vicit. <milestone unit="par" n="2"/> Achaeos bis proelio fudit triumphandos Mummio tradidit. <milestone unit="par" n="3"/> Invisus plebi ob nimiam severitatem et ideo post duas repulsas consul aegre factus Arbacos in Hispania domuit. <milestone unit="par" n="4"/> Apud Contrebiam oppidum cohortes loco pulsas redire et locum recipere iussit. <milestone unit="par" n="5"/> Cum omnia proprio et subito consilio ageret, amico cuidam, quid acturus esset, roganti: <milestone unit="par" n="6"/> Tunicam, inquit, meam exurerem, si eam consilium meum scire existimarem. Hic quattuor filiorum pater supremo tempore humeris eorum ad sepulcrum latus est; ex quibus tres consulares, unum etiam triumphantem vidit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Mummius</hi>, devicta Achaia Achaicus dictus, consul
+               adversum Corinthios missus victoriam alieno labore quaesitam intercepit. <milestone
+                  unit="par" n="2"/> Nam cum illos Metellus Macedonicus apud Heracleam fudisset et
+               duce Critolao privasset, cum lictoribus et paucis equitibus in Metelli castra
+               properavit et Corinthios apud Leucopetram vicit duce Diaeo, qui domum refugit eamque
+               incendit, coniugem interfecit et in ignem praecipitavit, ipse veneno interiit.
+                  <milestone unit="par" n="3"/> Mummius Corinthum signis tabulisque spoliavit;
+               quibus cum totam replesset Italiam, in domum suam nihil contulit. </p>
          </div>
-            <div type="cap" n="62">
+         <div type="cap" n="61">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Caecilius Metellus Numidicus</hi>, qui de Iugurtha rege triumphavit, censor Quintium, qui se Tiberii Gracchi filium mentiebatur, in censum non recepit. <milestone unit="par" n="2"/> Idem in legem Apuleiam per vim latam iurare noluit, quare in exilium actus Smyrnae exulavit. <milestone unit="par" n="3"/> Calidia deinde rogatione revocatus cum ludis forte litteras in theatro accepisset, non prius eas legere dignatus est, quam spectaculum finiretur. <milestone unit="par" n="4"/> Metellae sororis suae virum laudare noluit, quod is olim iudicium contra leges detrectarat. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Caecilius Metellus</hi>, domita Macedonia <hi
+                  rend="expanded">Macedonicus</hi> dictus, praetor Pseudophilippum, qui idem
+               Andriscus dictus est, vicit. <milestone unit="par" n="2"/> Achaeos bis proelio fudit
+               triumphandos Mummio tradidit. <milestone unit="par" n="3"/> Invisus plebi ob nimiam
+               severitatem et ideo post duas repulsas consul aegre factus Arbacos in Hispania
+               domuit. <milestone unit="par" n="4"/> Apud Contrebiam oppidum cohortes loco pulsas
+               redire et locum recipere iussit. <milestone unit="par" n="5"/> Cum omnia proprio et
+               subito consilio ageret, amico cuidam, quid acturus esset, roganti: <milestone
+                  unit="par" n="6"/> Tunicam, inquit, meam exurerem, si eam consilium meum scire
+               existimarem. Hic quattuor filiorum pater supremo tempore humeris eorum ad sepulcrum
+               latus est; ex quibus tres consulares, unum etiam triumphantem vidit. </p>
          </div>
-            <div type="cap" n="63">
+         <div type="cap" n="62">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Quintus Metellus Pius</hi>, Numidici filius, Pius, quia patrem lacrimis et precibus assidue revocavit, praetor bello sociali Q. Popedium Marsorum ducem interfecit. <milestone unit="par" n="2"/> Consul in Hispania Herculeios fratres oppressit, Sertorium Hispania expulit. <milestone unit="par" n="3"/> Adolescens in petitione praeturae et pontificatus consularibus viris praelatus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Caecilius Metellus Numidicus</hi>, qui de Iugurtha rege
+               triumphavit, censor Quintium, qui se Tiberii Gracchi filium mentiebatur, in censum
+               non recepit. <milestone unit="par" n="2"/> Idem in legem Apuleiam per vim latam
+               iurare noluit, quare in exilium actus Smyrnae exulavit. <milestone unit="par" n="3"/>
+               Calidia deinde rogatione revocatus cum ludis forte litteras in theatro accepisset,
+               non prius eas legere dignatus est, quam spectaculum finiretur. <milestone unit="par"
+                  n="4"/> Metellae sororis suae virum laudare noluit, quod is olim iudicium contra
+               leges detrectarat. </p>
          </div>
-            <div type="cap" n="64">
+         <div type="cap" n="63">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Tiberius Gracchus</hi>, Africani ex filia nepos, quaestor Mancino in Hispania foedus eius flagitiosum probavit. <milestone unit="par" n="2"/> Periculum deditionis eloquentiae gratia effugit. <milestone unit="par" n="3"/> Tribunus plebis legem tulit, ne quis plus mille agri iugera haberet. <milestone unit="par" n="4"/> Octavio collegae intercedenti novo exemplo magistratum abrogavit. <milestone unit="par" n="5"/> Dein tulit, ut de ea pecunia, quae ex Attali hereditate erat, ageretur et populo divideretur. <milestone unit="par" n="6"/> Deinde cum prorogare sibi potestatem vellet, adversis auspiciis in publicum processit statimque Capitolium petiit manum ad caput referens, quo salutem suam populo commendabat. <milestone unit="par" n="7"/> Hoc nobilitas ita accepit, quasi diadema posceretur; segniterque cessante Mucio consule Scipio Nasica sequi se iussit, qui salvam rempublicam vellent, Gracchum in Capitolium persecutus oppressit. <milestone unit="par" n="8"/> Cuius corpus Lucretii aedilis manu in Tiberim missum; unde ille Vispillo dictus. <milestone unit="par" n="9"/> Nasica ut invidiae subtraheretur, per speciem legationis in Asiam ablegatus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Quintus Metellus Pius</hi>, Numidici filius, Pius, quia patrem
+               lacrimis et precibus assidue revocavit, praetor bello sociali Q. Popedium Marsorum
+               ducem interfecit. <milestone unit="par" n="2"/> Consul in Hispania Herculeios fratres
+               oppressit, Sertorium Hispania expulit. <milestone unit="par" n="3"/> Adolescens in
+               petitione praeturae et pontificatus consularibus viris praelatus est. </p>
          </div>
-            <div type="cap" n="65">
+         <div type="cap" n="64">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Gracchus</hi> pestilentem Sardiniam quaestor sortitus non veniente successore sua sponte discessit. <milestone unit="par" n="2"/> Asculanae et Fregellanae defectionis invidiam sustinuit. <milestone unit="par" n="3"/> Tribunus plebis agrarias et frumentarias leges tulit, colonos etiam Capuam et Tarentum mittendos censuit. <milestone unit="par" n="4"/> Triumviros agris dividendis se et Fulvium Flaccum et C. Crassum constituit. <milestone unit="par" n="5"/> Minucio Rufo tribuno plebis legibus suis obrogante in Capitolium venit; ubi cum Antyllius praeco Opimii consulis in turba fuisset occisus, in forum descendit et imprudens contionem a tribuno plebis avocavit; qua re arcessitus cum in senatum non venisset, armata familia Aventinum occupavit; ubi ab Opimio victus, dum a templo Lunae desilit, talum intorsit et Pomponio amico apud portam Trigeminam, P. Laetorio in ponte sublicio persequentibus resistente in lucum Furinae pervenit. <milestone unit="par" n="6"/> Ibi vel sua vel servi Euphori manu interfectus; caput a Septimuleio amico Gracchi ad Opimium relatum auro expensum fertur, propter avaritiam infuso plumbo gravius effectum. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Tiberius Gracchus</hi>, Africani ex filia nepos, quaestor Mancino
+               in Hispania foedus eius flagitiosum probavit. <milestone unit="par" n="2"/> Periculum
+               deditionis eloquentiae gratia effugit. <milestone unit="par" n="3"/> Tribunus plebis
+               legem tulit, ne quis plus mille agri iugera haberet. <milestone unit="par" n="4"/>
+               Octavio collegae intercedenti novo exemplo magistratum abrogavit. <milestone
+                  unit="par" n="5"/> Dein tulit, ut de ea pecunia, quae ex Attali hereditate erat,
+               ageretur et populo divideretur. <milestone unit="par" n="6"/> Deinde cum prorogare
+               sibi potestatem vellet, adversis auspiciis in publicum processit statimque Capitolium
+               petiit manum ad caput referens, quo salutem suam populo commendabat. <milestone
+                  unit="par" n="7"/> Hoc nobilitas ita accepit, quasi diadema posceretur;
+               segniterque cessante Mucio consule Scipio Nasica sequi se iussit, qui salvam
+               rempublicam vellent, Gracchum in Capitolium persecutus oppressit. <milestone
+                  unit="par" n="8"/> Cuius corpus Lucretii aedilis manu in Tiberim missum; unde ille
+               Vispillo dictus. <milestone unit="par" n="9"/> Nasica ut invidiae subtraheretur, per
+               speciem legationis in Asiam ablegatus est. </p>
          </div>
-            <div type="cap" n="66">
+         <div type="cap" n="65">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Livius Drusus</hi>, genere et eloquentia magnus, sed ambitiosus et superbus, aedilis munus magnificentissimum dedit. <milestone unit="par" n="2"/> Vbi Remmio collegae quaedam de utilitate reipublicae suggerenti: Quid tibi, inquit, cum republica nostra? <milestone unit="par" n="3"/> Quaestor in Asia nullis insignibus uti voluit, ne quid ipso esset insignius. <milestone unit="par" n="4"/> Tribunus plebis Latinis civitatem, plebi agros, equitibus curiam, senatui iudicia permisit. <milestone unit="par" n="5"/> Nimiae liberalitatis fuit: ipse etiam professus nemini se ad largiendum praeter caelum et caenum reliquisse; ideoque cum pecunia egeret, multa contra dignitatem fecit. <milestone unit="par" n="6"/> Magudulsam Mauritaniae principem ob regis simultatem profugum accepta pecunia Boccho prodidit, quem ille elephanto obiecit. <milestone unit="par" n="7"/> Adherbalem filium regis Numidarum obsidem domi suae suppressit redemptionem eius occultam a patre sperans. <milestone unit="par" n="8"/> Caepionem inimicum actionibus suis resistentem ait se de saxo Tarpeio praecipitaturum. <milestone unit="par" n="9"/> Philippo consuli legibus agrariis resistenti ita collum in comitio obtorsit, ut multus sanguis efflueret e naribus; quam ille luxuriam opprobrans muriam de turdis esse dicebat. <milestone unit="par" n="10"/> Deinde ex gratia nimia in invidiam venit. Nam plebs acceptis agris gaudebat, expulsi dolebant, equites in senatum lecti laetabantur, sed praeteriti querebantur; senatus permissis iudiciis exultabat, sed societatem cum equitibus aegre ferebat. <milestone unit="par" n="11"/> Vnde Livius anxius, ut Latinorum postulata differret, qui promissam civitatem flagitabant, repente in publico concidit sive morbo comitiali seu hausto caprino sanguine, semianimis domum relatus. <milestone unit="par" n="12"/> Vota pro illo per Italiam publice suscepta sunt. Et cum Latini consulem in Albano monte interfecturi essent, Philippum admonuit, ut caveret: unde in senatu accusatus, cum domum se reciperet, immisso inter turbam percussore corruit. <milestone unit="par" n="13"/> Invidia caedis apud Philippum et Caepionem fuit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Gracchus</hi> pestilentem Sardiniam quaestor sortitus non
+               veniente successore sua sponte discessit. <milestone unit="par" n="2"/> Asculanae et
+               Fregellanae defectionis invidiam sustinuit. <milestone unit="par" n="3"/> Tribunus
+               plebis agrarias et frumentarias leges tulit, colonos etiam Capuam et Tarentum
+               mittendos censuit. <milestone unit="par" n="4"/> Triumviros agris dividendis se et
+               Fulvium Flaccum et C. Crassum constituit. <milestone unit="par" n="5"/> Minucio Rufo
+               tribuno plebis legibus suis obrogante in Capitolium venit; ubi cum Antyllius praeco
+               Opimii consulis in turba fuisset occisus, in forum descendit et imprudens contionem a
+               tribuno plebis avocavit; qua re arcessitus cum in senatum non venisset, armata
+               familia Aventinum occupavit; ubi ab Opimio victus, dum a templo Lunae desilit, talum
+               intorsit et Pomponio amico apud portam Trigeminam, P. Laetorio in ponte sublicio
+               persequentibus resistente in lucum Furinae pervenit. <milestone unit="par" n="6"/>
+               Ibi vel sua vel servi Euphori manu interfectus; caput a Septimuleio amico Gracchi ad
+               Opimium relatum auro expensum fertur, propter avaritiam infuso plumbo gravius
+               effectum. </p>
          </div>
-            <div type="cap" n="67">
+         <div type="cap" n="66">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Marius</hi> septies consul, Arpinas, humili loco natus, primis honoribus per ordinem functus, legatus Metello in Numidia criminando eum consulatum adeptus Iugurtham captum ante currum egit. <milestone unit="par" n="2"/> In proximum annum consul ultro factus Cimbros in Gallia apud Aquas Sextias, Teutonas in Italia in campo Raudio vicit deque his triumphavit. <milestone unit="par" n="3"/> Vsque sextum consulatum per ordinem factus Apuleium tribunum plebis et Glauciam praetorem seditiosos ex senatusconsulto interemit. <milestone unit="par" n="4"/> Et cum Sulpicia rogatione provinciam Syllae eriperet, armis ab eo victus Minturnis in palude delituit. <milestone unit="par" n="5"/> Inventus et in carcerem coniectus immissum percussorem Gallum vultus auctoritate deterruit acceptaque navicula in Africam traiecit, ubi diu exulavit. <milestone unit="par" n="6"/> Mox Cinnana dominatione revocatus ruptis ergastulis exercitum fecit caesisque inimicis iniuriam ultus septimo consulatu, ut quidam ferunt, voluntaria morte decessit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Livius Drusus</hi>, genere et eloquentia magnus, sed
+               ambitiosus et superbus, aedilis munus magnificentissimum dedit. <milestone unit="par"
+                  n="2"/> Vbi Remmio collegae quaedam de utilitate reipublicae suggerenti: Quid
+               tibi, inquit, cum republica nostra? <milestone unit="par" n="3"/> Quaestor in Asia
+               nullis insignibus uti voluit, ne quid ipso esset insignius. <milestone unit="par"
+                  n="4"/> Tribunus plebis Latinis civitatem, plebi agros, equitibus curiam, senatui
+               iudicia permisit. <milestone unit="par" n="5"/> Nimiae liberalitatis fuit: ipse etiam
+               professus nemini se ad largiendum praeter caelum et caenum reliquisse; ideoque cum
+               pecunia egeret, multa contra dignitatem fecit. <milestone unit="par" n="6"/>
+               Magudulsam Mauritaniae principem ob regis simultatem profugum accepta pecunia Boccho
+               prodidit, quem ille elephanto obiecit. <milestone unit="par" n="7"/> Adherbalem
+               filium regis Numidarum obsidem domi suae suppressit redemptionem eius occultam a
+               patre sperans. <milestone unit="par" n="8"/> Caepionem inimicum actionibus suis
+               resistentem ait se de saxo Tarpeio praecipitaturum. <milestone unit="par" n="9"/>
+               Philippo consuli legibus agrariis resistenti ita collum in comitio obtorsit, ut
+               multus sanguis efflueret e naribus; quam ille luxuriam opprobrans muriam de turdis
+               esse dicebat. <milestone unit="par" n="10"/> Deinde ex gratia nimia in invidiam
+               venit. Nam plebs acceptis agris gaudebat, expulsi dolebant, equites in senatum lecti
+               laetabantur, sed praeteriti querebantur; senatus permissis iudiciis exultabat, sed
+               societatem cum equitibus aegre ferebat. <milestone unit="par" n="11"/> Vnde Livius
+               anxius, ut Latinorum postulata differret, qui promissam civitatem flagitabant,
+               repente in publico concidit sive morbo comitiali seu hausto caprino sanguine,
+               semianimis domum relatus. <milestone unit="par" n="12"/> Vota pro illo per Italiam
+               publice suscepta sunt. Et cum Latini consulem in Albano monte interfecturi essent,
+               Philippum admonuit, ut caveret: unde in senatu accusatus, cum domum se reciperet,
+               immisso inter turbam percussore corruit. <milestone unit="par" n="13"/> Invidia
+               caedis apud Philippum et Caepionem fuit. </p>
          </div>
-            <div type="cap" n="68">
+         <div type="cap" n="67">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Marius filius</hi> viginti septem annorum consulatum invasit, quem honorem tam immaturum mater flevit. <milestone unit="par" n="2"/> Hic patri saevitia similis curiam armatus obsedit, inimicos trucidavit, quorum corpora in Tiberim praecipitavit. <milestone unit="par" n="3"/> In apparatu belli, quod contra Syllam parabatur, apud Sacriportum vigiliis et labore defessus sub divo requievit et absens victus fugae, non pugnae interfuit. <milestone unit="par" n="4"/> Praeneste confugit, ubi per Lucretium Afellam obsessus temptata per cuniculum fuga, cum omnia saepta intelligeret, iugulandum se Pontio Telesino praebuit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Marius</hi> septies consul, Arpinas, humili loco natus,
+               primis honoribus per ordinem functus, legatus Metello in Numidia criminando eum
+               consulatum adeptus Iugurtham captum ante currum egit. <milestone unit="par" n="2"/>
+               In proximum annum consul ultro factus Cimbros in Gallia apud Aquas Sextias, Teutonas
+               in Italia in campo Raudio vicit deque his triumphavit. <milestone unit="par" n="3"/>
+               Vsque sextum consulatum per ordinem factus Apuleium tribunum plebis et Glauciam
+               praetorem seditiosos ex senatusconsulto interemit. <milestone unit="par" n="4"/> Et
+               cum Sulpicia rogatione provinciam Syllae eriperet, armis ab eo victus Minturnis in
+               palude delituit. <milestone unit="par" n="5"/> Inventus et in carcerem coniectus
+               immissum percussorem Gallum vultus auctoritate deterruit acceptaque navicula in
+               Africam traiecit, ubi diu exulavit. <milestone unit="par" n="6"/> Mox Cinnana
+               dominatione revocatus ruptis ergastulis exercitum fecit caesisque inimicis iniuriam
+               ultus septimo consulatu, ut quidam ferunt, voluntaria morte decessit. </p>
          </div>
-            <div type="cap" n="69">
+         <div type="cap" n="68">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Cornelius Cinna</hi> flagitiosissimus rempublicam summa crudelitate vastavit. <milestone unit="par" n="2"/> Primo consulatu legem de exulibus revocandis ferens ab Octavio collega prohibitus et honore privatus urbe profugit vocatisque ad pilleum servis adversarios vicit, Octavium interfecit, Ianiculum occupavit. <milestone unit="par" n="3"/> Iterum et tertio consulem se ipse fecit. <milestone unit="par" n="4"/> Quarto consulatu cum bellum contra Syllam pararet, Anconae ob nimiam crudelitatem ab exercitu lapidibus occisus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Marius filius</hi> viginti septem annorum consulatum
+               invasit, quem honorem tam immaturum mater flevit. <milestone unit="par" n="2"/> Hic
+               patri saevitia similis curiam armatus obsedit, inimicos trucidavit, quorum corpora in
+               Tiberim praecipitavit. <milestone unit="par" n="3"/> In apparatu belli, quod contra
+               Syllam parabatur, apud Sacriportum vigiliis et labore defessus sub divo requievit et
+               absens victus fugae, non pugnae interfuit. <milestone unit="par" n="4"/> Praeneste
+               confugit, ubi per Lucretium Afellam obsessus temptata per cuniculum fuga, cum omnia
+               saepta intelligeret, iugulandum se Pontio Telesino praebuit. </p>
          </div>
-            <div type="cap" n="70">
+         <div type="cap" n="69">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Flavius Fimbria</hi> saevissimus, quippe Cinnae satelles, Valerio Flacco consuli legatus in Asiam profectus, per simultatem dimissus corrupto exercitu ducem interficiendum curavit. <milestone unit="par" n="2"/> Ipse correptis imperii insignibus provinciam ingressus Mithridatem Pergamo expulit. <milestone unit="par" n="3"/> Ilium, ubi tardius portae patuerant, incendi iussit; ubi Minervae templum inviolatum stetit, quod divina maiestate servatum nemo dubitavit. <milestone unit="par" n="4"/> Ibidem Fimbria militiae principes securi percussit; mox a Sylla Pergami obsessus corrupto exercitu desertus semet occidit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Cornelius Cinna</hi> flagitiosissimus rempublicam summa
+               crudelitate vastavit. <milestone unit="par" n="2"/> Primo consulatu legem de exulibus
+               revocandis ferens ab Octavio collega prohibitus et honore privatus urbe profugit
+               vocatisque ad pilleum servis adversarios vicit, Octavium interfecit, Ianiculum
+               occupavit. <milestone unit="par" n="3"/> Iterum et tertio consulem se ipse fecit.
+                  <milestone unit="par" n="4"/> Quarto consulatu cum bellum contra Syllam pararet,
+               Anconae ob nimiam crudelitatem ab exercitu lapidibus occisus est. </p>
          </div>
-            <div type="cap" n="71">
+         <div type="cap" n="70">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Viriathus</hi> genere Lusitanus, ob paupertatem primo mercennarius, deinde alacritate venator, audacia latro, ad postremum dux, bellum adversum Romanos sumpsit eorumque imperatorem Claudium Vnimanum, dein C. Nigidium oppressit. <milestone unit="par" n="2"/> Pacem a Popilio maluit integer petere quam victus<unclear/> et cum alia dedisset et arma retinerentur, bellum renovavit. <milestone unit="par" n="3"/> Caepio cum vincere aliter non posset, duos satellites pecunia corrupit, qui Viriathum vino depositum peremerunt. <milestone unit="par" n="4"/> Quae victoria, quia empta erat, a senatu non probata. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Flavius Fimbria</hi> saevissimus, quippe Cinnae satelles, Valerio
+               Flacco consuli legatus in Asiam profectus, per simultatem dimissus corrupto exercitu
+               ducem interficiendum curavit. <milestone unit="par" n="2"/> Ipse correptis imperii
+               insignibus provinciam ingressus Mithridatem Pergamo expulit. <milestone unit="par"
+                  n="3"/> Ilium, ubi tardius portae patuerant, incendi iussit; ubi Minervae templum
+               inviolatum stetit, quod divina maiestate servatum nemo dubitavit. <milestone
+                  unit="par" n="4"/> Ibidem Fimbria militiae principes securi percussit; mox a Sylla
+               Pergami obsessus corrupto exercitu desertus semet occidit. </p>
          </div>
-            <div type="cap" n="72">
+         <div type="cap" n="71">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Aemilius Scaurus</hi> nobilis, pauper: nam pater eius quamvis patricius ob paupertatem carbonarium negotium exercuit. <milestone unit="par" n="2"/> Ipse primo dubitavit, honores peteret an argentariam faceret; sed eloquentiae consultus ex ea gloriam peperit. <milestone unit="par" n="3"/> Primo in Hispania corniculum meruit; sub Oreste in Sardinia stipendia fecit. <milestone unit="par" n="4"/> Aedilis iuri reddendo magis quam muneri edendo studuit. Praetor adversus Iugurtham, tamen eius pecunia victus. <milestone unit="par" n="5"/> Consul legem de sumptibus et libertinorum suffragiis tulit. <milestone unit="par" n="6"/> P. Decium praetorem transeunte ipso sedentem iussit assurgere eique vestem scidit, sellam concidit; ne quis ad eum in ius iret, edixit. <milestone unit="par" n="7"/> Consul Liguras Tauriscos domuit atque de his triumphavit. <milestone unit="par" n="8"/> Censor viam Aemiliam stravit, pontem Mulvium fecit. <milestone unit="par" n="9"/> Tantumque auctoritate potuit, ut Opimium contra Gracchum, Marium contra Glauciam et Saturninum privato consilio armaret. <milestone unit="par" n="10"/> Idem filium suum, quia praesidium deseruerat, in conspectum suum vetuit accedere; ille ob hoc dedecus mortem sibi conscivit. <milestone unit="par" n="11"/> Scaurus senex cum a Vario tribuno plebis argueretur, quasi socios et Latium ad arma coegisset, apud populum ait: Varius Sucronensis Aemilium Scaurum ait socios ad arma coegisse, Scaurus negat: utri potius credendum putatis? </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Viriathus</hi> genere Lusitanus, ob paupertatem primo
+               mercennarius, deinde alacritate venator, audacia latro, ad postremum dux, bellum
+               adversum Romanos sumpsit eorumque imperatorem Claudium Vnimanum, dein C. Nigidium
+               oppressit. <milestone unit="par" n="2"/> Pacem a Popilio maluit integer petere quam
+               victus<unclear/> et cum alia dedisset et arma retinerentur, bellum renovavit.
+                  <milestone unit="par" n="3"/> Caepio cum vincere aliter non posset, duos
+               satellites pecunia corrupit, qui Viriathum vino depositum peremerunt. <milestone
+                  unit="par" n="4"/> Quae victoria, quia empta erat, a senatu non probata. </p>
          </div>
-            <div type="cap" n="73">
+         <div type="cap" n="72">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Apuleius Saturninus</hi>, tribunus plebis seditiosus, ut gratiam Marianorum militum pararet, legem tulit, ut veteranis centena agri iugera in Africa dividerentur; intercedentem Baebium collegam facta per populum lapidatione submovit. <milestone unit="par" n="2"/> Glauciae praetori, quod is eo die, quo ipse contionem habebat, ius dicendo partem populi avocasset, sellam concidit, ut magis popularis videretur. <milestone unit="par" n="3"/> Quendam libertini ordinis subornavit, qui se Tiberii Gracchi filium fingeret. <milestone unit="par" n="4"/> Ad hoc testimonium Sempronia soror Gracchorum producta nec precibus nec minis adduci potuit, ut dedecus familiae agnosceret. <milestone unit="par" n="5"/> Saturninus Aulo Nunnio competitore interfecto tribunus plebis refectus Siciliam, Achaiam, Macedoniam novis colonis destinavit; et aurum dolo an scelere Caepionis partum ad emptionem agrorum convertit. <milestone unit="par" n="6"/> Aqua et igni interdixit ei, qui in leges suas non iurasset. <milestone unit="par" n="7"/> Huic legi multi nobiles obrogantes, cum tonuisset, clamarunt: Iam, inquit, nisi quiescetis, grandinabit. <milestone unit="par" n="8"/> Metellus Numidicus exulare quam iurare maluit. <milestone unit="par" n="9"/> Saturninus tertio tribunus plebis refectus, ut satellitem suum Glauciam praetorem faceret, Mummium competitorem eius in campo Martio necandum curavit. <milestone unit="par" n="10"/> Marius senatusconsulto armatus, quo censeretur, darent operam consules, ne quid respublica detrimenti caperet, Saturninum et Glauciam in Capitolium persecutus obsedit maximoque aestu incisis fistulis in deditionem accepit. Nec deditis fides servata: <milestone unit="par" n="11"/> Glauciae fracta cervix, Apuleius cum in curiam fugisset, lapidibus et tegulis desuper interfectus est. <milestone unit="par" n="12"/> Caput eius Rabirius quidam senator per convivia in ludibrium circumtulit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Aemilius Scaurus</hi> nobilis, pauper: nam pater eius
+               quamvis patricius ob paupertatem carbonarium negotium exercuit. <milestone unit="par"
+                  n="2"/> Ipse primo dubitavit, honores peteret an argentariam faceret; sed
+               eloquentiae consultus ex ea gloriam peperit. <milestone unit="par" n="3"/> Primo in
+               Hispania corniculum meruit; sub Oreste in Sardinia stipendia fecit. <milestone
+                  unit="par" n="4"/> Aedilis iuri reddendo magis quam muneri edendo studuit. Praetor
+               adversus Iugurtham, tamen eius pecunia victus. <milestone unit="par" n="5"/> Consul
+               legem de sumptibus et libertinorum suffragiis tulit. <milestone unit="par" n="6"/> P.
+               Decium praetorem transeunte ipso sedentem iussit assurgere eique vestem scidit,
+               sellam concidit; ne quis ad eum in ius iret, edixit. <milestone unit="par" n="7"/>
+               Consul Liguras Tauriscos domuit atque de his triumphavit. <milestone unit="par" n="8"
+               /> Censor viam Aemiliam stravit, pontem Mulvium fecit. <milestone unit="par" n="9"/>
+               Tantumque auctoritate potuit, ut Opimium contra Gracchum, Marium contra Glauciam et
+               Saturninum privato consilio armaret. <milestone unit="par" n="10"/> Idem filium suum,
+               quia praesidium deseruerat, in conspectum suum vetuit accedere; ille ob hoc dedecus
+               mortem sibi conscivit. <milestone unit="par" n="11"/> Scaurus senex cum a Vario
+               tribuno plebis argueretur, quasi socios et Latium ad arma coegisset, apud populum
+               ait: Varius Sucronensis Aemilium Scaurum ait socios ad arma coegisse, Scaurus negat:
+               utri potius credendum putatis? </p>
          </div>
-            <div type="cap" n="74">
+         <div type="cap" n="73">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Lucius Licinius Lucullus</hi> nobilis, disertus et dives, munus quaestorium amplissimum dedit. <milestone unit="par" n="2"/> Mox per Murenam in Asia classem Mithridatis et Ptolomaeum regem Alexandriae consuli Syllae conciliavit. <milestone unit="par" n="3"/> Praetor Africam iustissime rexit. <milestone unit="par" n="4"/> Adversus Mithridatem missus collegam suum Cottam Chalcedone obsessum liberavit. Cyzicum obsidione solvit. <milestone unit="par" n="5"/> Mithridatis copias ferro et fame afflixit eumque regno suo id est Ponto expulit. <milestone unit="par" n="6"/> Quem rursum cum Tigrane rege Armeniae subveniente magna felicitate superavit. <milestone unit="par" n="7"/> Nimius in habitu, maxime signorum et tabularum amore flagravit. <milestone unit="par" n="8"/> Post cum alienata mente desipere coepisset, tutela eius M. Lucullo fratri permissa est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Apuleius Saturninus</hi>, tribunus plebis seditiosus, ut
+               gratiam Marianorum militum pararet, legem tulit, ut veteranis centena agri iugera in
+               Africa dividerentur; intercedentem Baebium collegam facta per populum lapidatione
+               submovit. <milestone unit="par" n="2"/> Glauciae praetori, quod is eo die, quo ipse
+               contionem habebat, ius dicendo partem populi avocasset, sellam concidit, ut magis
+               popularis videretur. <milestone unit="par" n="3"/> Quendam libertini ordinis
+               subornavit, qui se Tiberii Gracchi filium fingeret. <milestone unit="par" n="4"/> Ad
+               hoc testimonium Sempronia soror Gracchorum producta nec precibus nec minis adduci
+               potuit, ut dedecus familiae agnosceret. <milestone unit="par" n="5"/> Saturninus Aulo
+               Nunnio competitore interfecto tribunus plebis refectus Siciliam, Achaiam, Macedoniam
+               novis colonis destinavit; et aurum dolo an scelere Caepionis partum ad emptionem
+               agrorum convertit. <milestone unit="par" n="6"/> Aqua et igni interdixit ei, qui in
+               leges suas non iurasset. <milestone unit="par" n="7"/> Huic legi multi nobiles
+               obrogantes, cum tonuisset, clamarunt: Iam, inquit, nisi quiescetis, grandinabit.
+                  <milestone unit="par" n="8"/> Metellus Numidicus exulare quam iurare maluit.
+                  <milestone unit="par" n="9"/> Saturninus tertio tribunus plebis refectus, ut
+               satellitem suum Glauciam praetorem faceret, Mummium competitorem eius in campo Martio
+               necandum curavit. <milestone unit="par" n="10"/> Marius senatusconsulto armatus, quo
+               censeretur, darent operam consules, ne quid respublica detrimenti caperet, Saturninum
+               et Glauciam in Capitolium persecutus obsedit maximoque aestu incisis fistulis in
+               deditionem accepit. Nec deditis fides servata: <milestone unit="par" n="11"/>
+               Glauciae fracta cervix, Apuleius cum in curiam fugisset, lapidibus et tegulis desuper
+               interfectus est. <milestone unit="par" n="12"/> Caput eius Rabirius quidam senator
+               per convivia in ludibrium circumtulit. </p>
          </div>
-            <div type="cap" n="75">
+         <div type="cap" n="74">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Cornelius Sylla</hi>, a fortuna Felix dictus, cum parvulus a nutrice ferretur, mulier obvia: Salve, inquit, puer tibi et reipublicae tuae felix; et statim quaesita, quae haec dixisset, non potuit inveniri. <milestone unit="par" n="2"/> Hic quaestor Marii Iugurtham a Boccho in deditionem accepit. <milestone unit="par" n="3"/> Bello Cimbrico et Teutonico legatus bonam operam navavit. Praetor inter cives ius dixit. <milestone unit="par" n="4"/> Praetor Ciliciam provinciam habuit. <milestone unit="par" n="5"/> Bello sociali Samnites Hirpinosque superavit. <milestone unit="par" n="6"/> Ne monumenta Bocchi tollerentur, Mario restitit. <milestone unit="par" n="7"/> Consul Asiam sortitus Mithridatem apud Orchomenum et Chaeroniam proelio fudit, Archelaum praefectum eius Athenis vicit, portum Piraeum recepit, Maedos et Dardanos in itinere superavit. <milestone unit="par" n="8"/> Mox cum rogatione Sulpicia imperium eius transferretur ad Marium, in Italiam regressus corruptis adversariorum exercitibus Carbonem Italia expulit, Marium apud Sacriportum, Telesinum apud portam Collinam vicit. <milestone unit="par" n="9"/> Mario Praeneste interfecto Felicem se edicto appellavit. Proscriptionis tabulas primus proposuit. <milestone unit="par" n="10"/> Novem milia dediticiorum in villa publica cecidit. <milestone unit="par" n="11"/> Numerum sacerdotum auxit, tribuniciam potestatem minuit. <milestone unit="par" n="12"/> Republica ordinata dictaturam deposuit; unde sperni coeptus Puteolos concessit et morbo, qui phthiriasis vocatur, interiit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Lucius Licinius Lucullus</hi> nobilis, disertus et dives, munus
+               quaestorium amplissimum dedit. <milestone unit="par" n="2"/> Mox per Murenam in Asia
+               classem Mithridatis et Ptolomaeum regem Alexandriae consuli Syllae conciliavit.
+                  <milestone unit="par" n="3"/> Praetor Africam iustissime rexit. <milestone
+                  unit="par" n="4"/> Adversus Mithridatem missus collegam suum Cottam Chalcedone
+               obsessum liberavit. Cyzicum obsidione solvit. <milestone unit="par" n="5"/>
+               Mithridatis copias ferro et fame afflixit eumque regno suo id est Ponto expulit.
+                  <milestone unit="par" n="6"/> Quem rursum cum Tigrane rege Armeniae subveniente
+               magna felicitate superavit. <milestone unit="par" n="7"/> Nimius in habitu, maxime
+               signorum et tabularum amore flagravit. <milestone unit="par" n="8"/> Post cum
+               alienata mente desipere coepisset, tutela eius M. Lucullo fratri permissa est. </p>
          </div>
-            <div type="cap" n="76">
+         <div type="cap" n="75">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Mithridates</hi> rex Ponti oriundus a septem Persis, magna vi animi et corporis, ut sexiuges equos regeret, quinquaginta gentium ore loqueretur. <milestone unit="par" n="2"/> Bello sociali dissidentibus Romanis Nicomedem Bithynia, Ariobarzanen Cappadocia expulit. <milestone unit="par" n="3"/> Litteras per totam Asiam misit, ut, quicunque Romanus esset, certa die interficeretur; et factum est. <milestone unit="par" n="4"/> Graeciam insulasque omnes excepta Rhodo occupavit. <milestone unit="par" n="5"/> Sylla eum proelio vicit, classem eius proditione Archelai intercepit, ipsum apud Dardanum oppidum fudit et oppressit, et potuit capere, nisi adversum Marium festinans qualemcumque pacem componere maluisset. <milestone unit="par" n="6"/> Deinde eum acrius resistentem Lucullus fudit. <milestone unit="par" n="7"/> Mithridates post a Pompeio nocturno proelio victus in regnum confugit, ubi per seditionem popularium a Pharnace filio in turre obsessus venenum sumpsit. <milestone unit="par" n="8"/> Quod cum tardius combiberet, quia adversum venena multis antea medicaminibus corpus firmarat, immissum percussorem Gallum Bithocum auctoritate vultus territum revocavit et in caedem suam manum trepidantis adiuvit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Cornelius Sylla</hi>, a fortuna Felix dictus, cum parvulus a
+               nutrice ferretur, mulier obvia: Salve, inquit, puer tibi et reipublicae tuae felix;
+               et statim quaesita, quae haec dixisset, non potuit inveniri. <milestone unit="par"
+                  n="2"/> Hic quaestor Marii Iugurtham a Boccho in deditionem accepit. <milestone
+                  unit="par" n="3"/> Bello Cimbrico et Teutonico legatus bonam operam navavit.
+               Praetor inter cives ius dixit. <milestone unit="par" n="4"/> Praetor Ciliciam
+               provinciam habuit. <milestone unit="par" n="5"/> Bello sociali Samnites Hirpinosque
+               superavit. <milestone unit="par" n="6"/> Ne monumenta Bocchi tollerentur, Mario
+               restitit. <milestone unit="par" n="7"/> Consul Asiam sortitus Mithridatem apud
+               Orchomenum et Chaeroniam proelio fudit, Archelaum praefectum eius Athenis vicit,
+               portum Piraeum recepit, Maedos et Dardanos in itinere superavit. <milestone
+                  unit="par" n="8"/> Mox cum rogatione Sulpicia imperium eius transferretur ad
+               Marium, in Italiam regressus corruptis adversariorum exercitibus Carbonem Italia
+               expulit, Marium apud Sacriportum, Telesinum apud portam Collinam vicit. <milestone
+                  unit="par" n="9"/> Mario Praeneste interfecto Felicem se edicto appellavit.
+               Proscriptionis tabulas primus proposuit. <milestone unit="par" n="10"/> Novem milia
+               dediticiorum in villa publica cecidit. <milestone unit="par" n="11"/> Numerum
+               sacerdotum auxit, tribuniciam potestatem minuit. <milestone unit="par" n="12"/>
+               Republica ordinata dictaturam deposuit; unde sperni coeptus Puteolos concessit et
+               morbo, qui phthiriasis vocatur, interiit. </p>
          </div>
-            <div type="cap" n="77">
+         <div type="cap" n="76">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Cn. Pompeius Magnus</hi>, civili bello Syllae partes secutus ita egit, ut ab eo maxime diligeretur. Siciliam sine bello a proscriptis recepit. <milestone unit="par" n="2"/> Numidiam Hiarbae ereptam Massinissae restituit. Viginti sex annos natus triumphavit. <milestone unit="par" n="3"/> Lepidum acta Syllae rescindere volentem privatus Italia fugavit. <milestone unit="par" n="4"/> Praetor in Hispaniam pro consulibus missus Sertorium vicit. <milestone unit="par" n="5"/> Mox piratas intra quadragesimum diem subegit. Tigranem ad deditionem, Mithridatem ad venenum compulit. <milestone unit="par" n="6"/> Deinde mira felicitate nunc in septemtrionem Albanos, Colchos, Heniochos, Caspios, Iberos, nunc in orientem Parthos, Arabas atque Iudaeos cum magno sui terrore penetravit. <milestone unit="par" n="7"/> Primus in Hyrcanum, Rubrum et Arabicum mare usque pervenit. <milestone unit="par" n="8"/> Moxque diviso orbis imperio, cum Crassus Syriam, Caesar Galliam, Pompeius urbem obtineret, post caedem Crassi Caesarem dimittere exercitum iussit. <milestone unit="par" n="9"/> Cuius infesto adventu urbe pulsus, in Pharsalia victus ad Ptolomaeum Alexandriae regem confugit. Eius imperio ab Achilla et Potino satellitibus occisus est. </p>
-                <p> (Huius latus sub oculis uxoris et liberorum a Septimio, Ptolomaei praefecto, mucrone confossum est. Iamque defuncti caput gladio praecisum, quod usque ad ea tempora fuerat ignoratum. Truncus Nilo iactatus a Servio Codro rogo inustus humatusque est inscribente sepulcro: <hi rend="expanded">Hic positus est Magnus</hi>. Caput ab Achilla, Ptolomaei satellite, Aegyptio velamine involutum cum anulo Caesari praesentatum est; qui non continens lacrimas illud plurimis et pretiosissimis odoribus cremandum curavit.) </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Mithridates</hi> rex Ponti oriundus a septem Persis, magna vi
+               animi et corporis, ut sexiuges equos regeret, quinquaginta gentium ore loqueretur.
+                  <milestone unit="par" n="2"/> Bello sociali dissidentibus Romanis Nicomedem
+               Bithynia, Ariobarzanen Cappadocia expulit. <milestone unit="par" n="3"/> Litteras per
+               totam Asiam misit, ut, quicunque Romanus esset, certa die interficeretur; et factum
+               est. <milestone unit="par" n="4"/> Graeciam insulasque omnes excepta Rhodo occupavit.
+                  <milestone unit="par" n="5"/> Sylla eum proelio vicit, classem eius proditione
+               Archelai intercepit, ipsum apud Dardanum oppidum fudit et oppressit, et potuit
+               capere, nisi adversum Marium festinans qualemcumque pacem componere maluisset.
+                  <milestone unit="par" n="6"/> Deinde eum acrius resistentem Lucullus fudit.
+                  <milestone unit="par" n="7"/> Mithridates post a Pompeio nocturno proelio victus
+               in regnum confugit, ubi per seditionem popularium a Pharnace filio in turre obsessus
+               venenum sumpsit. <milestone unit="par" n="8"/> Quod cum tardius combiberet, quia
+               adversum venena multis antea medicaminibus corpus firmarat, immissum percussorem
+               Gallum Bithocum auctoritate vultus territum revocavit et in caedem suam manum
+               trepidantis adiuvit. </p>
          </div>
-            <div type="cap" n="78">
+         <div type="cap" n="77">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Iulius Caesar</hi>, veneratione rerum gestarum Divus dictus, contubernalis Thermo in Asiam profectus, cum saepe ad Nicomedem, regem Bithyniae, commearet, impudicitiae infamatus est. <milestone unit="par" n="2"/> Mox Dolabellam iudicio oppressit. <milestone unit="par" n="3"/> Dum studiorum causa Rhodum petit, a piratis captus et redemptus, eosdem et postea captos punivit. <milestone unit="par" n="4"/> Praetor Lusitaniam et post Galliam ab Alpibus usque et Oceanum bis classe transgressus Britanniam subegit. <milestone unit="par" n="5"/> Cum ei triumphus a Pompeio negaretur, armis eum urbe pulsum in Pharsalia vicit. <milestone unit="par" n="6"/> Capite eius oblato flevit, et honorifice sepeliri fecit; mox a satellitibus Ptolomaei obsessus eorum et regis nece Pompeio parentavit. <milestone unit="par" n="7"/> Pharnacem Mithridatis filium fama nominis fugavit. <milestone unit="par" n="8"/> Iubam et Scipionem in Africa, Pompeios iuvenes in Hispania apud Mundam oppidum ingenti proelio vicit. <milestone unit="par" n="9"/> Deinde ignoscendo amicis odia cum armis deposuit: nam Lentulum tantum et Afranium et Faustum Syllae filium iussit occidi. <milestone unit="par" n="10"/> Dictator in perpetuum factus a senatu, in curia Cassio et Bruto caedis auctoribus tribus et viginti vulneribus occisus est; cuius corpore pro rostris posito sol orbem suum celasse dicitur. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Cn. Pompeius Magnus</hi>, civili bello Syllae partes secutus ita
+               egit, ut ab eo maxime diligeretur. Siciliam sine bello a proscriptis recepit.
+                  <milestone unit="par" n="2"/> Numidiam Hiarbae ereptam Massinissae restituit.
+               Viginti sex annos natus triumphavit. <milestone unit="par" n="3"/> Lepidum acta
+               Syllae rescindere volentem privatus Italia fugavit. <milestone unit="par" n="4"/>
+               Praetor in Hispaniam pro consulibus missus Sertorium vicit. <milestone unit="par"
+                  n="5"/> Mox piratas intra quadragesimum diem subegit. Tigranem ad deditionem,
+               Mithridatem ad venenum compulit. <milestone unit="par" n="6"/> Deinde mira felicitate
+               nunc in septemtrionem Albanos, Colchos, Heniochos, Caspios, Iberos, nunc in orientem
+               Parthos, Arabas atque Iudaeos cum magno sui terrore penetravit. <milestone unit="par"
+                  n="7"/> Primus in Hyrcanum, Rubrum et Arabicum mare usque pervenit. <milestone
+                  unit="par" n="8"/> Moxque diviso orbis imperio, cum Crassus Syriam, Caesar
+               Galliam, Pompeius urbem obtineret, post caedem Crassi Caesarem dimittere exercitum
+               iussit. <milestone unit="par" n="9"/> Cuius infesto adventu urbe pulsus, in Pharsalia
+               victus ad Ptolomaeum Alexandriae regem confugit. Eius imperio ab Achilla et Potino
+               satellitibus occisus est. </p>
+            <p> (Huius latus sub oculis uxoris et liberorum a Septimio, Ptolomaei praefecto, mucrone
+               confossum est. Iamque defuncti caput gladio praecisum, quod usque ad ea tempora
+               fuerat ignoratum. Truncus Nilo iactatus a Servio Codro rogo inustus humatusque est
+               inscribente sepulcro: <hi rend="expanded">Hic positus est Magnus</hi>. Caput ab
+               Achilla, Ptolomaei satellite, Aegyptio velamine involutum cum anulo Caesari
+               praesentatum est; qui non continens lacrimas illud plurimis et pretiosissimis
+               odoribus cremandum curavit.) </p>
          </div>
-            <div type="cap" n="79">
+         <div type="cap" n="78">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Caesar Octavianus</hi> ex Octavia familia in Iuliam translatus in ultionem Iulii Caesaris, a quo heres fuerat institutus, Brutum et Cassium caedis auctores in Macedonia vicit. <milestone unit="par" n="2"/> Sextum Pompeium Gnaei Pompei filium bona paterna repetentem in freto Siculo superavit. <milestone unit="par" n="3"/> Marcum Antonium consulem Syriam obtinentem amore Cleopatrae devinctum in Actiaco Ambraciae litore debellavit. <milestone unit="par" n="4"/> Reliquam orbis partem per legatos domuit. Huic Parthi signa, quae Crasso sustulerant, ultro reddiderunt. <milestone unit="par" n="5"/> Indi, Scythae, Sarmatae, Daci, quos non domuerat, dona miserunt. <milestone unit="par" n="6"/> Iani gemini portas bis ante se clausas, primo sub Numa, iterum post primum Punicum bellum, sua manu clausit. <milestone unit="par" n="7"/> Dictator in perpetuum factus a senatu ob res gestas Divus Augustus est appellatus. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Iulius Caesar</hi>, veneratione rerum gestarum Divus
+               dictus, contubernalis Thermo in Asiam profectus, cum saepe ad Nicomedem, regem
+               Bithyniae, commearet, impudicitiae infamatus est. <milestone unit="par" n="2"/> Mox
+               Dolabellam iudicio oppressit. <milestone unit="par" n="3"/> Dum studiorum causa
+               Rhodum petit, a piratis captus et redemptus, eosdem et postea captos punivit.
+                  <milestone unit="par" n="4"/> Praetor Lusitaniam et post Galliam ab Alpibus usque
+               et Oceanum bis classe transgressus Britanniam subegit. <milestone unit="par" n="5"/>
+               Cum ei triumphus a Pompeio negaretur, armis eum urbe pulsum in Pharsalia vicit.
+                  <milestone unit="par" n="6"/> Capite eius oblato flevit, et honorifice sepeliri
+               fecit; mox a satellitibus Ptolomaei obsessus eorum et regis nece Pompeio parentavit.
+                  <milestone unit="par" n="7"/> Pharnacem Mithridatis filium fama nominis fugavit.
+                  <milestone unit="par" n="8"/> Iubam et Scipionem in Africa, Pompeios iuvenes in
+               Hispania apud Mundam oppidum ingenti proelio vicit. <milestone unit="par" n="9"/>
+               Deinde ignoscendo amicis odia cum armis deposuit: nam Lentulum tantum et Afranium et
+               Faustum Syllae filium iussit occidi. <milestone unit="par" n="10"/> Dictator in
+               perpetuum factus a senatu, in curia Cassio et Bruto caedis auctoribus tribus et
+               viginti vulneribus occisus est; cuius corpore pro rostris posito sol orbem suum
+               celasse dicitur. </p>
          </div>
-            <div type="cap" n="80">
+         <div type="cap" n="79">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Cato praetorius</hi> Catonis censorii pronepos cum in domo avunculi Drusi educaretur, nec pretio nec minis potuit adduci a Q. Popedio Silone Marsorum principe, ut favere se causae sociorum diceret. <milestone unit="par" n="2"/> Quaestor Cyprum missus ad vehendam ex Ptolomaei hereditate pecuniam cum summa eam fide perduxit; praeterea coniuratos puniendos censuit. <milestone unit="par" n="3"/> Bello civili Pompei partes secutus est; quo victo exercitum per deserta Africae duxit, ubi Scipioni consulari delatum ad se imperium concessit. <milestone unit="par" n="4"/> Victis partibus Vticam concessit, ubi filium hortatus, ut clementiam Caesaris experiretur, ipse lecto Platonis libro, qui de bono mortis est, semet occidit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Caesar Octavianus</hi> ex Octavia familia in Iuliam translatus in
+               ultionem Iulii Caesaris, a quo heres fuerat institutus, Brutum et Cassium caedis
+               auctores in Macedonia vicit. <milestone unit="par" n="2"/> Sextum Pompeium Gnaei
+               Pompei filium bona paterna repetentem in freto Siculo superavit. <milestone
+                  unit="par" n="3"/> Marcum Antonium consulem Syriam obtinentem amore Cleopatrae
+               devinctum in Actiaco Ambraciae litore debellavit. <milestone unit="par" n="4"/>
+               Reliquam orbis partem per legatos domuit. Huic Parthi signa, quae Crasso sustulerant,
+               ultro reddiderunt. <milestone unit="par" n="5"/> Indi, Scythae, Sarmatae, Daci, quos
+               non domuerat, dona miserunt. <milestone unit="par" n="6"/> Iani gemini portas bis
+               ante se clausas, primo sub Numa, iterum post primum Punicum bellum, sua manu clausit.
+                  <milestone unit="par" n="7"/> Dictator in perpetuum factus a senatu ob res gestas
+               Divus Augustus est appellatus. </p>
          </div>
-            <div type="cap" n="81">
+         <div type="cap" n="80">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Tullius Cicero</hi>, genere Arpinas, patre equite Romano natus, genus a Tito Tatio rege duxit. <milestone unit="par" n="2"/> Adolescens Rosciano iudicio eloquentiam et libertatem suam adversus Sullanos ostendit; ex quo veritus invidiam Athenas studiorum gratia petivit, ubi Antiochum Academicum philosophum studiose audivit. Inde eloquentiae gratia Asiam, post Rhodum petiit, ubi Molonem Graecum rhetorem tum disertissimum magistrum habuit; qui flesse dicitur, quod per hunc Graecia eloquentiae laude privaretur. <milestone unit="par" n="3"/> Quaestor Siciliam habuit. Aedilis Gaium Verrem repetundarum damnavit. Praetor Ciliciam latrociniis liberavit. <milestone unit="par" n="4"/> Consul coniuratos capite punivit. Mox invidia P. Clodii instinctuque Caesaris et Pompei, quos dominationis suspectos eadem, qua quondam Sullanos, libertate perstrinxerat, sollicitatis Pisone et Gabinio consulibus, qui Macedoniam Asiamque provincias in stipendium opera huius acceperant, in exilium actus; mox ipso referente Pompeio rediit eumque civili bello secutus est. <milestone unit="par" n="5"/> Quo victo veniam a Caesare ultro accepit; quo interfecto Augustum fovit, Antonium hostem iudicavit; <milestone unit="par" n="6"/> et cum triumviros se fecissent Caesar, Lepidus Antoniusque, concordia non aliter visa est inter eos iungi posse, nisi Tullius necaretur; qui immissis ab Antonio percussoribus cum forte Formiis quiesceret, imminens exitium corvi auspicio didicit et fugiens occisus est. Caput ad Antonium relatum. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Cato praetorius</hi> Catonis censorii pronepos cum in domo
+               avunculi Drusi educaretur, nec pretio nec minis potuit adduci a Q. Popedio Silone
+               Marsorum principe, ut favere se causae sociorum diceret. <milestone unit="par" n="2"
+               /> Quaestor Cyprum missus ad vehendam ex Ptolomaei hereditate pecuniam cum summa eam
+               fide perduxit; praeterea coniuratos puniendos censuit. <milestone unit="par" n="3"/>
+               Bello civili Pompei partes secutus est; quo victo exercitum per deserta Africae
+               duxit, ubi Scipioni consulari delatum ad se imperium concessit. <milestone unit="par"
+                  n="4"/> Victis partibus Vticam concessit, ubi filium hortatus, ut clementiam
+               Caesaris experiretur, ipse lecto Platonis libro, qui de bono mortis est, semet
+               occidit. </p>
          </div>
-            <div type="cap" n="82">
+         <div type="cap" n="81">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Brutus</hi>, avunculi Catonis imitator, Athenis philosophiam, Rhodi eloquentiam didicit. <milestone unit="par" n="2"/> Cytheridem mimam cum Antonio et Gallo amavit. <milestone unit="par" n="3"/> Quaestor <supplied>Caesari</supplied> in Galliam proficisci noluit, quod is bonis omnibus displicebat. <milestone unit="par" n="4"/> Cum Appio socero in Cilicia fuit, et cum ille repetundarum accusaretur, ipse ne verbo quidem infamatus est. <milestone unit="par" n="5"/> Civili bello a Catone ex Cilicia retractus Pompeium secutus est, quo victo veniam a Caesare accepit et proconsul Galliam rexit; tamen cum aliis coniuratis in curia Caesarem occidit. <milestone unit="par" n="6"/> Et ob invidiam veteranorum in Macedoniam missus, ab Augusto in campis Philippiis victus Stratoni cervicem praebuit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Tullius Cicero</hi>, genere Arpinas, patre equite Romano
+               natus, genus a Tito Tatio rege duxit. <milestone unit="par" n="2"/> Adolescens
+               Rosciano iudicio eloquentiam et libertatem suam adversus Sullanos ostendit; ex quo
+               veritus invidiam Athenas studiorum gratia petivit, ubi Antiochum Academicum
+               philosophum studiose audivit. Inde eloquentiae gratia Asiam, post Rhodum petiit, ubi
+               Molonem Graecum rhetorem tum disertissimum magistrum habuit; qui flesse dicitur, quod
+               per hunc Graecia eloquentiae laude privaretur. <milestone unit="par" n="3"/> Quaestor
+               Siciliam habuit. Aedilis Gaium Verrem repetundarum damnavit. Praetor Ciliciam
+               latrociniis liberavit. <milestone unit="par" n="4"/> Consul coniuratos capite
+               punivit. Mox invidia P. Clodii instinctuque Caesaris et Pompei, quos dominationis
+               suspectos eadem, qua quondam Sullanos, libertate perstrinxerat, sollicitatis Pisone
+               et Gabinio consulibus, qui Macedoniam Asiamque provincias in stipendium opera huius
+               acceperant, in exilium actus; mox ipso referente Pompeio rediit eumque civili bello
+               secutus est. <milestone unit="par" n="5"/> Quo victo veniam a Caesare ultro accepit;
+               quo interfecto Augustum fovit, Antonium hostem iudicavit; <milestone unit="par" n="6"
+               /> et cum triumviros se fecissent Caesar, Lepidus Antoniusque, concordia non aliter
+               visa est inter eos iungi posse, nisi Tullius necaretur; qui immissis ab Antonio
+               percussoribus cum forte Formiis quiesceret, imminens exitium corvi auspicio didicit
+               et fugiens occisus est. Caput ad Antonium relatum. </p>
          </div>
-            <div type="cap" n="83">
+         <div type="cap" n="82">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Gaius Cassius Longinus</hi> quaestor Crassi in Syria fuit, post cuius caedem collectis reliquiis in Syriam rediit. <milestone unit="par" n="2"/> Osacem, praefectum regium, apud Orontem fluvium superavit. <milestone unit="par" n="3"/> Dein eo quod coemptis Syriacis mercibus foedissime negotiaretur, Caryota cognominatus est. <milestone unit="par" n="4"/> Tribunus plebis Caesarem oppugnavit. <milestone unit="par" n="5"/> Bello civili Pompeium secutus classi praefuit. <milestone unit="par" n="6"/> A Caesare veniam accepit; tamen adversus eum coniurationis auctor cum Bruto fuit et in caede dubitanti cuidam: Vel per me, inquit, feri; magnoque exercitu comparato in Macedonia Bruto coniunctus in campis Philippiis ab Antonio victus, cum eandem fortunam Bruti putaret, qui Caesarem vicerat, Pindaro liberto iugulum praebuit. <milestone unit="par" n="7"/> Cuius morte audita Antonius exclamasse dicitur: Vici. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Brutus</hi>, avunculi Catonis imitator, Athenis
+               philosophiam, Rhodi eloquentiam didicit. <milestone unit="par" n="2"/> Cytheridem
+               mimam cum Antonio et Gallo amavit. <milestone unit="par" n="3"/> Quaestor
+                  <supplied>Caesari</supplied> in Galliam proficisci noluit, quod is bonis omnibus
+               displicebat. <milestone unit="par" n="4"/> Cum Appio socero in Cilicia fuit, et cum
+               ille repetundarum accusaretur, ipse ne verbo quidem infamatus est. <milestone
+                  unit="par" n="5"/> Civili bello a Catone ex Cilicia retractus Pompeium secutus
+               est, quo victo veniam a Caesare accepit et proconsul Galliam rexit; tamen cum aliis
+               coniuratis in curia Caesarem occidit. <milestone unit="par" n="6"/> Et ob invidiam
+               veteranorum in Macedoniam missus, ab Augusto in campis Philippiis victus Stratoni
+               cervicem praebuit. </p>
          </div>
-            <div type="cap" n="84">
+         <div type="cap" n="83">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Sextus Pompeius</hi>, in Hispania apud Mundam victus, amisso fratre, reliquiis exercitus collectis Siciliam petiit, ubi ruptis ergastulis mare obsedit. <milestone unit="par" n="2"/> Interceptis commeatibus Italiam vexavit; et cum mari feliciter uteretur, Neptuni se filium professus est eumque bobus auratis et equo placavit. <milestone unit="par" n="3"/> Pace facta epulatus in navi cum Antonio et Caesare non invenuste ait: Hae sunt meae carinae; quia Romae in Carinis domum eius Antonius tenebat. <milestone unit="par" n="4"/> Rupto per eundem Antonium foedere Sextus ab Augusto per Agrippam navali proelio victus in Asiam fugit, ubi ab Antonianis militibus occisus est. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Gaius Cassius Longinus</hi> quaestor Crassi in Syria fuit, post
+               cuius caedem collectis reliquiis in Syriam rediit. <milestone unit="par" n="2"/>
+               Osacem, praefectum regium, apud Orontem fluvium superavit. <milestone unit="par"
+                  n="3"/> Dein eo quod coemptis Syriacis mercibus foedissime negotiaretur, Caryota
+               cognominatus est. <milestone unit="par" n="4"/> Tribunus plebis Caesarem oppugnavit.
+                  <milestone unit="par" n="5"/> Bello civili Pompeium secutus classi praefuit.
+                  <milestone unit="par" n="6"/> A Caesare veniam accepit; tamen adversus eum
+               coniurationis auctor cum Bruto fuit et in caede dubitanti cuidam: Vel per me, inquit,
+               feri; magnoque exercitu comparato in Macedonia Bruto coniunctus in campis Philippiis
+               ab Antonio victus, cum eandem fortunam Bruti putaret, qui Caesarem vicerat, Pindaro
+               liberto iugulum praebuit. <milestone unit="par" n="7"/> Cuius morte audita Antonius
+               exclamasse dicitur: Vici. </p>
          </div>
-            <div type="cap" n="85">
+         <div type="cap" n="84">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Marcus Antonius</hi>, in omnibus expeditionibus Iulio Caesari comes, Lupercalibus diadema ei imponere tentavit, mortuo divinos honores decrevit. <milestone unit="par" n="2"/> Augustum perfidiose tractavit, a quo apud Mutinam victus, Perusii fame domitus in Galliam fugit. Ibi Lepidum sibi collegam adiunxit; Brutum exercitu eius corrupto occidit; reparatis viribus in Italiam regressus cum Caesare in gratiam rediit. <milestone unit="par" n="3"/> Triumvir factus proscriptionem a Lucio Caesare avunculo suo coepit. <milestone unit="par" n="4"/> In Syriam missus bellum Parthis intulit; a quibus victus vix tertiam partem de quindecim legionibus in Aegyptum perduxit; ibi Cleopatrae amore devinctus in Actiaco litore ab Augusto victus est. <milestone unit="par" n="5"/> In Alexandriam regressus, cum habitu regio in solio regali sedisset, necem sibi ipse conscivit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Sextus Pompeius</hi>, in Hispania apud Mundam victus, amisso
+               fratre, reliquiis exercitus collectis Siciliam petiit, ubi ruptis ergastulis mare
+               obsedit. <milestone unit="par" n="2"/> Interceptis commeatibus Italiam vexavit; et
+               cum mari feliciter uteretur, Neptuni se filium professus est eumque bobus auratis et
+               equo placavit. <milestone unit="par" n="3"/> Pace facta epulatus in navi cum Antonio
+               et Caesare non invenuste ait: Hae sunt meae carinae; quia Romae in Carinis domum eius
+               Antonius tenebat. <milestone unit="par" n="4"/> Rupto per eundem Antonium foedere
+               Sextus ab Augusto per Agrippam navali proelio victus in Asiam fugit, ubi ab
+               Antonianis militibus occisus est. </p>
          </div>
-            <div type="cap" n="86">
+         <div type="cap" n="85">
             <p>
-               <milestone unit="par" n="1"/> 
-               <hi rend="expanded">Cleopatra</hi> Ptolomaei regis Aegyptiorum filia, a fratre suo Ptolomaeo eodemque marito, quem fraudare regno voluerat, pulsa ad Caesarem bello civili in Alexandriam venit; ab eo specie sua et concubitu regnum Ptolomaei et necem impetravit. <milestone unit="par" n="2"/> Haec tantae libidinis fuit, ut saepe prostiterit, tantae pulchritudinis, ut multi noctem illius morte emerint. <milestone unit="par" n="3"/> Postea Antonio iuncta, cum eo victa, cum se illi inferias ferre simularet, in Mausoleo eius admotis aspidibus periit. </p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Marcus Antonius</hi>, in omnibus expeditionibus Iulio Caesari
+               comes, Lupercalibus diadema ei imponere tentavit, mortuo divinos honores decrevit.
+                  <milestone unit="par" n="2"/> Augustum perfidiose tractavit, a quo apud Mutinam
+               victus, Perusii fame domitus in Galliam fugit. Ibi Lepidum sibi collegam adiunxit;
+               Brutum exercitu eius corrupto occidit; reparatis viribus in Italiam regressus cum
+               Caesare in gratiam rediit. <milestone unit="par" n="3"/> Triumvir factus
+               proscriptionem a Lucio Caesare avunculo suo coepit. <milestone unit="par" n="4"/> In
+               Syriam missus bellum Parthis intulit; a quibus victus vix tertiam partem de quindecim
+               legionibus in Aegyptum perduxit; ibi Cleopatrae amore devinctus in Actiaco litore ab
+               Augusto victus est. <milestone unit="par" n="5"/> In Alexandriam regressus, cum
+               habitu regio in solio regali sedisset, necem sibi ipse conscivit. </p>
          </div>
-            
-        </body>
-    </text>
+         <div type="cap" n="86">
+            <p>
+               <milestone unit="par" n="1"/>
+               <hi rend="expanded">Cleopatra</hi> Ptolomaei regis Aegyptiorum filia, a fratre suo
+               Ptolomaeo eodemque marito, quem fraudare regno voluerat, pulsa ad Caesarem bello
+               civili in Alexandriam venit; ab eo specie sua et concubitu regnum Ptolomaei et necem
+               impetravit. <milestone unit="par" n="2"/> Haec tantae libidinis fuit, ut saepe
+               prostiterit, tantae pulchritudinis, ut multi noctem illius morte emerint. <milestone
+                  unit="par" n="3"/> Postea Antonio iuncta, cum eo victa, cum se illi inferias ferre
+               simularet, in Mausoleo eius admotis aspidibus periit. </p>
+         </div>
+
+      </body>
+   </text>
 
 </TEI>

--- a/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="unknown" matchPattern="(\w+)"
+            <cRefPattern n="chapter" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-               <p>This pointer pattern extracts unknown</p>
+               <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>

--- a/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
@@ -34,7 +34,7 @@
       <encodingDesc>
          <refsDecl n="CTS">
             <cRefPattern n="chapter" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
                <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>

--- a/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
@@ -77,7 +77,7 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
    </teiHeader>

--- a/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa002/stoa0044.stoa002.digilibLT-lat1.xml
@@ -80,6 +80,10 @@
             <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
+      <revisionDesc>
+         <change who="Vincent Giovannangeli" when="2021-04-24">Suppression de la seconde ligne qui empêchait la validation du fichier, 
+            correction de la langue, de la balise cRefPattern, du Xpath et ajout d'un revision desk pour indiquer l'auteur et la date de la correction</change>
+      </revisionDesc>
    </teiHeader>
 
    <text>


### PR DESCRIPTION
Issue #78 

**Fichier XML CapiTains 3/5 corrigé**

Nom du fichier: `stoa0044.stoa002.digilibLT-lat1.xml`
Titre de l'oeuvre: _Liber de uiris illustribus urbis Romae_

Afin de rendre le document compatible avec CapiTainS, j'ai effectué les corrections suivantes :

- [x] Dans la balise `cRefPattern` précision de ce que l'on extraie: transformation de "unknown" en "chapters"

- [x] Correction du Xpath avec la suppression d'un noeud (une `tei:div` inutile)

- [x] Correction dans la balise `language` de la langue utilisée dans le fichier, "la" en "lat" pour latin

- [x]  Ajout de balises `revisionDesc` et `change` pour indiquer la date et l'auteur des corrections

- [x]  Suppression de la seconde ligne, qui posait des problèmes de validation du fichier
