### PR TITLE
4/5 | Correction du fichier "stoa0122c.stoa001"

### DIFF
--- a/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
@@ -27,57 +26,65 @@
             <idno>dlt000182</idno>
          </publicationStmt>
          <sourceDesc>
-            <p>Favonii Eulogii Disputatio de somnio Scipionis, édition et traduction Roger E. Van Weddingen, Bruxelles 1957 (Collection de Latomus, 27)</p>
+            <p>Favonii Eulogii Disputatio de somnio Scipionis, édition et traduction Roger E. Van
+               Weddingen, Bruxelles 1957 (Collection de Latomus, 27)</p>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS">
+            <cRefPattern n="unknown" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts unknown</p>
+            </cRefPattern>
+         </refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
          </projectDesc>
          <editorialDecl>
-    
+
             <p>
                <hi rend="bold">Note di trascrizione e codifica specifiche del file </hi>
             </p>
             <p>Il file contiene immagini.</p>
-    
+
             <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
             <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-     l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-     e commenti e ogni altro contenuto redatto da editori moderni. </p>
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
             <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-     correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-     distinzione u/v minuscole.</p>
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
             <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
             <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-     grassetto, corsivo, spaziatura espansa.</p>
+               grassetto, corsivo, spaziatura espansa.</p>
             <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-     &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-               <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-     si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-     [...]<lb/> lacuna integrata dagli editori:
-     &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-    </p>
-            <p>Sono stati marcati i termini in lingua greca
-     &lt;foreign xml:lang="grc"&gt;αβγ&lt;/foreign&gt;
-    </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-      [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αβγ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
          </editorialDecl>
-   
+
       </encodingDesc>
       <profileDesc>
          <langUsage>
             <language ident="la">Latino</language>
          </langUsage>
       </profileDesc>
-  
+
    </teiHeader>
 
    <text>
@@ -85,247 +92,277 @@
 
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0122c.stoa001.digilibLT-lat1">
          <div type="cap" n="1">
-            <p> Imitatione Platonis Cicero de re publica scribens locum etiam de Eris Pamphylii reditu in
-     uitam, qui, ut ait, rogo impositus reuixisset multaque de inferis secreta narrasset, non
-     fabulosa, ut ille, assimulatione commentus est, sed sollertis somnii rationabili quadam
-     imaginatione composuit, uidelicet scite significans haec, quae de animae immortalitate
-     dicerentur caeloque, <supplied>nec</supplied> somniantium philosophorum esse commenta nec
-     fabulas incredibiles, quas Epicurei derident, sed prudentium coniecturas. Insinuat Scipionem
-     illum, qui Carthagine subiugata cognomen familiae suae peperit Africanum, huic Scipioni Pauli
-     filio futuras a propinquis insidias et fatalis metae denuntiare curriculum, quod necessitate
-     numerorum in uitae perfectae tempora coartetur, ponitque illum aetatis suae quinquagesimo ac
-     sexto anno, duobus in se coeuntibus numeris <supplied>plenis</supplied>, absolutam caelo
-     animam, unde acceperat, redditurum, quod et immortalis esset animi mentisque substantia, et
-     bene meritis de re publica patriaeque custodibus lactei circuli lucida ac candens habitatio
-     deberetur. Has igitur rationes, quibus supra positi uiri uita perficitur, arithmeticis
-     approbationibus explanantes, prudentiae tuae, Superi, uir clarissime atque sublimis, non ut
-     nouas ignotasque narramus, sed in recordationem qua possumus commemoratione reducimus. Quae si
-     doctis auribus tuis placere peruidero, ad alia quoque audacius, quae iubere dignaris, operam
-     stilumque conuertam.<lb/>
+            <p> Imitatione Platonis Cicero de re publica scribens locum etiam de Eris Pamphylii
+               reditu in uitam, qui, ut ait, rogo impositus reuixisset multaque de inferis secreta
+               narrasset, non fabulosa, ut ille, assimulatione commentus est, sed sollertis somnii
+               rationabili quadam imaginatione composuit, uidelicet scite significans haec, quae de
+               animae immortalitate dicerentur caeloque, <supplied>nec</supplied> somniantium
+               philosophorum esse commenta nec fabulas incredibiles, quas Epicurei derident, sed
+               prudentium coniecturas. Insinuat Scipionem illum, qui Carthagine subiugata cognomen
+               familiae suae peperit Africanum, huic Scipioni Pauli filio futuras a propinquis
+               insidias et fatalis metae denuntiare curriculum, quod necessitate numerorum in uitae
+               perfectae tempora coartetur, ponitque illum aetatis suae quinquagesimo ac sexto anno,
+               duobus in se coeuntibus numeris <supplied>plenis</supplied>, absolutam caelo animam,
+               unde acceperat, redditurum, quod et immortalis esset animi mentisque substantia, et
+               bene meritis de re publica patriaeque custodibus lactei circuli lucida ac candens
+               habitatio deberetur. Has igitur rationes, quibus supra positi uiri uita perficitur,
+               arithmeticis approbationibus explanantes, prudentiae tuae, Superi, uir clarissime
+               atque sublimis, non ut nouas ignotasque narramus, sed in recordationem qua possumus
+               commemoratione reducimus. Quae si doctis auribus tuis placere peruidero, ad alia
+               quoque audacius, quae iubere dignaris, operam stilumque conuertam.<lb/>
             </p>
          </div>
          <div type="cap" n="2">
             <p>
-               <lb/> Ac primum illud existimo praelibandum quod Italicae sapientiae conditor Pythagoras
-     numeris censet constare naturam, mundumque omnem ratis et competentibus interuallis ad musicam
-     caeli consona modulatione decurrere, aliumque alii rei numerum conuenire, ut concordiae
-     publicae nuptialem, ut edendis partibus cybicum, aliosque caelestibus, alios terrenis. Quid sit
-     hoc totum, pro captu meo curabo distinguere.<lb/>
+               <lb/> Ac primum illud existimo praelibandum quod Italicae sapientiae conditor
+               Pythagoras numeris censet constare naturam, mundumque omnem ratis et competentibus
+               interuallis ad musicam caeli consona modulatione decurrere, aliumque alii rei numerum
+               conuenire, ut concordiae publicae nuptialem, ut edendis partibus cybicum, aliosque
+               caelestibus, alios terrenis. Quid sit hoc totum, pro captu meo curabo
+               distinguere.<lb/>
             </p>
          </div>
          <div type="cap" n="3">
             <p>
-               <lb/> Numerus igitur, res aeterna, intellegibilis, incorrupta, cuncta quae sunt ui sua
-     complectitur; totumque sub numerum uenit quicquid aut sensibus aut animi cogitatione
-     comprehenditur. Nam et corpora figuram ex numeris trahunt, et figurae lineis pari ratione
-     formantur. Ipsaeque artes praecepta sua non sine numeri ammixtione pronuntiant: et cum
-     rhetorica status causarum quatuor, philosophia totidem asserit esse uirtutes. Et cum dicimus
-     trigona lineis tribus, quatuor quadrata describi, utique uides hoc ad numeros oportere
-     conuerti. <lb/>
+               <lb/> Numerus igitur, res aeterna, intellegibilis, incorrupta, cuncta quae sunt ui
+               sua complectitur; totumque sub numerum uenit quicquid aut sensibus aut animi
+               cogitatione comprehenditur. Nam et corpora figuram ex numeris trahunt, et figurae
+               lineis pari ratione formantur. Ipsaeque artes praecepta sua non sine numeri
+               ammixtione pronuntiant: et cum rhetorica status causarum quatuor, philosophia totidem
+               asserit esse uirtutes. Et cum dicimus trigona lineis tribus, quatuor quadrata
+               describi, utique uides hoc ad numeros oportere conuerti. <lb/>
             </p>
          </div>
          <div type="cap" n="4">
-            <p> Sed numerus est quantitas congregabilis, a duobus initium sumens et in denariam metam
-     crescendi accessione perueniens. Nam monadem non numerum, sed semen et substantiam numerorum
-     esse, manifestum et ex illa supra posita definitione perficitur. Nec enim unum ac singulare
-     quoddam congregabilis quantitas intellegitur, nec par aut impar haberi potest, quae sunt genera
-     numerorum. Ergo initium monas, numerus dyas et trias caeterique ita reliqui uocabuntur;
-     breuiterque dicemus quid monas, quid dyas, quid sequentes numeri ualeant in natura.<lb/>
+            <p> Sed numerus est quantitas congregabilis, a duobus initium sumens et in denariam
+               metam crescendi accessione perueniens. Nam monadem non numerum, sed semen et
+               substantiam numerorum esse, manifestum et ex illa supra posita definitione
+               perficitur. Nec enim unum ac singulare quoddam congregabilis quantitas intellegitur,
+               nec par aut impar haberi potest, quae sunt genera numerorum. Ergo initium monas,
+               numerus dyas et trias caeterique ita reliqui uocabuntur; breuiterque dicemus quid
+               monas, quid dyas, quid sequentes numeri ualeant in natura.<lb/>
             </p>
          </div>
          <div type="cap" n="5">
-            <p> Monas singularitas insecabilis, indiuisa, sola non ex partibus constans. Cum sit aliud unum,
-     alium unum solum: unum enim dicimus mundum, sed non unum solum, quia confit ex partibus; unum
-     populum ex pluribus ciuibus, exercitum ex multis militibus unum; nullumque corpus unum
-     solumque. Corpus unum <del>solum</del> recte dicetur, quod in partes sui diuisione discedat. At
-     si <del>unum</del> animum non minutis et coeuntibus portionibus in sui habitum esse compositum,
-     sed naturali simplicitate subsistentem <supplied>reperimus</supplied>, non unum, sed solum
-     quoque nominamus (quamuis circa corpora diuisibilem Plato testatur: genere tamen unum eundemque
-     cognoscit). Quicquid enim numerosa progressione non perit singulare natura est. Vnus
-      <supplied>solus</supplied> igitur deus, etsi sint eius innumerae diuisaeque uirtutes sexu per
-     fabulas nominibusque discretae. At non sic mundus unus <supplied>solus</supplied>, cuius aut
-     duae sunt partes, mens et materia, aut uero quatuor elementa, momentis potentiaque distantia.
-     Illud igitur numerus <del>hoc</del>, quod numerabile est, recte dicetur. Ille complectitur
-     uniuersa, ut in eo diuina etiam numerentur. Hoc autem accidit numero ac subiacet numerabile.
-     Estque numerus, ut Xenocrates censuit, animus ac deus; non enim aliud est quam quod ei subest.
-     Sed illud ipsum, quod est unum ac singulare tantummodo, <del>quod</del> ante omnia, in omnibus
-     et post omnia. Quantam enim uelis colligas quantitatem, ducetur ab uno, texetur ab uno
-     desinetque in unum. Ac, pereuntibus aliis, quae id recipere possunt, immutabile
-     perseuerat.<lb/>
+            <p> Monas singularitas insecabilis, indiuisa, sola non ex partibus constans. Cum sit
+               aliud unum, alium unum solum: unum enim dicimus mundum, sed non unum solum, quia
+               confit ex partibus; unum populum ex pluribus ciuibus, exercitum ex multis militibus
+               unum; nullumque corpus unum solumque. Corpus unum <del>solum</del> recte dicetur,
+               quod in partes sui diuisione discedat. At si <del>unum</del> animum non minutis et
+               coeuntibus portionibus in sui habitum esse compositum, sed naturali simplicitate
+               subsistentem <supplied>reperimus</supplied>, non unum, sed solum quoque nominamus
+               (quamuis circa corpora diuisibilem Plato testatur: genere tamen unum eundemque
+               cognoscit). Quicquid enim numerosa progressione non perit singulare natura est. Vnus
+                  <supplied>solus</supplied> igitur deus, etsi sint eius innumerae diuisaeque
+               uirtutes sexu per fabulas nominibusque discretae. At non sic mundus unus
+                  <supplied>solus</supplied>, cuius aut duae sunt partes, mens et materia, aut uero
+               quatuor elementa, momentis potentiaque distantia. Illud igitur numerus
+               <del>hoc</del>, quod numerabile est, recte dicetur. Ille complectitur uniuersa, ut in
+               eo diuina etiam numerentur. Hoc autem accidit numero ac subiacet numerabile. Estque
+               numerus, ut Xenocrates censuit, animus ac deus; non enim aliud est quam quod ei
+               subest. Sed illud ipsum, quod est unum ac singulare tantummodo, <del>quod</del> ante
+               omnia, in omnibus et post omnia. Quantam enim uelis colligas quantitatem, ducetur ab
+               uno, texetur ab uno desinetque in unum. Ac, pereuntibus aliis, quae id recipere
+               possunt, immutabile perseuerat.<lb/>
             </p>
          </div>
          <div type="cap" n="6">
-            <p> Dyas uero, ut theologi asserunt, secundus est motus. Primus enim motus in monade stabilis et
-     consistens in dyadem uelut foras egreditur. Primumque conubium poetae fabulose dixerunt sororis
-     et coniugis, quod uidelicet unius generis numero coeunte copuletur; et Iunonem uocant, uni
-     scilicet Ioui accessione alterius inhaerentem. Ab hoc numero mundus apparuit, mente ac materia,
-     quae Graece dicitur <foreign xml:lang="grc">ὕλη</foreign>, constructus; ab hoc iustitia,
-     naturalis uirtus, librata partium aequalitate diluxit. Namque diuisus hic nunc numerus, quia
-     prior diuidi potest, aequali sectione discedit. Nec tamen adhuc totus est, quia initium
-     finemque demonstrat, medio nullo censetur. Diciturque femineus, quia iunctus alteri pari parem
-     creat ex sese, quod in eo qui sequitur non potest inueniri. Bis enim bini fit quartus; bis
-     terni non facit imparem sicut ille superior, quod ex paribus par, ex imparibus impar esse non
-     poterit.<lb/>
+            <p> Dyas uero, ut theologi asserunt, secundus est motus. Primus enim motus in monade
+               stabilis et consistens in dyadem uelut foras egreditur. Primumque conubium poetae
+               fabulose dixerunt sororis et coniugis, quod uidelicet unius generis numero coeunte
+               copuletur; et Iunonem uocant, uni scilicet Ioui accessione alterius inhaerentem. Ab
+               hoc numero mundus apparuit, mente ac materia, quae Graece dicitur <foreign
+                  xml:lang="grc">ὕλη</foreign>, constructus; ab hoc iustitia, naturalis uirtus,
+               librata partium aequalitate diluxit. Namque diuisus hic nunc numerus, quia prior
+               diuidi potest, aequali sectione discedit. Nec tamen adhuc totus est, quia initium
+               finemque demonstrat, medio nullo censetur. Diciturque femineus, quia iunctus alteri
+               pari parem creat ex sese, quod in eo qui sequitur non potest inueniri. Bis enim bini
+               fit quartus; bis terni non facit imparem sicut ille superior, quod ex paribus par, ex
+               imparibus impar esse non poterit.<lb/>
             </p>
          </div>
          <div type="cap" n="7">
-            <p> Sed trias primus est totus quod habet et medium. Estque, ut dicitur, masculinus, quod
-     adiunctus alteri impari creare non ualeat id quod ipse sit. Mundus ab hoc numero nomen accepit;
-     namque ex duobus factus in tertium quod genus eualuit. Non enim aut mens tantum aut sola
-     materia, sed utrumque est, tertium quid illorum commixtione compositum. Triaque tempora pro sui
-     natura sortitus est, praeteritum, praesens, futurum, triade uidelicet operante; fatalisque
-     necessitas in eo numero est, Clotho, Lachesis, Atropos; tria rerum genera, masculinum,
-     femininum, neutrum; tria uocum discrimina, acutum, graue, inflexum; tria genera litterarum,
-     uocales, semiuocales, mutae; tribus lineis figura prima componitur, quae trigonon nominatur;
-     tria corporum interualla monstrantur, longitudo, latitudo, altitudo, quibus omne solidum
-     continetur.<lb/>
+            <p> Sed trias primus est totus quod habet et medium. Estque, ut dicitur, masculinus,
+               quod adiunctus alteri impari creare non ualeat id quod ipse sit. Mundus ab hoc numero
+               nomen accepit; namque ex duobus factus in tertium quod genus eualuit. Non enim aut
+               mens tantum aut sola materia, sed utrumque est, tertium quid illorum commixtione
+               compositum. Triaque tempora pro sui natura sortitus est, praeteritum, praesens,
+               futurum, triade uidelicet operante; fatalisque necessitas in eo numero est, Clotho,
+               Lachesis, Atropos; tria rerum genera, masculinum, femininum, neutrum; tria uocum
+               discrimina, acutum, graue, inflexum; tria genera litterarum, uocales, semiuocales,
+               mutae; tribus lineis figura prima componitur, quae trigonon nominatur; tria corporum
+               interualla monstrantur, longitudo, latitudo, altitudo, quibus omne solidum
+               continetur.<lb/>
             </p>
          </div>
          <div type="cap" n="8">
-            <p> Quatuor, secunda generis alterius plenitudo, duo media pro sui qualitate complectitur.
-     Primusque quadratus est numerus. Quadratum arithmetici uocant qui, ductus in se, in maiorem
-     cumulum surgit. Bis enim bini quartus <supplied>primus</supplied>, ter terni nonus secundus
-     quadratus est numerus. Deinceps caeteri in sese ducti usque ad decimi metam quadratos efficiunt
-     numeros. Nam uiginti per se cum efficiunt quadringentos, ad secundi uersus pertinent rationem.
-     Versus arithmetici dicunt ordines numerorum, ut ab uno ad decem, ab decem ad centum, a centum
-     ad mille, et sic alios uersus progressione maioris crementi coaedificant; idemque ualet decimus
-     ad uicesimum quod unus ad duo; dupli enim substantia separantur at, si diuersa fit summa, ratio
-     tamen eadem perseuerat. Ac sic in denaria summa crescendi <supplied>primi</supplied> finis et
-     initium secundi uersus est. Sed is in quaternario numero subtili disputatione colligitur; Nam
-     duo, tres, quatuor, adiuncta monade, in decadem procedunt. Ab hoc numero elementa, ab hoc
-     tempora natura disposuit, quae per terna caeli signa solis curriculis dimensa uariantur. Nam
-     uer in tribus signis agitur, ariete, tauro, geminis; aestas in cancro, leone, uirgine; autumnus
-      <supplied>in</supplied> libra, scorpio, sagittario; hiems in capricorno, aquario piscibusque
-     finiuntur. Videsque duobus primis <del>ac</del> plenis numeris mundani cursus tempora solis
-     moderatione conuolui.<lb/>
+            <p> Quatuor, secunda generis alterius plenitudo, duo media pro sui qualitate
+               complectitur. Primusque quadratus est numerus. Quadratum arithmetici uocant qui,
+               ductus in se, in maiorem cumulum surgit. Bis enim bini quartus
+                  <supplied>primus</supplied>, ter terni nonus secundus quadratus est numerus.
+               Deinceps caeteri in sese ducti usque ad decimi metam quadratos efficiunt numeros. Nam
+               uiginti per se cum efficiunt quadringentos, ad secundi uersus pertinent rationem.
+               Versus arithmetici dicunt ordines numerorum, ut ab uno ad decem, ab decem ad centum,
+               a centum ad mille, et sic alios uersus progressione maioris crementi coaedificant;
+               idemque ualet decimus ad uicesimum quod unus ad duo; dupli enim substantia separantur
+               at, si diuersa fit summa, ratio tamen eadem perseuerat. Ac sic in denaria summa
+               crescendi <supplied>primi</supplied> finis et initium secundi uersus est. Sed is in
+               quaternario numero subtili disputatione colligitur; Nam duo, tres, quatuor, adiuncta
+               monade, in decadem procedunt. Ab hoc numero elementa, ab hoc tempora natura
+               disposuit, quae per terna caeli signa solis curriculis dimensa uariantur. Nam uer in
+               tribus signis agitur, ariete, tauro, geminis; aestas in cancro, leone, uirgine;
+               autumnus <supplied>in</supplied> libra, scorpio, sagittario; hiems in capricorno,
+               aquario piscibusque finiuntur. Videsque duobus primis <del>ac</del> plenis numeris
+               mundani cursus tempora solis moderatione conuolui.<lb/>
             </p>
          </div>
          <div type="cap" n="9">
-            <p> Quinque autem caeli planetas sub zodiaco posuerunt, locis motibusque dissimiles. In quinque
-     partes circulum secuere ut sit primum medium punctum, quatuor absides, quarum altitudo et
-     altitudo altitudinis, humilitas <supplied>et humilitas</supplied> humilitatis in lunari globo
-     ratis erroribus obseruantur, quod ea uidelicet, ut ima a caelo, omne hoc interuallum, quod a
-     terra ad caelum usque protenditur, obire diuersis uidetur amfractibus, ne in umbram terrae,
-     quod dicitur eclipsis, semper incurrat; quam, dum altior aquilone, humilior austro incurrat,
-     uidetur euadere, nisi quod aliquando pro mundanae sortis et corporum quibus aer praeest
-     necessitate perpetitur ueluti sui luminis mortem. Vides ergo quid numerus iste, quem diximus,
-     agat in caelo. Constat hic ex pleno et non pleno, tribus uidelicet et duobus, nec diuiditur
-     sicut omnis impar aequaliter. Sensus corporis nostri sub hoc numero manifestum esse. Hunc
-     Romani in populi diuisione secuti sunt, in quinque classes omnia ciuitatis membra
-     claudentes.<lb/>
+            <p> Quinque autem caeli planetas sub zodiaco posuerunt, locis motibusque dissimiles. In
+               quinque partes circulum secuere ut sit primum medium punctum, quatuor absides, quarum
+               altitudo et altitudo altitudinis, humilitas <supplied>et humilitas</supplied>
+               humilitatis in lunari globo ratis erroribus obseruantur, quod ea uidelicet, ut ima a
+               caelo, omne hoc interuallum, quod a terra ad caelum usque protenditur, obire diuersis
+               uidetur amfractibus, ne in umbram terrae, quod dicitur eclipsis, semper incurrat;
+               quam, dum altior aquilone, humilior austro incurrat, uidetur euadere, nisi quod
+               aliquando pro mundanae sortis et corporum quibus aer praeest necessitate perpetitur
+               ueluti sui luminis mortem. Vides ergo quid numerus iste, quem diximus, agat in caelo.
+               Constat hic ex pleno et non pleno, tribus uidelicet et duobus, nec diuiditur sicut
+               omnis impar aequaliter. Sensus corporis nostri sub hoc numero manifestum esse. Hunc
+               Romani in populi diuisione secuti sunt, in quinque classes omnia ciuitatis membra
+               claudentes.<lb/>
             </p>
          </div>
          <div type="cap" n="10">
-            <p> Senarius uero, qui sequitur, numerus potentem ac diuinam naturae suae obtinet potestatem,
-     siquidem <foreign xml:lang="grc">τέλειος</foreign> primus, id est perfectus, esse reperitur.
-     Perfectum arithmetici uocant qui se implet partibus suis. Partes calculatores dicunt quibus
-     maior aliqua summa componitur, ut hic ex dimidia, tertia, sexta coniunctis
-      <supplied>se</supplied> senarius numerus complet. Nam tres, duo et unus (quae portio est
-     sexta) senariam expedit quantitatem, quod in aliis ex primo uersu numeris non reperies. Nam
-     caeteri pares numeri aut non se complent aut etiam transeunt; hic solus est qui suis partibus
-     sine ullo discrimine supputatus absoluitur. Nam quaternarius habet dimidiam duo; tertiam
-     propter monadem insecabilem non habet; quarta accedens tertii numeri continet summam. Colligi
-     ergo non potest quatuor, quod hic tertius ex paribus, <supplied>suis partibus</supplied>
-     constans, solus emeruit. Nam octo, qui ex paribus quartus est, cum habeat dimidiam quatuor,
-     tertia careat, quartam duo accipiat, quintam uero, sextam septimamque non habeat, accedente
-     octaua, quae superest, se complere non poterit, ut in his numeris cernas licet: quatuor, duo,
-     unus septem sunt, non octo. Qui supra sunt se itaque complere non poterunt. Decas, quintus par
-     numerus, habet dimidiam quinque, tertiam non habet, quartam non habet, quintam recipit duo,
-     sexta, septima, octaua, nona parte priuatus est; accedens decima, id est unus, facit octo, non
-     decem. Duodecim rursus attende, quamuis alterius uersus uideatur habere reliquias, ut extra
-     sortem propositae rationis sit, quia ut monas in primo uersu, sic in secundo decas obtinet
-     fundamentum. Ergo si duodecim partium uelis supputatione conficere, transibit semet ipsum, nec
-     eadem, quae supra dicta est, ratione quadrabit, siquidem sex dimidiam, quatuor tertia, quarta
-     tres, sexta duo et ipsa duodecima <supplied>unus</supplied> sedecim faciunt. Ita sibi coaequari
-     non ualent. In has enim solas partes duodecim separamus. <lb/>
+            <p> Senarius uero, qui sequitur, numerus potentem ac diuinam naturae suae obtinet
+               potestatem, siquidem <foreign xml:lang="grc">τέλειος</foreign> primus, id est
+               perfectus, esse reperitur. Perfectum arithmetici uocant qui se implet partibus suis.
+               Partes calculatores dicunt quibus maior aliqua summa componitur, ut hic ex dimidia,
+               tertia, sexta coniunctis <supplied>se</supplied> senarius numerus complet. Nam tres,
+               duo et unus (quae portio est sexta) senariam expedit quantitatem, quod in aliis ex
+               primo uersu numeris non reperies. Nam caeteri pares numeri aut non se complent aut
+               etiam transeunt; hic solus est qui suis partibus sine ullo discrimine supputatus
+               absoluitur. Nam quaternarius habet dimidiam duo; tertiam propter monadem insecabilem
+               non habet; quarta accedens tertii numeri continet summam. Colligi ergo non potest
+               quatuor, quod hic tertius ex paribus, <supplied>suis partibus</supplied> constans,
+               solus emeruit. Nam octo, qui ex paribus quartus est, cum habeat dimidiam quatuor,
+               tertia careat, quartam duo accipiat, quintam uero, sextam septimamque non habeat,
+               accedente octaua, quae superest, se complere non poterit, ut in his numeris cernas
+               licet: quatuor, duo, unus septem sunt, non octo. Qui supra sunt se itaque complere
+               non poterunt. Decas, quintus par numerus, habet dimidiam quinque, tertiam non habet,
+               quartam non habet, quintam recipit duo, sexta, septima, octaua, nona parte priuatus
+               est; accedens decima, id est unus, facit octo, non decem. Duodecim rursus attende,
+               quamuis alterius uersus uideatur habere reliquias, ut extra sortem propositae
+               rationis sit, quia ut monas in primo uersu, sic in secundo decas obtinet fundamentum.
+               Ergo si duodecim partium uelis supputatione conficere, transibit semet ipsum, nec
+               eadem, quae supra dicta est, ratione quadrabit, siquidem sex dimidiam, quatuor
+               tertia, quarta tres, sexta duo et ipsa duodecima <supplied>unus</supplied> sedecim
+               faciunt. Ita sibi coaequari non ualent. In has enim solas partes duodecim separamus.
+               <lb/>
             </p>
          </div>
          <div type="cap" n="11">
-            <p> Sed haec de aliis instructionis gratia diximus, ne de septimo aut octauo numero disputantes
-     obscuritatem aliquam, nulla praestructione posita, subiremus. Nunc dicendum est quae sit horum
-     plenitudo numerorum, quibus per alterutrum ductis <supplied>quinquaginta et</supplied> sex
-     conficiuntur anni. His enim Africani posterioris uita conclusa est.<lb/>
+            <p> Sed haec de aliis instructionis gratia diximus, ne de septimo aut octauo numero
+               disputantes obscuritatem aliquam, nulla praestructione posita, subiremus. Nunc
+               dicendum est quae sit horum plenitudo numerorum, quibus per alterutrum ductis
+                  <supplied>quinquaginta et</supplied> sex conficiuntur anni. His enim Africani
+               posterioris uita conclusa est.<lb/>
             </p>
          </div>
          <div type="cap" n="12">
-            <p> Septimus igitur numerus plenus est his de causis, quia et <del>in</del> initio duo et tres
-     medio et duo fine complexus est. Tum, quod primus ex duobus diuersi generis plenis est, ex
-     tribus imparibus scilicet et quatuor paribus iunctus, fit ipse plenissimus, cuius totae sunt
-     partes. Multumque in rerum natura dominatur. Nam sidera, quae obluceant caelo, sunt septem, si
-     ad quinque planetas solem lunamque iungamus, totidem circulis euolantia. Septem stellas cardo
-     maximus aquilonius inocciduo fulgore conuertit. Septem species luna crescentis ac decrescentis
-     luminis uarietate componit, quarum prima est quae a Graecis <foreign xml:lang="grc">ἁνατολή</foreign> dicitur, secunda <foreign xml:lang="grc">ἀμφίκυρτος</foreign>, tertia
-      <foreign xml:lang="grc">διχότομος</foreign>, quarta <foreign xml:lang="grc">πανσέληνος</foreign>, quinta item <foreign xml:lang="grc">διχότομος</foreign>, sexta <foreign xml:lang="grc">ἀμφίκυρτος</foreign>, septima <foreign xml:lang="grc">συνοδική</foreign>
-     uocatur, cum interlunio redit ad solem. Septem animi motus philosophi stoici posuerunt: quatuor
-     perturbationes, tres constantias, id est metum, dolorem, cupiditatem, laetitiam, quibus
-     insipientium animi uelut tempestatibus agitantur. Sapientium uero motus non <foreign xml:lang="grc">πάθη</foreign>, sed constantiae sunt, ut pro metu cautio sit, pro cupiditate
-     uoluntas aut studium, pro laetitia gaudium, quod distinctionis gratia separamus. Quartus ex
-     malis praesentibus sapienti nullus est motus, quia nec in malum incidere sapiens potest. Sunt
-     ergo animi motus septem, at uero corporum totidem. Primus est circularis, una linea
-     comprehensus; reliqui sex dexter, sinister, sursum, deorsum, ante, post. Sed ille mundi comes
-     totius, hi partiles habentur. Diximus supra quinque sensus esse corporeos; hi septem
-     foraminibus emittuntur: duo sunt uisionis, duo auditus, unum gustatus atque unum est odoratus;
-     septimum tactus, qui per totius corporis membra diffusus est. Et quia cerebri purissimam partem
-     animae principatum existimant obtinere, ministros eidem sensus septem ueluti fenestris emitti
-     manifestum est, cum illos Mineruae tanquam in arce positae subiecerunt. <lb/>
+            <p> Septimus igitur numerus plenus est his de causis, quia et <del>in</del> initio duo
+               et tres medio et duo fine complexus est. Tum, quod primus ex duobus diuersi generis
+               plenis est, ex tribus imparibus scilicet et quatuor paribus iunctus, fit ipse
+               plenissimus, cuius totae sunt partes. Multumque in rerum natura dominatur. Nam
+               sidera, quae obluceant caelo, sunt septem, si ad quinque planetas solem lunamque
+               iungamus, totidem circulis euolantia. Septem stellas cardo maximus aquilonius
+               inocciduo fulgore conuertit. Septem species luna crescentis ac decrescentis luminis
+               uarietate componit, quarum prima est quae a Graecis <foreign xml:lang="grc"
+                  >ἁνατολή</foreign> dicitur, secunda <foreign xml:lang="grc">ἀμφίκυρτος</foreign>,
+               tertia <foreign xml:lang="grc">διχότομος</foreign>, quarta <foreign xml:lang="grc"
+                  >πανσέληνος</foreign>, quinta item <foreign xml:lang="grc">διχότομος</foreign>,
+               sexta <foreign xml:lang="grc">ἀμφίκυρτος</foreign>, septima <foreign xml:lang="grc"
+                  >συνοδική</foreign> uocatur, cum interlunio redit ad solem. Septem animi motus
+               philosophi stoici posuerunt: quatuor perturbationes, tres constantias, id est metum,
+               dolorem, cupiditatem, laetitiam, quibus insipientium animi uelut tempestatibus
+               agitantur. Sapientium uero motus non <foreign xml:lang="grc">πάθη</foreign>, sed
+               constantiae sunt, ut pro metu cautio sit, pro cupiditate uoluntas aut studium, pro
+               laetitia gaudium, quod distinctionis gratia separamus. Quartus ex malis praesentibus
+               sapienti nullus est motus, quia nec in malum incidere sapiens potest. Sunt ergo animi
+               motus septem, at uero corporum totidem. Primus est circularis, una linea
+               comprehensus; reliqui sex dexter, sinister, sursum, deorsum, ante, post. Sed ille
+               mundi comes totius, hi partiles habentur. Diximus supra quinque sensus esse
+               corporeos; hi septem foraminibus emittuntur: duo sunt uisionis, duo auditus, unum
+               gustatus atque unum est odoratus; septimum tactus, qui per totius corporis membra
+               diffusus est. Et quia cerebri purissimam partem animae principatum existimant
+               obtinere, ministros eidem sensus septem ueluti fenestris emitti manifestum est, cum
+               illos Mineruae tanquam in arce positae subiecerunt. <lb/>
             </p>
          </div>
          <div type="cap" n="13">
             <p> Quid numerus septenarius Mineruae tribuitur, quae ex Iouis capite sine matris utero
-     procreata memoratur? Videlicet quod, ad senarium sapientem conuenientemque suis partibus
-     numerum monas, quae est caput numerorum, cum accesserit, septenarium creat, qui ab arithmeticis
-     Minerua dictus est quod neque creatus est ex duobus <del>sui</del> similibus neque procreare
-     ipse alios potest intra limitem primi uersus. Nam si respicias a principio, dyas et paritur ex
-     singulis et ex se quaternarium creat. Trias non equidem paritur, quia non similibus numeris
-     coeuntibus aggregatur, sed generat sex. <supplied>Quaternarius et paritur ex binis et ex se
-      octonarium creat.</supplied> Quinarius ipse non paritur, sed decimum ex duobus sui similibus
-     parit, in quo, ut dictum est, crescentium finis est numerorum, quorum ratio caeteris in
-     uersibus sub maiore summa repetitur. Sex paritur quidem, sed ipse non parit: duodecim namque
-     secundi uersus incipit habere reliquias. Octauus uero ex duobus quaternariis exortus in sedecim
-     duplicatus exundat; paritur ergo, non parit. Enneadem tres triplicati pariunt; duodeuicesimus
-     secundi uersus est numerus, qui a lege creandi diuersus est. Decas nata quidem ex bis quinis
-     cognoscitur, sed uiginti, quos colligit duplicatus hic numerus, non possunt dictae rationis
-     habere consortium. Septimus igitur solus nec creatur ex binis unius generis numeris nec ipse
-     alium geminatus effundit, unde merito Minerua, sine matre uirgo, sine procreatione,
-     perhibetur.<lb/>
+               procreata memoratur? Videlicet quod, ad senarium sapientem conuenientemque suis
+               partibus numerum monas, quae est caput numerorum, cum accesserit, septenarium creat,
+               qui ab arithmeticis Minerua dictus est quod neque creatus est ex duobus
+                  <del>sui</del> similibus neque procreare ipse alios potest intra limitem primi
+               uersus. Nam si respicias a principio, dyas et paritur ex singulis et ex se
+               quaternarium creat. Trias non equidem paritur, quia non similibus numeris coeuntibus
+               aggregatur, sed generat sex. <supplied>Quaternarius et paritur ex binis et ex se
+                  octonarium creat.</supplied> Quinarius ipse non paritur, sed decimum ex duobus sui
+               similibus parit, in quo, ut dictum est, crescentium finis est numerorum, quorum ratio
+               caeteris in uersibus sub maiore summa repetitur. Sex paritur quidem, sed ipse non
+               parit: duodecim namque secundi uersus incipit habere reliquias. Octauus uero ex
+               duobus quaternariis exortus in sedecim duplicatus exundat; paritur ergo, non parit.
+               Enneadem tres triplicati pariunt; duodeuicesimus secundi uersus est numerus, qui a
+               lege creandi diuersus est. Decas nata quidem ex bis quinis cognoscitur, sed uiginti,
+               quos colligit duplicatus hic numerus, non possunt dictae rationis habere consortium.
+               Septimus igitur solus nec creatur ex binis unius generis numeris nec ipse alium
+               geminatus effundit, unde merito Minerua, sine matre uirgo, sine procreatione,
+               perhibetur.<lb/>
             </p>
          </div>
          <div type="cap" n="14">
-            <p> Hippocrates Cous, naturae scrutator egregius, hunc numerum in libris, quos περὶ <foreign xml:lang="grc">ἑβδομάδων</foreign> appellat, ait creandis inesse corporibus. Nam semen fusum
-     et fomite matris exceptum septimo die in sanguinem commutari, septimo mense perfici ac
-     plerumque nasci legitimam partus dinumerationem mansurum; infantiumque dentes a septimo mense
-     prorumpere, septimo mutari anno; bis septimo incipere pubertatem; ter septeno florem barbae
-     iuuenilis absolui; quatuor autem annorum hebdomadibus euolutis staturae crescentis terminum
-     fieri nec ultra proceritatem posse procedere; triginta uero et quinque annis exemptis etiam
-     ingenii progressionem fere desistere quidam putauere philosophi, quod uidelicet in quinque
-     redigatur hebdomadas. Musici uero septem uocum discrimina duobus tetracordis pro rata portione
-     modulatis efficiunt, una corda communi, quae utriusque concentum harmoniae modificatione
-     componat, quod paulo post uberius exsequemur. Dialectici quoque conclusionis hypotheticae modos
-     in septenarium numerum redegerunt, quibus amplius nihil acuta quiuit disciplina
-     cognoscere.<lb/>
+            <p> Hippocrates Cous, naturae scrutator egregius, hunc numerum in libris, quos περὶ
+                  <foreign xml:lang="grc">ἑβδομάδων</foreign> appellat, ait creandis inesse
+               corporibus. Nam semen fusum et fomite matris exceptum septimo die in sanguinem
+               commutari, septimo mense perfici ac plerumque nasci legitimam partus dinumerationem
+               mansurum; infantiumque dentes a septimo mense prorumpere, septimo mutari anno; bis
+               septimo incipere pubertatem; ter septeno florem barbae iuuenilis absolui; quatuor
+               autem annorum hebdomadibus euolutis staturae crescentis terminum fieri nec ultra
+               proceritatem posse procedere; triginta uero et quinque annis exemptis etiam ingenii
+               progressionem fere desistere quidam putauere philosophi, quod uidelicet in quinque
+               redigatur hebdomadas. Musici uero septem uocum discrimina duobus tetracordis pro rata
+               portione modulatis efficiunt, una corda communi, quae utriusque concentum harmoniae
+               modificatione componat, quod paulo post uberius exsequemur. Dialectici quoque
+               conclusionis hypotheticae modos in septenarium numerum redegerunt, quibus amplius
+               nihil acuta quiuit disciplina cognoscere.<lb/>
             </p>
          </div>
          <div type="cap" n="15">
-            <p> De octauo autem numero non multa dicuntur, sed quae huic loco sufficiant: ita sunt. Octo,
-     primus cybus (<foreign xml:lang="grc">κύβον</foreign> Graeci, nos quadrantal dicimus), id est
-     forma quae tria corporum interualla contineat. Nam cum <foreign xml:lang="grc">σημεῖον</foreign>, lineae semen et signum sine ullis partibus animo cogitabis, eadem
-     cogitatione defluere uidebis in lineam. Quae quia duobus finibus terminetur linea longitudinis,
-     sub dualis numeri natura limitatur. Haec in quaternarium duplicatione progreditur, et facit
-     epiphaniam, id est superficiem planipedem; quam Graeci <foreign xml:lang="grc">ἐπίπεδον</foreign> nominarunt, quatuor lineis angulisque descriptam. Quae si aeque dupli
-     ratione grandescat, octauo numero quadrantal illud absoluet, eritque, ut diximus, in duobus
-     longitudo, in quatuor latitudo, in octo altitudo, qua nihil amplius in lineis corpora perfecta
-     conquirunt, quae a nobis solida, a Graecis <foreign xml:lang="grc">στερεά</foreign> nominantur.
-     Nam color, qui ueluti quartus accedit, a plerisque non naturis corporum sed lucis iactibus
-     impressionibusque tribuitur. Vnde illud recte Virgilius: et rebus abstulit nox atra colorem.
-     Quod utique <supplied>dies</supplied> dederat, sustulit. <lb/>
+            <p> De octauo autem numero non multa dicuntur, sed quae huic loco sufficiant: ita sunt.
+               Octo, primus cybus (<foreign xml:lang="grc">κύβον</foreign> Graeci, nos quadrantal
+               dicimus), id est forma quae tria corporum interualla contineat. Nam cum <foreign
+                  xml:lang="grc">σημεῖον</foreign>, lineae semen et signum sine ullis partibus animo
+               cogitabis, eadem cogitatione defluere uidebis in lineam. Quae quia duobus finibus
+               terminetur linea longitudinis, sub dualis numeri natura limitatur. Haec in
+               quaternarium duplicatione progreditur, et facit epiphaniam, id est superficiem
+               planipedem; quam Graeci <foreign xml:lang="grc">ἐπίπεδον</foreign> nominarunt,
+               quatuor lineis angulisque descriptam. Quae si aeque dupli ratione grandescat, octauo
+               numero quadrantal illud absoluet, eritque, ut diximus, in duobus longitudo, in
+               quatuor latitudo, in octo altitudo, qua nihil amplius in lineis corpora perfecta
+               conquirunt, quae a nobis solida, a Graecis <foreign xml:lang="grc">στερεά</foreign>
+               nominantur. Nam color, qui ueluti quartus accedit, a plerisque non naturis corporum
+               sed lucis iactibus impressionibusque tribuitur. Vnde illud recte Virgilius: et rebus
+               abstulit nox atra colorem. Quod utique <supplied>dies</supplied> dederat, sustulit.
+               <lb/>
             </p>
          </div>
          <div type="cap" n="16">
-            <p> Sed ne de primo cybo dicentes alium transeamus et sit mutilantis subtilitatis assertio: ut a
-     numero pari, qui femineus habetur, tribus illis limitibus duplicatis natus est cybus, ita
-     tribus per sui naturam ter triplicatis efficitur alius cybus generis imparis masculinus. Namque
-     tres lineam faciunt longitudinis, nouem lineam latitudinis, uiginti uero et septem
-     profunditatem illam soliditatis absoluent. Quod hac descriptione sic intuere:<lb/>
+            <p> Sed ne de primo cybo dicentes alium transeamus et sit mutilantis subtilitatis
+               assertio: ut a numero pari, qui femineus habetur, tribus illis limitibus duplicatis
+               natus est cybus, ita tribus per sui naturam ter triplicatis efficitur alius cybus
+               generis imparis masculinus. Namque tres lineam faciunt longitudinis, nouem lineam
+               latitudinis, uiginti uero et septem profunditatem illam soliditatis absoluent. Quod
+               hac descriptione sic intuere:<lb/>
                <figure>
                   <lb/>
                   <graphic url="IMG/dlt000182001.png"/>
@@ -333,160 +370,176 @@
                   <lb/>
                </figure>
                <lb/> Animaduerte quot summas descriptionis climax complectitur, nempe septem: et hoc
-     ad potentiam numeri septenarii referimus. Nam et Plato cum diuisionem primam ex cratere illo
-     suo, quo animam temperabat, efficeret et dupli ac tripli distantias propinquioribus pro rata
-     parte numeris inferciret, eadem posuit interualla primigenia; in quibus, dempto illo principe
-     qui communis omnibus lateribus inuenitur, remanent summae sex. <supplied>Et hoc ad potentiam
-      referimus huius</supplied> numeri, ut dictum est, potentis atque perfecti, per quem hos duos
-     cybos sibimet mixtos si multiplices, in ducentos et decem cumulus iste transibit. Nam octo et
-     uiginti septem fiunt triginta quinque. Hoc sexies ducito: facies, ut supra proposuimus,
-     ducentos et decem, qui dierum numerus septem menses absoluit. Hac ratione partus ille
-     septimanus est plenus. Vide iterum cybos his numeris contineri. Octo binarii generis cybus est.
-     Viginti septem septenarium continent in reliquiis. Nam summa maior, quae in uiginti est,
-     binorum laterum instar; reliquiae sunt eius in septem, quem plenum in loci huius expositione
-     iam diu demonstrauimus. <lb/>
+               ad potentiam numeri septenarii referimus. Nam et Plato cum diuisionem primam ex
+               cratere illo suo, quo animam temperabat, efficeret et dupli ac tripli distantias
+               propinquioribus pro rata parte numeris inferciret, eadem posuit interualla
+               primigenia; in quibus, dempto illo principe qui communis omnibus lateribus inuenitur,
+               remanent summae sex. <supplied>Et hoc ad potentiam referimus huius</supplied> numeri,
+               ut dictum est, potentis atque perfecti, per quem hos duos cybos sibimet mixtos si
+               multiplices, in ducentos et decem cumulus iste transibit. Nam octo et uiginti septem
+               fiunt triginta quinque. Hoc sexies ducito: facies, ut supra proposuimus, ducentos et
+               decem, qui dierum numerus septem menses absoluit. Hac ratione partus ille septimanus
+               est plenus. Vide iterum cybos his numeris contineri. Octo binarii generis cybus est.
+               Viginti septem septenarium continent in reliquiis. Nam summa maior, quae in uiginti
+               est, binorum laterum instar; reliquiae sunt eius in septem, quem plenum in loci huius
+               expositione iam diu demonstrauimus. <lb/>
             </p>
          </div>
          <div type="cap" n="17">
-            <p> Ad hunc numerum cybicum, ut Varroni placet, lunaris cursus congruit reuolutio, quae in
-     uiginti septem diebus omne tanti sideris lumen exhaurit. Adde quod octauus hic numerus dierum
-     noctiumque crementa conuertit. Nam cum octauam arietis partem sol ingreditur, lucis umbraeque
-     mensuram paribus momentis exaequat. Indeque ad cancri octauam partem lux aucta producitur. Vnde
-     alia rursus aequalitate regreditur ad librae octauam partem, ut fiant solis contractiora
-     curricula. Nouissime pigras ac breues horas ad capricorni humiliorem metam restringens in
-     solstitium aliud, quod brumale dicitur, tendit. Ac sic alterno discrimine dies a noctibus
-     umbraeque a solibus superantur, octauae partis quadrifariam limite disparato, ut aequinoctia
-     duo, solstitia totidem numerentur. Caeli uero in hunc numerum orbes seu deus artifex seu
-     prudens natura disposuit. Nam primus ac summus est aplanes, qui, quia semper uno ac iugi
-     continuatus agitur motu, nulli uidetur errori esse subiectus. Sub eo planetarum sunt quinque
-     circuli et solis ac lunae curricula. Nam terra, ut ait Tullius, nona immota semper sede manet,
-     et ab illorum motibus segregata obstipo pondere defixa subsedit. Additur causis, quod in musica
-     tonus octauae partis detractione consistit per numerum qui epogdous nominatur. <lb/>
+            <p> Ad hunc numerum cybicum, ut Varroni placet, lunaris cursus congruit reuolutio, quae
+               in uiginti septem diebus omne tanti sideris lumen exhaurit. Adde quod octauus hic
+               numerus dierum noctiumque crementa conuertit. Nam cum octauam arietis partem sol
+               ingreditur, lucis umbraeque mensuram paribus momentis exaequat. Indeque ad cancri
+               octauam partem lux aucta producitur. Vnde alia rursus aequalitate regreditur ad
+               librae octauam partem, ut fiant solis contractiora curricula. Nouissime pigras ac
+               breues horas ad capricorni humiliorem metam restringens in solstitium aliud, quod
+               brumale dicitur, tendit. Ac sic alterno discrimine dies a noctibus umbraeque a
+               solibus superantur, octauae partis quadrifariam limite disparato, ut aequinoctia duo,
+               solstitia totidem numerentur. Caeli uero in hunc numerum orbes seu deus artifex seu
+               prudens natura disposuit. Nam primus ac summus est aplanes, qui, quia semper uno ac
+               iugi continuatus agitur motu, nulli uidetur errori esse subiectus. Sub eo planetarum
+               sunt quinque circuli et solis ac lunae curricula. Nam terra, ut ait Tullius, nona
+               immota semper sede manet, et ab illorum motibus segregata obstipo pondere defixa
+               subsedit. Additur causis, quod in musica tonus octauae partis detractione consistit
+               per numerum qui epogdous nominatur. <lb/>
             </p>
          </div>
          <div type="cap" n="18">
-            <p> Iure igitur aetatem hominis hi numeri temperant, quorum in natura totius non est causa
-     potentia, quam colligi duorum altrinsecus subductione perspicimus? Qui numerus Africani clausit
-     aetatem. Hic quoque plenissimus intellegitur, quia et ordinem naturalem per analogiae
-     constituit rationem et ex his partibus constat, in quibus est miranda perfectio, id est
-     duodetriginta duplicatis in summam. Nam quinquaginta pro quinque debemus accipere, sicut pro
-     monade decadem. Quinque autem in ordine sequens senarius comitatur, quem superioribus adhaerere
-     cognoscis. Duodetriginta perfectus est numerus in secundo uersu, sicut est in primo senarius,
-     quod impletur partibus suis, nec absque hoc alius. Habet autem partes has: dimidiam
-     quatuordecim; tertiam non habet; quartam uero habet septem; quinta sextaque priuatus est;
-     septimam recipit numeris quatuor; octauam, nonam, decimam, undecimam, duodecimam, tertiam
-     decimam ne disquiras; quartam decimam uides in duobus existere, a qua usque in duodetricesimam
-     nulla subductae rationis portio reperitur. Omnes ergo partes eius in ordinem digere simulque
-     subducito: in cumulum primitus positum remeabunt. Namque quatuordecim, septem, quatuor, duo,
-     unus et duodetriginta congregatio iugata componet. Qui si perfectus est numerus, ut ratio
-     comprobauit, duo perfecti magis fecere perfectum. Non potuit igitur Africanus uelut immaturae
-     mortis queri dispendia, quia nihil minus est uitae, quam ratus est numerorum ordo
-     compleuit.<lb/>
+            <p> Iure igitur aetatem hominis hi numeri temperant, quorum in natura totius non est
+               causa potentia, quam colligi duorum altrinsecus subductione perspicimus? Qui numerus
+               Africani clausit aetatem. Hic quoque plenissimus intellegitur, quia et ordinem
+               naturalem per analogiae constituit rationem et ex his partibus constat, in quibus est
+               miranda perfectio, id est duodetriginta duplicatis in summam. Nam quinquaginta pro
+               quinque debemus accipere, sicut pro monade decadem. Quinque autem in ordine sequens
+               senarius comitatur, quem superioribus adhaerere cognoscis. Duodetriginta perfectus
+               est numerus in secundo uersu, sicut est in primo senarius, quod impletur partibus
+               suis, nec absque hoc alius. Habet autem partes has: dimidiam quatuordecim; tertiam
+               non habet; quartam uero habet septem; quinta sextaque priuatus est; septimam recipit
+               numeris quatuor; octauam, nonam, decimam, undecimam, duodecimam, tertiam decimam ne
+               disquiras; quartam decimam uides in duobus existere, a qua usque in duodetricesimam
+               nulla subductae rationis portio reperitur. Omnes ergo partes eius in ordinem digere
+               simulque subducito: in cumulum primitus positum remeabunt. Namque quatuordecim,
+               septem, quatuor, duo, unus et duodetriginta congregatio iugata componet. Qui si
+               perfectus est numerus, ut ratio comprobauit, duo perfecti magis fecere perfectum. Non
+               potuit igitur Africanus uelut immaturae mortis queri dispendia, quia nihil minus est
+               uitae, quam ratus est numerorum ordo compleuit.<lb/>
             </p>
          </div>
          <div type="cap" n="19">
-            <p> Adiungamus huic loco illud quoque de nouenario, quod Tullius ait: nouem tibi orbibus conexa
-     sint omnia, ut hoc demonstrato totius primi uersus plena sit disputatio. Est igitur quadratus
-     numerus nouenarius, quia ex tribus in se triplicatis exoritur, sicut haec figura composita est: <figure>
+            <p> Adiungamus huic loco illud quoque de nouenario, quod Tullius ait: nouem tibi orbibus
+               conexa sint omnia, ut hoc demonstrato totius primi uersus plena sit disputatio. Est
+               igitur quadratus numerus nouenarius, quia ex tribus in se triplicatis exoritur, sicut
+               haec figura composita est: <figure>
                   <lb/>
                   <graphic url="IMG/dlt000182002"/>
                   <head> IMG 2 </head>
                   <lb/>
                </figure>
                <lb/> Quoquo uerteris, quadraturam uidebis, cuncta eius latera congruentia. Totusque
-     habetur ex totis, quia et initium habet in tribus et medium obtinent tres idemque finiunt,
-     partesque ipsius totae sunt, quod in aliis nequaquam numeris inuenitur. Tres enim, ut supra
-     diximus, totus est numerus, sed non ex totis ipse compositus. At uero nouem et ipsi tribus
-     partibus toti sunt, et ipsae partes totae de tribus. Ex quo mihi uidetur Maro doctissimus
-     Romanorum dixisse illud: nouies Styx interfusa coercet. Terra enim nona est, ad quam Styx illa
-     protenditur: mystice ac Platonica dictum esse sapientia non ignores. Nam poetica libertate
-     inserit fontanae animae a caelo usque in terras esse decursum: hinc dicitur <foreign xml:lang="grc">πηγαία</foreign>. Nam sub pedibus summi patris, qui Dis est, Styx posita per
-     omnes circulos fluit, imponens singulis uelut in curru aurigam, id est uitae substantiam, ex
-     qua cuncta uiuentia originem sortiuntur, et eidem soluta redduntur. Manatque illa per cunctos
-      <supplied>circulos</supplied> uolentes commisceri, quod ex natura sunt hiulci: interiectu sui
-     uigoris separat et, quod ipse mire Virgilius loquitur: coercet, ut sui generis momenta
-     conseruent. Inter caelum et terram nouem interualla ipse consideres licet. Sic, quoniam primi
-     uersus absolutio nouenario numero continetur, neque ipsa decimum circulum natura
-     requirebat.<lb/>
+               habetur ex totis, quia et initium habet in tribus et medium obtinent tres idemque
+               finiunt, partesque ipsius totae sunt, quod in aliis nequaquam numeris inuenitur. Tres
+               enim, ut supra diximus, totus est numerus, sed non ex totis ipse compositus. At uero
+               nouem et ipsi tribus partibus toti sunt, et ipsae partes totae de tribus. Ex quo mihi
+               uidetur Maro doctissimus Romanorum dixisse illud: nouies Styx interfusa coercet.
+               Terra enim nona est, ad quam Styx illa protenditur: mystice ac Platonica dictum esse
+               sapientia non ignores. Nam poetica libertate inserit fontanae animae a caelo usque in
+               terras esse decursum: hinc dicitur <foreign xml:lang="grc">πηγαία</foreign>. Nam sub
+               pedibus summi patris, qui Dis est, Styx posita per omnes circulos fluit, imponens
+               singulis uelut in curru aurigam, id est uitae substantiam, ex qua cuncta uiuentia
+               originem sortiuntur, et eidem soluta redduntur. Manatque illa per cunctos
+                  <supplied>circulos</supplied> uolentes commisceri, quod ex natura sunt hiulci:
+               interiectu sui uigoris separat et, quod ipse mire Virgilius loquitur: coercet, ut sui
+               generis momenta conseruent. Inter caelum et terram nouem interualla ipse consideres
+               licet. Sic, quoniam primi uersus absolutio nouenario numero continetur, neque ipsa
+               decimum circulum natura requirebat.<lb/>
             </p>
          </div>
          <div type="cap" n="20">
-            <p> Habes de numeris quod sine libris in agello positus potui reminisci. Sequenti parte sermonis
-     etiam symphoniam mundi, qua eum personare Pythagoras existimat, referemus.<lb/>
+            <p> Habes de numeris quod sine libris in agello positus potui reminisci. Sequenti parte
+               sermonis etiam symphoniam mundi, qua eum personare Pythagoras existimat,
+               referemus.<lb/>
             </p>
          </div>
          <div type="cap" n="21">
-            <p> Sequitur locus cum rei obscuritate, tum expositionis a Tullio positae breuitate difficilis,
-     qui sub personis hisdem, quas supra memorauimus, sonitum mundi octo uidelicet orbium impulsione
-     concinere Pythagorei dogmatis assertione perdocuit. Nam terra, ut ait idem, nona immota semper
-     sede consistens nullo canore concutitur, et uelut fundamenti uice circum se actis octo cursibus
-     defixa libratur, atque ut in cithara testudo, sic ipsa mundanae harmoniae uelut machinam
-     praebet. Sed quaedam primitus ex musica disciplina tradenda sunt, quo facilior intellectus
-     existat. <lb/>
+            <p> Sequitur locus cum rei obscuritate, tum expositionis a Tullio positae breuitate
+               difficilis, qui sub personis hisdem, quas supra memorauimus, sonitum mundi octo
+               uidelicet orbium impulsione concinere Pythagorei dogmatis assertione perdocuit. Nam
+               terra, ut ait idem, nona immota semper sede consistens nullo canore concutitur, et
+               uelut fundamenti uice circum se actis octo cursibus defixa libratur, atque ut in
+               cithara testudo, sic ipsa mundanae harmoniae uelut machinam praebet. Sed quaedam
+               primitus ex musica disciplina tradenda sunt, quo facilior intellectus existat. <lb/>
             </p>
          </div>
          <div type="cap" n="22">
-            <p> Sicut in arte grammatica articulatae uocis maximae ac principales partes edocentur nomina et
-     uerba; horum autem sunt syllabae partes ac litterae syllabarum, per quas in unum collectae
-     significant aliquid, et in eas rursus diductae soluuntur, ita canorae uocis, quae a Graecis
-      <foreign xml:lang="grc">ἐμμελής</foreign> dicitur et est numeris modulisque contexta,
-     principales portiones habentur <foreign xml:lang="grc">συστήματα</foreign>. Systematum uero
-     partes ex certo contractu pronuntiationis existunt, quae <foreign xml:lang="grc">διαστήματα</foreign> Graeci, nos interualla nominamus. Diastematum uero partes sunt <foreign xml:lang="grc">φθόγγοι</foreign>, qui soni Latine dicuntur. Hi soni quasi fundamentum sunt
-     cantus. Est autem sonorum plurima differentia iuxta cordarum intentionem, quae non ut libet
-     efficitur, sed certa obseruatione numerorum, de quibus mox loquemur. Et acuti quidem soni
-     uehementius et citius percusso aere excitantur, grauiores autem quotiens lenius tardiusque
-     pulsantur, et ubi nimius incitatiorque pulsus est, accentio uocitatur, succentio uero, cum
-     lenior tardiorque pulsatio est. Ex accentionibus <supplied>et succentionibus</supplied> ratione
-     musicae cantio temperata symphonia dicitur, quam ita definiunt: symphonia est consonae uocis
-     continua modulatio. Dicunturque aliae simplices symphoniae, aliae uero copulatae. Prima igitur
-     symphonia in quatuor primis modulis inuenitur, quae diatesseron a musicis appellatur. Secunda,
-     quae ex quinque primis modulis constat, <del>ac</del> diapente nominatur. Quibus mixtis in
-     ordinem atque compositis nascitur ea cantilena, quae diapason habetur per epogdoum numerum,
-     quia ueteres musici octo tantum cordis utebantur, ad circulorum caelestium similitudinem
-     referentes. Tres sunt itaque symphoniae simplices ac primigeniae, diapente, diatesseron,
-     diapason, quae in tetracordo numerorum ratione disposito reperiuntur. Nam si unam cordam ut
-     libet intentam semel aut iterum uerberas, sonabit quidem uel graue uel acutum; consonantiam
-     tamen habere non poterit, quae dicitur symphonia. Huic cordae si alteram iungas diuersa ratione
-     distentam, quae tamen diuersitas analogiae congruentiam haberet, sonabunt non irritum aut
-     simplex, sed quod et aures oblectet et rationi, de qua loquimur, rite conueniat. Tendamus
-     igitur primam cordam momentis sex, alteram uero octo; comparatio istarum cordarum symphoniam
-     efficit diatesseron. At si aliam duobus momentis, aliam tribus intendas, diapente symphonia in
-     utriusque percussione resonabit. Si uero aliam sex momentis intorseris, aliam duodecim, dicetur
-     haec symphonia diapason, quam dupli ratio ex utraque superius demonstrata pepererit.<lb/>
+            <p> Sicut in arte grammatica articulatae uocis maximae ac principales partes edocentur
+               nomina et uerba; horum autem sunt syllabae partes ac litterae syllabarum, per quas in
+               unum collectae significant aliquid, et in eas rursus diductae soluuntur, ita canorae
+               uocis, quae a Graecis <foreign xml:lang="grc">ἐμμελής</foreign> dicitur et est
+               numeris modulisque contexta, principales portiones habentur <foreign xml:lang="grc"
+                  >συστήματα</foreign>. Systematum uero partes ex certo contractu pronuntiationis
+               existunt, quae <foreign xml:lang="grc">διαστήματα</foreign> Graeci, nos interualla
+               nominamus. Diastematum uero partes sunt <foreign xml:lang="grc">φθόγγοι</foreign>,
+               qui soni Latine dicuntur. Hi soni quasi fundamentum sunt cantus. Est autem sonorum
+               plurima differentia iuxta cordarum intentionem, quae non ut libet efficitur, sed
+               certa obseruatione numerorum, de quibus mox loquemur. Et acuti quidem soni
+               uehementius et citius percusso aere excitantur, grauiores autem quotiens lenius
+               tardiusque pulsantur, et ubi nimius incitatiorque pulsus est, accentio uocitatur,
+               succentio uero, cum lenior tardiorque pulsatio est. Ex accentionibus <supplied>et
+                  succentionibus</supplied> ratione musicae cantio temperata symphonia dicitur, quam
+               ita definiunt: symphonia est consonae uocis continua modulatio. Dicunturque aliae
+               simplices symphoniae, aliae uero copulatae. Prima igitur symphonia in quatuor primis
+               modulis inuenitur, quae diatesseron a musicis appellatur. Secunda, quae ex quinque
+               primis modulis constat, <del>ac</del> diapente nominatur. Quibus mixtis in ordinem
+               atque compositis nascitur ea cantilena, quae diapason habetur per epogdoum numerum,
+               quia ueteres musici octo tantum cordis utebantur, ad circulorum caelestium
+               similitudinem referentes. Tres sunt itaque symphoniae simplices ac primigeniae,
+               diapente, diatesseron, diapason, quae in tetracordo numerorum ratione disposito
+               reperiuntur. Nam si unam cordam ut libet intentam semel aut iterum uerberas, sonabit
+               quidem uel graue uel acutum; consonantiam tamen habere non poterit, quae dicitur
+               symphonia. Huic cordae si alteram iungas diuersa ratione distentam, quae tamen
+               diuersitas analogiae congruentiam haberet, sonabunt non irritum aut simplex, sed quod
+               et aures oblectet et rationi, de qua loquimur, rite conueniat. Tendamus igitur primam
+               cordam momentis sex, alteram uero octo; comparatio istarum cordarum symphoniam
+               efficit diatesseron. At si aliam duobus momentis, aliam tribus intendas, diapente
+               symphonia in utriusque percussione resonabit. Si uero aliam sex momentis intorseris,
+               aliam duodecim, dicetur haec symphonia diapason, quam dupli ratio ex utraque superius
+               demonstrata pepererit.<lb/>
             </p>
          </div>
          <div type="cap" n="23">
-            <p> Sed ne confusius haec a nobis tradantur, dicam quot modis inter se numeri comparentu, dein
-     quae sit numeris sonisque cognatio ad efficiendam consonantem iugiter cantilenam. Numerus
-     igitur aut diplasius aut hemiolius aut epitritus aut epogdous appellatur. Diplasius, Latine qui
-     dicitur duplex, sub exemplo senarii ac duodecimi numeri demonstatur, quae inter se summae, ut
-     uides, longius diducuntur. Hemolius uero propinquior ex duobus ac tribus est numeris, cum
-     minorem summam maior alia, collata, media minoris superat portione; namque uides tres duobus
-     uno anteire numero, qui minoris dimidia pars est. Tertia comparationis est ratio ex epitrito
-     numero, cum scilicet maior minorem summam non medietate minoris eiusdem sed tertia parte
-     progreditur, ut quatuor ad tria sunt; quamquam enim uno superentur, tamen hic unus non media
-     portio minoris est, sed tertia uidelicet. Epogdous autem tunc esse dicitur numerus, cum maior
-     minorem summam octaua parte minoris anteuenit, ut sunt nouem ad octo; qui cum uno similiter, ut
-     superiores, anteeat, tamen, ut uides, octaua pars minoris est unus. Qua comparatione nullam
-     artiorem fieri posse arithmetici asserunt uel in numeris uel in sonis. Nec enim possumus decem
-     ad nouenariam summam pari ratione conferre, prohibente epogdoi uersus memorato superius limite.
-     <lb/>
+            <p> Sed ne confusius haec a nobis tradantur, dicam quot modis inter se numeri
+               comparentu, dein quae sit numeris sonisque cognatio ad efficiendam consonantem
+               iugiter cantilenam. Numerus igitur aut diplasius aut hemiolius aut epitritus aut
+               epogdous appellatur. Diplasius, Latine qui dicitur duplex, sub exemplo senarii ac
+               duodecimi numeri demonstatur, quae inter se summae, ut uides, longius diducuntur.
+               Hemolius uero propinquior ex duobus ac tribus est numeris, cum minorem summam maior
+               alia, collata, media minoris superat portione; namque uides tres duobus uno anteire
+               numero, qui minoris dimidia pars est. Tertia comparationis est ratio ex epitrito
+               numero, cum scilicet maior minorem summam non medietate minoris eiusdem sed tertia
+               parte progreditur, ut quatuor ad tria sunt; quamquam enim uno superentur, tamen hic
+               unus non media portio minoris est, sed tertia uidelicet. Epogdous autem tunc esse
+               dicitur numerus, cum maior minorem summam octaua parte minoris anteuenit, ut sunt
+               nouem ad octo; qui cum uno similiter, ut superiores, anteeat, tamen, ut uides, octaua
+               pars minoris est unus. Qua comparatione nullam artiorem fieri posse arithmetici
+               asserunt uel in numeris uel in sonis. Nec enim possumus decem ad nouenariam summam
+               pari ratione conferre, prohibente epogdoi uersus memorato superius limite. <lb/>
             </p>
          </div>
          <div type="cap" n="24">
             <p> Expositis igitur comparationibus numerorum dicamus, quae cum his sit symphoniarum ab
-     harmonica disciplina coniunctio. Fac igitur tetracordum ex his, quos proponam, numeris
-     temperatum, quorum sit prior senarius, perfectus ac sapiens numerus, secundus octauus, tertius
-     nouenarius; duodecimus qui est, locetur extremus. In his quatuor cordis omnes simplices
-     symphoniae uaria cordarum percussione nascuntur. Nam ex interuallo senariae atque octonariae
-     summae symphonia diatesseron efficitur, atque epitrito numero continetur; qui etiam in duabus,
-     quae sunt reliquae, sicuti cernis, apparet. Nam duodecim ad nouem eodem comparantur epitrito,
-     recinuntque similiter symphoniam, quae diatesseron appellatur. At si altrinsecus prima
-     tertiaque, item secunda et extrema pulsetur, symphonia resonabit, quae dicitur diapente, ex
-     hemiolia orta ratione. Prima ergo et extrema percussae diapason efficiunt symphoniam ex
-     diplasio numero consonantem. Cuius umbilicum epogdous ille contineat, qui
-      <supplied>per</supplied> octo ac nouem uidetur insertus. Huius igitur figuram aspice
-     tetracordi: <figure>
+               harmonica disciplina coniunctio. Fac igitur tetracordum ex his, quos proponam,
+               numeris temperatum, quorum sit prior senarius, perfectus ac sapiens numerus, secundus
+               octauus, tertius nouenarius; duodecimus qui est, locetur extremus. In his quatuor
+               cordis omnes simplices symphoniae uaria cordarum percussione nascuntur. Nam ex
+               interuallo senariae atque octonariae summae symphonia diatesseron efficitur, atque
+               epitrito numero continetur; qui etiam in duabus, quae sunt reliquae, sicuti cernis,
+               apparet. Nam duodecim ad nouem eodem comparantur epitrito, recinuntque similiter
+               symphoniam, quae diatesseron appellatur. At si altrinsecus prima tertiaque, item
+               secunda et extrema pulsetur, symphonia resonabit, quae dicitur diapente, ex hemiolia
+               orta ratione. Prima ergo et extrema percussae diapason efficiunt symphoniam ex
+               diplasio numero consonantem. Cuius umbilicum epogdous ille contineat, qui
+                  <supplied>per</supplied> octo ac nouem uidetur insertus. Huius igitur figuram
+               aspice tetracordi: <figure>
                   <lb/>
                   <graphic url="IMG/dlt000182003.png"/>
                   <head> IMG 3 </head>
@@ -496,93 +549,101 @@
             </p>
          </div>
          <div type="cap" n="25">
-            <p> At quia non quatuor circulis, sed octo, ut traditum est, harmonia mundana compacta est, non
-     diapason, sed disdiapason symphonia concinit ex duobus uelut tetracordis inter se coeuntibus.
-     Quorum interualla doctissimus ille Pythagoras ostendit, qui a terra usque ad illum uerticem,
-     qui dicitur aplanes, duodecim hemitonia patere cognouit, quorum diuisio ad dupli conuenit
-     rationem, si octo ad quaternarium numerum referre uolueris. Namque ait a terra ad lunam tonon
-     esse, a luna ad Mercurii circulum hemitonion, indeque ad Veneris hemitonion, a quo ad solem
-     tria hemitonia; a solis autem orbe ad circulum Martium tonon esse, a quo ad Iouem hemitonion,
-     indeque ad Saturni hemitonion, a quo ad signiferum circulum similiter hemitonion. Ita fieri, ut
-     sex tonis caelum distet a terra, duodecim scilicet hemitoniis, fierique his traditas
-     symphonias. Namque a terra ad solis circulum diatesseron reboat symphonia, a solis uero ad
-     zodiacum diapente, totum autem diapason, quae ex duobus primis <supplied>…</supplied> aeque duo
-     sunt hemisphaeria, superius et inferius, et disdiapason totius mundi sonitus concinit, uiginti
-     quatuor uidelicet hemitoniis, quae rursus ad duplum licet accipias. Nam ut octo a quaternario
-     duplo distant, sic uiginti quatuor a duodecim. Habent enim eosdem in se et alios totidem
-     duplicatos, quae dupli natura est. Sic ergo per tonos, qui epogdoa ratione consertim iunctimque
-     miscentur, efficitur consonae iugitatis continua modulatio. Quam, ut ait Cicero, imitati docti
-     atque sapientes, aperuerunt sibi reditum in caelum, quod et musica disciplina purgatos animos
-     faciat labe corporea et imperiosis pateat uia carminibus in usque illum
-      <supplied>circulum</supplied>, qui dicitur galaxias, animarum beata luce fulgentem. Verba
-     igitur Ciceronis attende: dixerat Africanus: Quis est qui implet aures meas sonus ? Mirifice
-     implet: quid enim eo plenius aut grandius cogitaueris, qui auditum nostrum nimio sono uocis
-     obtundat et oculos multo lumine caligantes ipsa sui substantia cernendi nimietate debilitet?
-     Cui responsum est: Hic est, qui interuallis disiunctus imparibus. Quae sunt interualla? Quae,
-     ut dixi, Graeci <foreign xml:lang="grc">διαστήματα</foreign> nominauerunt, non locorum, sed
-     numerorum spatia, quae in metris aures sensu metiuntur. Disparibus tamen, sed non pugnantibus,
-     quod hac ratione quoque probabitur. Quatuor posuimus summas: <figure>
+            <p> At quia non quatuor circulis, sed octo, ut traditum est, harmonia mundana compacta
+               est, non diapason, sed disdiapason symphonia concinit ex duobus uelut tetracordis
+               inter se coeuntibus. Quorum interualla doctissimus ille Pythagoras ostendit, qui a
+               terra usque ad illum uerticem, qui dicitur aplanes, duodecim hemitonia patere
+               cognouit, quorum diuisio ad dupli conuenit rationem, si octo ad quaternarium numerum
+               referre uolueris. Namque ait a terra ad lunam tonon esse, a luna ad Mercurii circulum
+               hemitonion, indeque ad Veneris hemitonion, a quo ad solem tria hemitonia; a solis
+               autem orbe ad circulum Martium tonon esse, a quo ad Iouem hemitonion, indeque ad
+               Saturni hemitonion, a quo ad signiferum circulum similiter hemitonion. Ita fieri, ut
+               sex tonis caelum distet a terra, duodecim scilicet hemitoniis, fierique his traditas
+               symphonias. Namque a terra ad solis circulum diatesseron reboat symphonia, a solis
+               uero ad zodiacum diapente, totum autem diapason, quae ex duobus primis
+                  <supplied>…</supplied> aeque duo sunt hemisphaeria, superius et inferius, et
+               disdiapason totius mundi sonitus concinit, uiginti quatuor uidelicet hemitoniis, quae
+               rursus ad duplum licet accipias. Nam ut octo a quaternario duplo distant, sic uiginti
+               quatuor a duodecim. Habent enim eosdem in se et alios totidem duplicatos, quae dupli
+               natura est. Sic ergo per tonos, qui epogdoa ratione consertim iunctimque miscentur,
+               efficitur consonae iugitatis continua modulatio. Quam, ut ait Cicero, imitati docti
+               atque sapientes, aperuerunt sibi reditum in caelum, quod et musica disciplina
+               purgatos animos faciat labe corporea et imperiosis pateat uia carminibus in usque
+               illum <supplied>circulum</supplied>, qui dicitur galaxias, animarum beata luce
+               fulgentem. Verba igitur Ciceronis attende: dixerat Africanus: Quis est qui implet
+               aures meas sonus ? Mirifice implet: quid enim eo plenius aut grandius cogitaueris,
+               qui auditum nostrum nimio sono uocis obtundat et oculos multo lumine caligantes ipsa
+               sui substantia cernendi nimietate debilitet? Cui responsum est: Hic est, qui
+               interuallis disiunctus imparibus. Quae sunt interualla? Quae, ut dixi, Graeci
+                  <foreign xml:lang="grc">διαστήματα</foreign> nominauerunt, non locorum, sed
+               numerorum spatia, quae in metris aures sensu metiuntur. Disparibus tamen, sed non
+               pugnantibus, quod hac ratione quoque probabitur. Quatuor posuimus summas: <figure>
                   <lb/>
                   <graphic url="IMG/dlt000182004.png"/>
                   <head> IMG 4 </head>
                   <lb/>
                </figure>
                <lb/> Quid tam diuersum? Tamen naturalem inter eas cerne concordiam: duc primam cum
-     extrema, item unam ex mediis in sese; eandem colligent quantitatem: bis etenim sedecim ducti
-     triginta duo efficiunt et sex decies bini idem colligunt; medietas uero prima in se ducta
-     triginta duo colligit, quod faciunt ambae medietates sibi consertae; namque quater octoni
-     triginta duo colligit et octies quaterni triginta duo efficiunt. Atque ita naturalis illa
-     unitas congruentiaque seruatur, dum idem sint extrema, quod media, mediumque in se uersum
-     extremorum efficiat quantitatem. Quid quod item notare nos conuenit? Ad perspiciendam numerorum
-     inter se caritatem: ut enim prima medietas cum extrema summa collecta sexaginta quatuor
-     efficit, ita secunda medietas sibi complexa atque in semet adducta eandem, quam modo posui,
-     exhibet quantitatem.<lb/>
+               extrema, item unam ex mediis in sese; eandem colligent quantitatem: bis etenim
+               sedecim ducti triginta duo efficiunt et sex decies bini idem colligunt; medietas uero
+               prima in se ducta triginta duo colligit, quod faciunt ambae medietates sibi
+               consertae; namque quater octoni triginta duo colligit et octies quaterni triginta duo
+               efficiunt. Atque ita naturalis illa unitas congruentiaque seruatur, dum idem sint
+               extrema, quod media, mediumque in se uersum extremorum efficiat quantitatem. Quid
+               quod item notare nos conuenit? Ad perspiciendam numerorum inter se caritatem: ut enim
+               prima medietas cum extrema summa collecta sexaginta quatuor efficit, ita secunda
+               medietas sibi complexa atque in semet adducta eandem, quam modo posui, exhibet
+               quantitatem.<lb/>
             </p>
          </div>
          <div type="cap" n="26">
-            <p> Haec in arithmetica disciplina proportio (Graece <foreign xml:lang="grc">ἀναλογία</foreign>)
-     censetur, quae pari crementorum ordine sic progreditur, ut mediis extrema primaque coniungat
-     faciatque eadem, quae fuerant natura discreta. Quam in sonis quoque caelestium circulorum
-     diuinitus esse seruatam doctissime Tullius ipse commendat dicens: qui interuallis disiunctus
-     imparibus, sed tamen pro rata parte ratione dispositis, inpulsu eorum orbium efficitur. Haec
-     est enim Graece analogia quae numquam in duobus ostenditur, sed tribus et deinceps, ut fiat
-      quod<del>quot</del> eius est proprium: quantum hoc ad illud, tantum <del>hoc</del> illud ad
-     hoc. Nam ut duo prima quatuor dupli ratione superant, sic eodem duplo uincuntur ab octo
-     rursusque sedecim duplo superant octonariam summam. Hoc igitur in sono seruari musicorum
-     scientia profitetur, ut sic diuersis temperetur uocibus cantilena, ut ipsa fiat rata diuersitas
-     et concentu proficiat, quicquid absonum canere uidebatur. Nam cum, sicut ipse nos docuit, ex
-     alia parte acutum personet mundus, ex alia graue. Temperantur haec mediis et ita gradatim
-     uniuersa miscentur, ut sit in caeteris uis duorum, acuti scilicet atque grauis: ut acuto
-     zodiacus circulus, graui lunaris, – illudque dicatur nete, hoc hypate, – sono Dorio moueatur.
-     Quod in nostris uocibus quoque animaduertere conuenit, in quibus a graui sono in acutum surgit
-     accentus. Et, ut lingua nostra pulsatus aer sensibile quiddam auribus reddit, sic circulis
-     impellentibus aera permixtum percussione dissimili editur mundi consonum melos, tonis ueluti
-     pedibus metiendum. Nam tonus certa mensura est cum uel octaua tibiae parte dimensa, uel aeris
-     in pondere, uel in fidibus torquendo, diuersitas numeri rata et pro competenti seruatur. Nam si
-     tibiam cuiuslibet longitudinis sumas et octaua eius portione deducta cauernam imprimas, tonus
-     auditur; si sextam decimam ex reliqua metiaris, emitonium consequitur. Itaque cauernis
-     harmoniae lege dispositis edentur symphoniae, quas docui per numerorum interualla congruere.
-     Hoc idem in siccandis cordis pondera moliuntur, ut inter duas pari habitudine facta epogdoi
-     discrimina reseruentur, octauae partis semper accessione dimensa; ex qua, ut dixi, tonus
-     existit: si uero hemitonium tono copulare uolueris, sexta decima ponderis parte minor corda
-     siccabitur, atque ita concinentia consonae modulationis orietur.<lb/>
+            <p> Haec in arithmetica disciplina proportio (Graece <foreign xml:lang="grc"
+                  >ἀναλογία</foreign>) censetur, quae pari crementorum ordine sic progreditur, ut
+               mediis extrema primaque coniungat faciatque eadem, quae fuerant natura discreta. Quam
+               in sonis quoque caelestium circulorum diuinitus esse seruatam doctissime Tullius ipse
+               commendat dicens: qui interuallis disiunctus imparibus, sed tamen pro rata parte
+               ratione dispositis, inpulsu eorum orbium efficitur. Haec est enim Graece analogia
+               quae numquam in duobus ostenditur, sed tribus et deinceps, ut fiat
+                  quod<del>quot</del> eius est proprium: quantum hoc ad illud, tantum <del>hoc</del>
+               illud ad hoc. Nam ut duo prima quatuor dupli ratione superant, sic eodem duplo
+               uincuntur ab octo rursusque sedecim duplo superant octonariam summam. Hoc igitur in
+               sono seruari musicorum scientia profitetur, ut sic diuersis temperetur uocibus
+               cantilena, ut ipsa fiat rata diuersitas et concentu proficiat, quicquid absonum
+               canere uidebatur. Nam cum, sicut ipse nos docuit, ex alia parte acutum personet
+               mundus, ex alia graue. Temperantur haec mediis et ita gradatim uniuersa miscentur, ut
+               sit in caeteris uis duorum, acuti scilicet atque grauis: ut acuto zodiacus circulus,
+               graui lunaris, – illudque dicatur nete, hoc hypate, – sono Dorio moueatur. Quod in
+               nostris uocibus quoque animaduertere conuenit, in quibus a graui sono in acutum
+               surgit accentus. Et, ut lingua nostra pulsatus aer sensibile quiddam auribus reddit,
+               sic circulis impellentibus aera permixtum percussione dissimili editur mundi consonum
+               melos, tonis ueluti pedibus metiendum. Nam tonus certa mensura est cum uel octaua
+               tibiae parte dimensa, uel aeris in pondere, uel in fidibus torquendo, diuersitas
+               numeri rata et pro competenti seruatur. Nam si tibiam cuiuslibet longitudinis sumas
+               et octaua eius portione deducta cauernam imprimas, tonus auditur; si sextam decimam
+               ex reliqua metiaris, emitonium consequitur. Itaque cauernis harmoniae lege dispositis
+               edentur symphoniae, quas docui per numerorum interualla congruere. Hoc idem in
+               siccandis cordis pondera moliuntur, ut inter duas pari habitudine facta epogdoi
+               discrimina reseruentur, octauae partis semper accessione dimensa; ex qua, ut dixi,
+               tonus existit: si uero hemitonium tono copulare uolueris, sexta decima ponderis parte
+               minor corda siccabitur, atque ita concinentia consonae modulationis orietur.<lb/>
             </p>
          </div>
          <div type="cap" n="27">
             <p> Idem in organis atque aere seruabitur, auribus perite iudicantibus spatia uocum uel
-     incitatius enuntiantium uel tardius grauiusque sonantium. Hinc illa septem discrimina uocis
-     existunt, de quibus ait idem Tullius: septem efficiunt distinctos interuallis sonos. Quod sic
-     intellegere conuenit, ut aut septem interualla octo circulos diuidant aut unius, id est solis,
-     commune sit melos, ut duo ista tetracorda quodam modo non hiantia neque dissona uideantur in
-     medio fiatque ab imo usque ad summum disdiapason iugiter audiendi modulatio cantilenae.<lb/>
+               incitatius enuntiantium uel tardius grauiusque sonantium. Hinc illa septem discrimina
+               uocis existunt, de quibus ait idem Tullius: septem efficiunt distinctos interuallis
+               sonos. Quod sic intellegere conuenit, ut aut septem interualla octo circulos diuidant
+               aut unius, id est solis, commune sit melos, ut duo ista tetracorda quodam modo non
+               hiantia neque dissona uideantur in medio fiatque ab imo usque ad summum disdiapason
+               iugiter audiendi modulatio cantilenae.<lb/>
             </p>
          </div>
          <div type="cap" n="28">
-            <p> Scio me, uir doctissime, reprehendi posse in hac temeritatis audacia, qui haec iam diu
-     scolis obolita non meditata lucubratione sed tumultuaria digesserim. Sed habeant alii scientiae
-     gloriam: mihi pro defensione <supplied>est</supplied> studio tuo paruisse, quod ita flagras
-     ardore discendi, ut ea quoque inter iudicationum tuarum occupationes audire uolueris, quae
-     peritius ipse docere alios potuisti.<lb/>
+            <p> Scio me, uir doctissime, reprehendi posse in hac temeritatis audacia, qui haec iam
+               diu scolis obolita non meditata lucubratione sed tumultuaria digesserim. Sed habeant
+               alii scientiae gloriam: mihi pro defensione <supplied>est</supplied> studio tuo
+               paruisse, quod ita flagras ardore discendi, ut ea quoque inter iudicationum tuarum
+               occupationes audire uolueris, quae peritius ipse docere alios potuisti.<lb/>
             </p>
          </div>
       </body>

--- a/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
@@ -32,9 +32,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="unknown" matchPattern="(\w+)"
+            <cRefPattern n="chapter" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-               <p>This pointer pattern extracts unknown</p>
+               <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>

--- a/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
@@ -81,7 +81,7 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
 

--- a/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
@@ -33,7 +33,7 @@
       <encodingDesc>
          <refsDecl n="CTS">
             <cRefPattern n="chapter" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
                <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>

--- a/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0122c/stoa001/stoa0122c.stoa001.digilibLT-lat1.xml
@@ -84,7 +84,10 @@
             <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
-
+      <revisionDesc>
+         <change who="Vincent Giovannangeli" when="2021-04-25">Suppression de la seconde ligne qui empêchait la validation du fichier, 
+            correction de la langue, de la balise cRefPattern, du Xpath et ajout d'un revision desc pour indiquer l'auteur et la date de la correction</change>
+      </revisionDesc>
    </teiHeader>
 
    <text>


### PR DESCRIPTION
Issue #80 

**Fichier XML CapiTains 4/5 corrigé**

Nom du fichier: `stoa0122c.stoa001.digilibLT-lat1.xml`
Titre de l'oeuvre: _Disputatio de somnio Scipionis_

Afin de rendre le document compatible avec CapiTainS, j'ai effectué les corrections suivantes :

- [x] Dans la balise `cRefPattern` précision de ce que l'on extraie: transformation de "unknown" en "chapters"

- [x] Correction du Xpath avec la suppression d'un noeud (une `tei:div` inutile)

- [x] Correction dans la balise `language` de la langue utilisée dans le fichier, "la" en "lat" pour latin

- [x]  Ajout de balises `revisionDesc` et `change` pour indiquer la date et l'auteur des corrections

- [x]  Suppression de la seconde ligne, qui posait des problèmes de validation du fichier