### PR TITLE
5/5 | Correction du fichier "stoa0044.stoa003"

### DIFF
--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -34,7 +34,7 @@
       <encodingDesc>
          <refsDecl n="CTS">
             <cRefPattern n="chapter" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei/text/body/div/div/div[@n='$1']))">
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
                <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="unknown" matchPattern="(\w+)"
+            <cRefPattern n="chapter" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei/text/body/div/div/div[@n='$1']))">
-               <p>This pointer pattern extracts unknown</p>
+               <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -34,7 +34,7 @@
       <encodingDesc>
          <refsDecl n="CTS">
             <cRefPattern n="chapter" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
                <p>This pointer pattern extracts chapters</p>
             </cRefPattern>
          </refsDecl>
@@ -92,7 +92,6 @@
          <div type="opus">
             <head>LIBELLVS DE VITA ET MORIBVS IMPERATORVM BREVIATVS EX LIBRIS SEXTI AVRELII VICTORIS
                <lb/> a Caesare Augusto usque ad Theodosium </head>
-         </div>
             <div type="cap" n="1">
                <p>
                   <milestone unit="par" n="1"/> Anno urbis conditae septingentesimo vicesimo
@@ -1372,6 +1371,7 @@
                   quinquagesimum apud Mediolanum excessit utramque rempublicam utrisque filiis, id
                   est Arcadio et Honorio, quietam relinquens. <milestone unit="par" n="20"/> Corpus
                   eius eodem anno Constantinopolim translatum atque sepultum est. </p>
+         </div>
          </div>
       </body>
    </text>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -1,344 +1,1304 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
-        <fileDesc>
-            <titleStmt>
-                <title>Epitome de Caesaribus</title>
-                <author>Aurelius Victor Ps.</author>
-                <respStmt>
-                    <resp>Correzione linguistica</resp>
-                    <name>Valentina Rinaldi</name>
-                </respStmt>
-                <respStmt>
-                    <resp>Codifica XML</resp>
-                    <name>Valentina Rinaldi</name>
-                </respStmt>
-            </titleStmt>
-            <publicationStmt>
-                <publisher>DigilibLT</publisher>
-                <pubPlace>Vercelli</pubPlace>
-                <date>2011</date>
-                <availability>
-                    <p>
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Epitome de Caesaribus</title>
+            <author>Aurelius Victor Ps.</author>
+            <respStmt>
+               <resp>Correzione linguistica</resp>
+               <name>Valentina Rinaldi</name>
+            </respStmt>
+            <respStmt>
+               <resp>Codifica XML</resp>
+               <name>Valentina Rinaldi</name>
+            </respStmt>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>DigilibLT</publisher>
+            <pubPlace>Vercelli</pubPlace>
+            <date>2011</date>
+            <availability>
+               <p>
                   <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
                </p>
-                </availability>
-                <idno>dlt000030</idno>
-            </publicationStmt>
-            <sourceDesc>
-                <p>Sexti Aureli Victori, Liber de Caesaribus. Praecedunt Origo gentis Romanae et Liber de viris illustribus urbis Romae, subsequitur Epitome de Caesaribus, edidit F. Pichlmayr, Teubner, Leipzig 1911, 1970 (con aggiunte di R. Gruendel).</p>
-            </sourceDesc>
-        </fileDesc>
-        <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei/text/body/div/div/div[@n='$1']))"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
-            <projectDesc>
-                <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-                <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
-            </projectDesc>
-            <editorialDecl>
-                                
-                <p>
+            </availability>
+            <idno>dlt000030</idno>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Sexti Aureli Victori, Liber de Caesaribus. Praecedunt Origo gentis Romanae et Liber
+               de viris illustribus urbis Romae, subsequitur Epitome de Caesaribus, edidit F.
+               Pichlmayr, Teubner, Leipzig 1911, 1970 (con aggiunte di R. Gruendel).</p>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="unknown" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei/text/body/div/div/div[@n='$1']))">
+               <p>This pointer pattern extracts unknown</p>
+            </cRefPattern>
+         </refsDecl>
+         <projectDesc>
+            <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
+         </projectDesc>
+         <editorialDecl>
+
+            <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
-                <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-                    l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-                    e commenti e ogni altro contenuto redatto da editori moderni. </p>
-                <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-                    correttezza di trascrizione</p>
-                <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-                    distinzione u/v minuscole.</p>
-                <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-                <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-                    grassetto, corsivo, spaziatura espansa.</p>
-                <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-                    &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-                    <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-                    si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-                    [...]<lb/> lacuna integrata dagli editori:
-                    &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-                </p>
-                <p>Sono stati marcati i termini in lingua greca
-                    &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-                </p>
-                <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-                    [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
+            <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
+            <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
+               grassetto, corsivo, spaziatura espansa.</p>
+            <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
-            </editorialDecl>
-           
-        </encodingDesc>
-        
-    </teiHeader>
+         </editorialDecl>
 
-    <text>
-        <body xml:lang="lat" n="urn:cts:latinLit:stoa0044.stoa003.digilibLT-lat1">
+      </encodingDesc>
+
+   </teiHeader>
+
+   <text>
+      <body xml:lang="lat" n="urn:cts:latinLit:stoa0044.stoa003.digilibLT-lat1">
          <div type="opus">
-            <head>LIBELLVS DE VITA ET MORIBVS IMPERATORVM BREVIATVS EX LIBRIS SEXTI AVRELII VICTORIS <lb/> 
-           a Caesare Augusto usque ad Theodosium </head>
+            <head>LIBELLVS DE VITA ET MORIBVS IMPERATORVM BREVIATVS EX LIBRIS SEXTI AVRELII VICTORIS
+               <lb/> a Caesare Augusto usque ad Theodosium </head>
+         </div>
             <div type="cap" n="1">
                <p>
-                  <milestone unit="par" n="1"/> Anno urbis conditae septingentesimo vicesimo secundo, ab exactis vero regibus quadringentesimo octogesimoque, mos Romae repetitus uni prorsus parendi, pro rege imperatori vel sanctiori nomine Augusto appellato. <milestone unit="par" n="2"/> 
-                  <hi rend="expanded">Octavianus</hi> igitur, patre Octavio senatore genitus, maternum genus ab Aenea per Iuliam familiam sortitus, adoptione vero Gai Caesaris maioris avunculi <hi rend="expanded">Gaius Caesar</hi> dictus, deinde ob victoriam <hi rend="expanded">Augustus</hi> cognominatus est. <milestone unit="par" n="3"/> Iste in imperio positus tribuniciam potestatem per se exercuit. <milestone unit="par" n="4"/> Regionem Aegypti inundatione Nili accessu difficilem inviamque paludibus in provinciae formam redegit. <milestone unit="par" n="5"/> Quam ut annonae urbis copiosam efficeret, fossas incuria vetustatis limo clausas labore militum patefecit. <milestone unit="par" n="6"/> Huius tempore ex Aegypto urbi annua ducenties centena milia frumenti inferebantur. <milestone unit="par" n="7"/> Iste Cantabros et Aquitanos, Rhaetos, Vindelicos, Dalmatas provinciarum numero populo Romano coniunxit. Suevos Cattosque delevit, Sigambros in Galliam transtulit. Pannonios stipendiarios adiecit. Getarum populos Basternasque lacessitos bellis ad concordiam compulit. <milestone unit="par" n="8"/> Huic Persae obsides obtulerunt creandique reges arbitrium permiserunt. <milestone unit="par" n="9"/> Ad hunc Indi, Scythae, Garamantes, Aethiopes legatos cum donis miserunt. <milestone unit="par" n="10"/> Adeo denique turbas bella simultates execratus est, ut nisi iustis de causis numquam genti cuiquam bellum indixerit. Iactantisque esse ingenii et levissimi dicebat ardore triumphandi et ob lauream coronam, id est folia infructuosa, in discrimen per incertos eventus certaminum securitatem civium praecipitare; <milestone unit="par" n="11"/> neque imperatori bono quicquam minus quam temeritatem congruere: satis celeriter fieri, quicquid commode gereretur, <milestone unit="par" n="12"/> armaque, nisi maioris emolumenti spe, nequaquam movenda esse, ne compendio tenui, iactura gravi, petita victoria similis sit hamo aureo piscantibus, cuius abrupti amissique detrimentum nullo capturae lucro pensari potest. <milestone unit="par" n="13"/> Huius tempore trans Rhenum vastatus est Romanus exercitus atque tribuni et propraetor. Quod in tantum accidisse perdoluit, ut cerebri valido incursu parietem pulsaret, veste capilloque ac reliquis lugentium indiciis deformis. <milestone unit="par" n="14"/> Avunculi quoque inventum vehementer arguebat, qui milites commilitones novo blandoque more appellans, dum affectat carior fieri, auctoritatem principis emolliverat. <milestone unit="par" n="15"/> Denique erga cives clementissime versatus est. <milestone unit="par" n="16"/> In amicos fidus extitit. Quorum praecipui erant ob taciturnitatem Maecenas, ob patientiam laboris modestiamque Agrippa. Diligebat praeterea Virgilium. Rarus quidem ad recipiendas amicitias, ad retinendas constantissimus. <milestone unit="par" n="17"/> Liberalibus studiis, praesertim eloquentiae, in tantum incumbens, ut nullus ne in procinctu quidem laberetur dies, quin legeret scriberet declamaret. <milestone unit="par" n="18"/> Leges alias novas alias correctas protulit suo nomine. Auxit ornavitque Romam aedificiis multis, isto glorians dicto: <milestone unit="par" n="19"/> 'Vrbem latericiam repperi, relinquo marmoream.' <milestone unit="par" n="20"/> Fuit mitis gratus civilis animi et lepidi, corpore toto pulcher, sed oculis magis. Quorum acies clarissimorum siderum modo vibrans libenter accipiebat cedi ab intendentibus tamquam solis radiis aspectu suo. A cuius facie dum quidam miles oculos averteret et interrogaretur ab eo, cur ita faceret, respondit: 'Quia fulmen oculorum tuorum ferre non possum'.</p>
-                <p>
-                  <milestone unit="par" n="21"/> Nec tamen vir tantus vitiis caruit. Fuit enim paululum impatiens, leniter iracundus, occulte invidus, palam factiosus; porro autem dominandi supra quam aestimari potest, cupidissimus, studiosus aleae lusor. <milestone unit="par" n="22"/> Cumque esset cibi ac vini multum, aliquatenus vero somni abstinens, serviebat tamen libidini usque ad probrum vulgaris famae. Nam inter duodecim catamitos totidemque puellas accubare solitus erat. <milestone unit="par" n="23"/> Abiecta quoque uxore Scribonia amore alienae coniugis possessus Liviam quasi marito concedente sibi coniunxit. Cuius Liviae iam erant filii Tiberius et Drusus. <milestone unit="par" n="24"/> Cumque esset luxuriae serviens, erat tamen eiusdem vitii severissimus ultor, more hominum, qui in ulciscendis vitiis, quibus ipsi vehementer indulgent, acres sunt. Nam poetam Ovidium, qui et Naso, pro eo, quod tres libellos amatoriae artis conscripsit, exilio damnavit. <milestone unit="par" n="25"/> Quodque est laeti animi vel amoeni, oblectabatur omni genere spectaculorum, praecipue ferarum incognita specie et infinito numero.</p>
-                <p>
-                  <milestone unit="par" n="26"/> Annos septem et septuaginta ingressus Nolae morbo interiit. <milestone unit="par" n="27"/> Quamquam alii scribant dolo Liviae exstinctum metuentis, ne, quia privignae filium Agrippam, quem odio novercali in insulam relegaverat, reduci compererat, eo summam rerum adepto poenas daret. <milestone unit="par" n="28"/> Igitur mortuum seu necatum multis novisque honoribus senatus censuit decorandum. Nam praeter id, quod antea Patrem patriae dixerat, templa tam Romae quam per urbes celeberrimas ei consecravit, cunctis vulgo iactantibus: 'Utinam aut non nasceretur aut non moreretur!' <milestone unit="par" n="29"/> Alterum pessimi incepti, exitus praeclari alterum. Nam et in adipiscendo principatu oppressor libertatis est habitus et in gerendo cives sic amavit, ut tridui frumento in horreis quondam viso statuisset veneno mori, si e provinciis classes interea non venirent. <milestone unit="par" n="30"/> Quibus advectis felicitati eius salus patriae est attributa. Imperavit annos quinquaginta et sex, duodecim cum Antonio, quadraginta vero et quattuor solus. <milestone unit="par" n="31"/> Qui certe nunquam aut reipublicae ad se potentiam traxisset aut tamdiu ea potiretur, nisi magnis naturae et studiorum bonis abundasset. </p>
+                  <milestone unit="par" n="1"/> Anno urbis conditae septingentesimo vicesimo
+                  secundo, ab exactis vero regibus quadringentesimo octogesimoque, mos Romae
+                  repetitus uni prorsus parendi, pro rege imperatori vel sanctiori nomine Augusto
+                  appellato. <milestone unit="par" n="2"/>
+                  <hi rend="expanded">Octavianus</hi> igitur, patre Octavio senatore genitus,
+                  maternum genus ab Aenea per Iuliam familiam sortitus, adoptione vero Gai Caesaris
+                  maioris avunculi <hi rend="expanded">Gaius Caesar</hi> dictus, deinde ob victoriam
+                     <hi rend="expanded">Augustus</hi> cognominatus est. <milestone unit="par" n="3"
+                  /> Iste in imperio positus tribuniciam potestatem per se exercuit. <milestone
+                     unit="par" n="4"/> Regionem Aegypti inundatione Nili accessu difficilem
+                  inviamque paludibus in provinciae formam redegit. <milestone unit="par" n="5"/>
+                  Quam ut annonae urbis copiosam efficeret, fossas incuria vetustatis limo clausas
+                  labore militum patefecit. <milestone unit="par" n="6"/> Huius tempore ex Aegypto
+                  urbi annua ducenties centena milia frumenti inferebantur. <milestone unit="par"
+                     n="7"/> Iste Cantabros et Aquitanos, Rhaetos, Vindelicos, Dalmatas provinciarum
+                  numero populo Romano coniunxit. Suevos Cattosque delevit, Sigambros in Galliam
+                  transtulit. Pannonios stipendiarios adiecit. Getarum populos Basternasque
+                  lacessitos bellis ad concordiam compulit. <milestone unit="par" n="8"/> Huic
+                  Persae obsides obtulerunt creandique reges arbitrium permiserunt. <milestone
+                     unit="par" n="9"/> Ad hunc Indi, Scythae, Garamantes, Aethiopes legatos cum
+                  donis miserunt. <milestone unit="par" n="10"/> Adeo denique turbas bella
+                  simultates execratus est, ut nisi iustis de causis numquam genti cuiquam bellum
+                  indixerit. Iactantisque esse ingenii et levissimi dicebat ardore triumphandi et ob
+                  lauream coronam, id est folia infructuosa, in discrimen per incertos eventus
+                  certaminum securitatem civium praecipitare; <milestone unit="par" n="11"/> neque
+                  imperatori bono quicquam minus quam temeritatem congruere: satis celeriter fieri,
+                  quicquid commode gereretur, <milestone unit="par" n="12"/> armaque, nisi maioris
+                  emolumenti spe, nequaquam movenda esse, ne compendio tenui, iactura gravi, petita
+                  victoria similis sit hamo aureo piscantibus, cuius abrupti amissique detrimentum
+                  nullo capturae lucro pensari potest. <milestone unit="par" n="13"/> Huius tempore
+                  trans Rhenum vastatus est Romanus exercitus atque tribuni et propraetor. Quod in
+                  tantum accidisse perdoluit, ut cerebri valido incursu parietem pulsaret, veste
+                  capilloque ac reliquis lugentium indiciis deformis. <milestone unit="par" n="14"/>
+                  Avunculi quoque inventum vehementer arguebat, qui milites commilitones novo
+                  blandoque more appellans, dum affectat carior fieri, auctoritatem principis
+                  emolliverat. <milestone unit="par" n="15"/> Denique erga cives clementissime
+                  versatus est. <milestone unit="par" n="16"/> In amicos fidus extitit. Quorum
+                  praecipui erant ob taciturnitatem Maecenas, ob patientiam laboris modestiamque
+                  Agrippa. Diligebat praeterea Virgilium. Rarus quidem ad recipiendas amicitias, ad
+                  retinendas constantissimus. <milestone unit="par" n="17"/> Liberalibus studiis,
+                  praesertim eloquentiae, in tantum incumbens, ut nullus ne in procinctu quidem
+                  laberetur dies, quin legeret scriberet declamaret. <milestone unit="par" n="18"/>
+                  Leges alias novas alias correctas protulit suo nomine. Auxit ornavitque Romam
+                  aedificiis multis, isto glorians dicto: <milestone unit="par" n="19"/> 'Vrbem
+                  latericiam repperi, relinquo marmoream.' <milestone unit="par" n="20"/> Fuit mitis
+                  gratus civilis animi et lepidi, corpore toto pulcher, sed oculis magis. Quorum
+                  acies clarissimorum siderum modo vibrans libenter accipiebat cedi ab intendentibus
+                  tamquam solis radiis aspectu suo. A cuius facie dum quidam miles oculos averteret
+                  et interrogaretur ab eo, cur ita faceret, respondit: 'Quia fulmen oculorum tuorum
+                  ferre non possum'.</p>
+               <p>
+                  <milestone unit="par" n="21"/> Nec tamen vir tantus vitiis caruit. Fuit enim
+                  paululum impatiens, leniter iracundus, occulte invidus, palam factiosus; porro
+                  autem dominandi supra quam aestimari potest, cupidissimus, studiosus aleae lusor.
+                     <milestone unit="par" n="22"/> Cumque esset cibi ac vini multum, aliquatenus
+                  vero somni abstinens, serviebat tamen libidini usque ad probrum vulgaris famae.
+                  Nam inter duodecim catamitos totidemque puellas accubare solitus erat. <milestone
+                     unit="par" n="23"/> Abiecta quoque uxore Scribonia amore alienae coniugis
+                  possessus Liviam quasi marito concedente sibi coniunxit. Cuius Liviae iam erant
+                  filii Tiberius et Drusus. <milestone unit="par" n="24"/> Cumque esset luxuriae
+                  serviens, erat tamen eiusdem vitii severissimus ultor, more hominum, qui in
+                  ulciscendis vitiis, quibus ipsi vehementer indulgent, acres sunt. Nam poetam
+                  Ovidium, qui et Naso, pro eo, quod tres libellos amatoriae artis conscripsit,
+                  exilio damnavit. <milestone unit="par" n="25"/> Quodque est laeti animi vel
+                  amoeni, oblectabatur omni genere spectaculorum, praecipue ferarum incognita specie
+                  et infinito numero.</p>
+               <p>
+                  <milestone unit="par" n="26"/> Annos septem et septuaginta ingressus Nolae morbo
+                  interiit. <milestone unit="par" n="27"/> Quamquam alii scribant dolo Liviae
+                  exstinctum metuentis, ne, quia privignae filium Agrippam, quem odio novercali in
+                  insulam relegaverat, reduci compererat, eo summam rerum adepto poenas daret.
+                     <milestone unit="par" n="28"/> Igitur mortuum seu necatum multis novisque
+                  honoribus senatus censuit decorandum. Nam praeter id, quod antea Patrem patriae
+                  dixerat, templa tam Romae quam per urbes celeberrimas ei consecravit, cunctis
+                  vulgo iactantibus: 'Utinam aut non nasceretur aut non moreretur!' <milestone
+                     unit="par" n="29"/> Alterum pessimi incepti, exitus praeclari alterum. Nam et
+                  in adipiscendo principatu oppressor libertatis est habitus et in gerendo cives sic
+                  amavit, ut tridui frumento in horreis quondam viso statuisset veneno mori, si e
+                  provinciis classes interea non venirent. <milestone unit="par" n="30"/> Quibus
+                  advectis felicitati eius salus patriae est attributa. Imperavit annos quinquaginta
+                  et sex, duodecim cum Antonio, quadraginta vero et quattuor solus. <milestone
+                     unit="par" n="31"/> Qui certe nunquam aut reipublicae ad se potentiam traxisset
+                  aut tamdiu ea potiretur, nisi magnis naturae et studiorum bonis abundasset. </p>
             </div>
             <div type="cap" n="2">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Claudius Tiberius</hi>, Liviae filius, Caesaris Octaviani privignus, imperavit annos viginti tres. <milestone unit="par" n="2"/> Iste, quia Claudius Tiberius Nero dicebatur, eleganter a iocularibus Caldius Biberius Mero ob vinolentiam nominatus est. <milestone unit="par" n="3"/> Satis prudens in armis satisque fortunatus ante sumptum imperium sub Augusto fuit, ut non immerito reipublicae dominatus ei committeretur. <milestone unit="par" n="4"/> Inerat ei scientia litterarum multa. Eloquio clarior, sed ingenio pessimo truci avaro insidioso, simulans ea se velle quae nollet; his quasi infensus, quibus consultum cupiebat, his vero, quos oderat, quasi benivolus apparens. <milestone unit="par" n="5"/> Repentinis responsionibus aut consiliis melior quam meditatis. <milestone unit="par" n="6"/> Denique delatum a patribus principatum (quod quidem astu fecerat) ficte abnuere, quid singuli dicerent vel sentirent, atrociter explorans: quae res bonos quosque pessumdedit. <milestone unit="par" n="7"/> Aestimantes enim ex animo eum longa oratione imperialis molestiae magnitudinem declinare, cum sententias ad eius voluntatem promunt, incidere exitia postrema. <milestone unit="par" n="8"/> Iste Cappadocas in provinciam remoto Archelao rege eorum redegit. Gaetulorum latrocinia repressit. Marobodum, Suevorum regem, callide circumvenit. <milestone unit="par" n="9"/> Cum immani furore insontes noxios, suos pariter externosque puniret, resolutis militiae artibus Armenia per Parthos, Moesia a Dacis, Pannonia a Sarmatis, Gallia a finitimis gentibus direptae sunt. <milestone unit="par" n="10"/> Ipse post octogesimum octavum annum et mensem quartum insidiis Caligulae exstinctus est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Claudius Tiberius</hi>, Liviae filius, Caesaris Octaviani
+                  privignus, imperavit annos viginti tres. <milestone unit="par" n="2"/> Iste, quia
+                  Claudius Tiberius Nero dicebatur, eleganter a iocularibus Caldius Biberius Mero ob
+                  vinolentiam nominatus est. <milestone unit="par" n="3"/> Satis prudens in armis
+                  satisque fortunatus ante sumptum imperium sub Augusto fuit, ut non immerito
+                  reipublicae dominatus ei committeretur. <milestone unit="par" n="4"/> Inerat ei
+                  scientia litterarum multa. Eloquio clarior, sed ingenio pessimo truci avaro
+                  insidioso, simulans ea se velle quae nollet; his quasi infensus, quibus consultum
+                  cupiebat, his vero, quos oderat, quasi benivolus apparens. <milestone unit="par"
+                     n="5"/> Repentinis responsionibus aut consiliis melior quam meditatis.
+                     <milestone unit="par" n="6"/> Denique delatum a patribus principatum (quod
+                  quidem astu fecerat) ficte abnuere, quid singuli dicerent vel sentirent, atrociter
+                  explorans: quae res bonos quosque pessumdedit. <milestone unit="par" n="7"/>
+                  Aestimantes enim ex animo eum longa oratione imperialis molestiae magnitudinem
+                  declinare, cum sententias ad eius voluntatem promunt, incidere exitia postrema.
+                     <milestone unit="par" n="8"/> Iste Cappadocas in provinciam remoto Archelao
+                  rege eorum redegit. Gaetulorum latrocinia repressit. Marobodum, Suevorum regem,
+                  callide circumvenit. <milestone unit="par" n="9"/> Cum immani furore insontes
+                  noxios, suos pariter externosque puniret, resolutis militiae artibus Armenia per
+                  Parthos, Moesia a Dacis, Pannonia a Sarmatis, Gallia a finitimis gentibus direptae
+                  sunt. <milestone unit="par" n="10"/> Ipse post octogesimum octavum annum et mensem
+                  quartum insidiis Caligulae exstinctus est. </p>
             </div>
             <div type="cap" n="3">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Caligula</hi> imperavit annos quattuor. <milestone unit="par" n="2"/> Iste filius fuit Germanici, et quia natus in exercitu fuerat, cognomentum calciamenti militaris (id est caligula) sortitus est. <milestone unit="par" n="3"/> Ante principatum omnibus carus acceptusque fuit, in principatu vero talis, ut non inmerito vulgaretur atrociorem illo dominum non fuisse. <milestone unit="par" n="4"/> Denique tres sorores suas stupro maculavit. <milestone unit="par" n="5"/> Incedebat habitu deorum suorum; Iovem ob incestum, e choro autem Bacchanali Liberum se asserebat. <milestone unit="par" n="6"/> De quo nescio an decuerit memoriae prodi, nisi forte quia iuvat de principibus nosse omnia, ut improbi saltem famae metu talia declinent. <milestone unit="par" n="7"/> In palatio matronas nobiles publicae libidini subiecit. <milestone unit="par" n="8"/> Primus diademate imposito dominum se iussit appellari. <milestone unit="par" n="9"/> In spatio trium milium, quod in sinu Puteolano inter moles iacet, duplici ordine naves contexens, arenae aggestu ad terrae speciem viam solidatam, phalerato equo insignisque aenea corona, quasi triumphans indutus aureo paludamento, curru biiugo decucurrit. <milestone unit="par" n="10"/> Dehinc a militibus confossus interiit.</p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Caligula</hi> imperavit annos quattuor. <milestone unit="par"
+                     n="2"/> Iste filius fuit Germanici, et quia natus in exercitu fuerat,
+                  cognomentum calciamenti militaris (id est caligula) sortitus est. <milestone
+                     unit="par" n="3"/> Ante principatum omnibus carus acceptusque fuit, in
+                  principatu vero talis, ut non inmerito vulgaretur atrociorem illo dominum non
+                  fuisse. <milestone unit="par" n="4"/> Denique tres sorores suas stupro maculavit.
+                     <milestone unit="par" n="5"/> Incedebat habitu deorum suorum; Iovem ob
+                  incestum, e choro autem Bacchanali Liberum se asserebat. <milestone unit="par"
+                     n="6"/> De quo nescio an decuerit memoriae prodi, nisi forte quia iuvat de
+                  principibus nosse omnia, ut improbi saltem famae metu talia declinent. <milestone
+                     unit="par" n="7"/> In palatio matronas nobiles publicae libidini subiecit.
+                     <milestone unit="par" n="8"/> Primus diademate imposito dominum se iussit
+                  appellari. <milestone unit="par" n="9"/> In spatio trium milium, quod in sinu
+                  Puteolano inter moles iacet, duplici ordine naves contexens, arenae aggestu ad
+                  terrae speciem viam solidatam, phalerato equo insignisque aenea corona, quasi
+                  triumphans indutus aureo paludamento, curru biiugo decucurrit. <milestone
+                     unit="par" n="10"/> Dehinc a militibus confossus interiit.</p>
             </div>
             <div type="cap" n="4">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Claudius Titus</hi>, Drusi, Tiberii fratris, filius, Caligulae patruus, imperavit annos quattuordecim. <milestone unit="par" n="2"/> Iste, cum senatus censuisset gentem Caesarum exterminari, deformi latebra latere repertus a militibus, quia vecors erat, mitissimus videbatur imprudentibus, imperator effectus est. <milestone unit="par" n="3"/> Hic ventri vino libidini foede oboediens, vecors et prope hebes, ignavus ac pavidus libertorum et coniugis imperiis subiectus fuit. <milestone unit="par" n="4"/> Huius tempore Scribonianus Camillus intra Dalmatias imperator creatus continuo occiditur. Mauri provinciis accessere; caesa Musulamiorum manus est. Aqua Claudia Romae introducta. <milestone unit="par" n="5"/> Huius uxor Messalina primo passim quasi iure adulteriis utebatur: ex quo facto plures metu abstinentes exstincti sunt. Dehinc atrocius accensa nobiliores quasque nuptas et virgines scortorum modo secum proposuerat coactique mares, ut adessent. Quod si quis talia horruerat, afficto crimine in ipsum omnemque familiam saeviebatur, ut magis videretur sub imperatore viro quam imperatori nupta esse. <milestone unit="par" n="6"/> Ita liberti eius potestatem summam adepti stupris exilio caede proscriptionibus omnia foedabant. <milestone unit="par" n="7"/> Ex quibus Felicem legionibus Iudaeae praefecit. Possidonio eunucho post triumphum Britannicum inter militarium fortissimos arma insignia tamquam participi victoriae dono dedit. <milestone unit="par" n="8"/> Polybium inter consules medium incedere fecit. Hos omnes anteibat Narcissus ab epistulis, dominum se gerens ipsius domini, Pallasque praetoriis ornamentis sublimatus; adeo divites, ut causante eo inopiam fisci lepidissime famoso elogio vulgatum sit abunde ei pecuniam fore, si a duobus libertis in societatem reciperetur. <milestone unit="par" n="9"/> Huius temporibus visus est apud Aegyptum Phoenix, quam volucrem ferunt anno quingentesimo ex Arabis memoratos locos advolare; atque in Aegaeo mari repente insula emersit. <milestone unit="par" n="10"/> Hic Agrippinam, Germanici fratris sui filiam, uxorem duxit; quae filio imperium procurans primo privignos insidiis multiformibus, dehinc ipsum coniugem veneno interemit. <milestone unit="par" n="11"/> Vixit annos sexaginta quattuor; cuius funus, ut quondam in Tarquinio Prisco, diu occultatum. <milestone unit="par" n="12"/> Dum arte muliebri corrupti custodes aegrum simulant, Nero privignus eius imperii iura suscepit. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Claudius Titus</hi>, Drusi, Tiberii fratris, filius, Caligulae
+                  patruus, imperavit annos quattuordecim. <milestone unit="par" n="2"/> Iste, cum
+                  senatus censuisset gentem Caesarum exterminari, deformi latebra latere repertus a
+                  militibus, quia vecors erat, mitissimus videbatur imprudentibus, imperator
+                  effectus est. <milestone unit="par" n="3"/> Hic ventri vino libidini foede
+                  oboediens, vecors et prope hebes, ignavus ac pavidus libertorum et coniugis
+                  imperiis subiectus fuit. <milestone unit="par" n="4"/> Huius tempore Scribonianus
+                  Camillus intra Dalmatias imperator creatus continuo occiditur. Mauri provinciis
+                  accessere; caesa Musulamiorum manus est. Aqua Claudia Romae introducta. <milestone
+                     unit="par" n="5"/> Huius uxor Messalina primo passim quasi iure adulteriis
+                  utebatur: ex quo facto plures metu abstinentes exstincti sunt. Dehinc atrocius
+                  accensa nobiliores quasque nuptas et virgines scortorum modo secum proposuerat
+                  coactique mares, ut adessent. Quod si quis talia horruerat, afficto crimine in
+                  ipsum omnemque familiam saeviebatur, ut magis videretur sub imperatore viro quam
+                  imperatori nupta esse. <milestone unit="par" n="6"/> Ita liberti eius potestatem
+                  summam adepti stupris exilio caede proscriptionibus omnia foedabant. <milestone
+                     unit="par" n="7"/> Ex quibus Felicem legionibus Iudaeae praefecit. Possidonio
+                  eunucho post triumphum Britannicum inter militarium fortissimos arma insignia
+                  tamquam participi victoriae dono dedit. <milestone unit="par" n="8"/> Polybium
+                  inter consules medium incedere fecit. Hos omnes anteibat Narcissus ab epistulis,
+                  dominum se gerens ipsius domini, Pallasque praetoriis ornamentis sublimatus; adeo
+                  divites, ut causante eo inopiam fisci lepidissime famoso elogio vulgatum sit
+                  abunde ei pecuniam fore, si a duobus libertis in societatem reciperetur.
+                     <milestone unit="par" n="9"/> Huius temporibus visus est apud Aegyptum Phoenix,
+                  quam volucrem ferunt anno quingentesimo ex Arabis memoratos locos advolare; atque
+                  in Aegaeo mari repente insula emersit. <milestone unit="par" n="10"/> Hic
+                  Agrippinam, Germanici fratris sui filiam, uxorem duxit; quae filio imperium
+                  procurans primo privignos insidiis multiformibus, dehinc ipsum coniugem veneno
+                  interemit. <milestone unit="par" n="11"/> Vixit annos sexaginta quattuor; cuius
+                  funus, ut quondam in Tarquinio Prisco, diu occultatum. <milestone unit="par"
+                     n="12"/> Dum arte muliebri corrupti custodes aegrum simulant, Nero privignus
+                  eius imperii iura suscepit. </p>
             </div>
             <div type="cap" n="5">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Domitius Nero</hi>, patre Domitio Ahenobarbo genitus, matre Agrippina, imperavit annos tredecim. <milestone unit="par" n="2"/> Iste quinquennio tolerabilis visus. Unde quidam prodidere Traianum solitum dicere procul distare cunctos principes Neronis quinquennio. <milestone unit="par" n="3"/> Hic in urbe amphitheatrum et lavacra construxit. <milestone unit="par" n="4"/> Pontum in ius provinciae Polemonis reguli permissu redegit, a quo Polemoniacus Pontus appellatur, itemque Cottias Alpes Cottio rege mortuo. <milestone unit="par" n="5"/> Eo namque dedecore reliquum vitae egit, ut pudeat memorare huiuscemodi quemquam. Eo progressus est, ut neque suae neque aliorum pudicitiae parcens, ad extremum amictus nubentium virginum specie palam convocato senatu, dote dicta, cunctis festa more frequentantibus nuberet. Pelle tectus ferae utrique sexui genitalia vultu contrectabat. Matrem etiam stupro contaminavit, quam postmodum interemit. Octaviam et Sabinam cognomento Poppaeam in matrimonium duxit viris earum trucidatis. <milestone unit="par" n="6"/> Tunc Galba, Hispaniae proconsul, et Gaius Iulius imperium corripuere. <milestone unit="par" n="7"/> Ubi adventare Nero Galbam didicit senatusque sententia constitutum, ut more maiorum collo in furcam coniecto virgis ad necem caederetur, desertus undique noctis medio egressus urbe sequentibus Phaone Epaphrodito Neophytoque et spadone Sporo, quem quondam exsectum formare in mulierem temptaverat, semet ictu gladii transegit adiuvante trepidantem manum impuro, de quo diximus, eunucho, cum sane prius nullo reperto, a quo feriretur, exclamaret: 'Itane nec amicum habeo nec inimicum? Dedecorose vixi, turpius peream'. <milestone unit="par" n="8"/> Periit anno aetatis tricesimo secundo. Hunc Persae in tantum dilexerant, ut legatos mitterent orantes copiam construendi monumenti. <milestone unit="par" n="9"/> Ceterum adeo cunctae provinciae omnisque Roma interitu eius exultavit, ut plebs induta pilleis manumissionum tamquam saevo exempta domino triumpharet. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Domitius Nero</hi>, patre Domitio Ahenobarbo genitus, matre
+                  Agrippina, imperavit annos tredecim. <milestone unit="par" n="2"/> Iste
+                  quinquennio tolerabilis visus. Unde quidam prodidere Traianum solitum dicere
+                  procul distare cunctos principes Neronis quinquennio. <milestone unit="par" n="3"
+                  /> Hic in urbe amphitheatrum et lavacra construxit. <milestone unit="par" n="4"/>
+                  Pontum in ius provinciae Polemonis reguli permissu redegit, a quo Polemoniacus
+                  Pontus appellatur, itemque Cottias Alpes Cottio rege mortuo. <milestone unit="par"
+                     n="5"/> Eo namque dedecore reliquum vitae egit, ut pudeat memorare huiuscemodi
+                  quemquam. Eo progressus est, ut neque suae neque aliorum pudicitiae parcens, ad
+                  extremum amictus nubentium virginum specie palam convocato senatu, dote dicta,
+                  cunctis festa more frequentantibus nuberet. Pelle tectus ferae utrique sexui
+                  genitalia vultu contrectabat. Matrem etiam stupro contaminavit, quam postmodum
+                  interemit. Octaviam et Sabinam cognomento Poppaeam in matrimonium duxit viris
+                  earum trucidatis. <milestone unit="par" n="6"/> Tunc Galba, Hispaniae proconsul,
+                  et Gaius Iulius imperium corripuere. <milestone unit="par" n="7"/> Ubi adventare
+                  Nero Galbam didicit senatusque sententia constitutum, ut more maiorum collo in
+                  furcam coniecto virgis ad necem caederetur, desertus undique noctis medio egressus
+                  urbe sequentibus Phaone Epaphrodito Neophytoque et spadone Sporo, quem quondam
+                  exsectum formare in mulierem temptaverat, semet ictu gladii transegit adiuvante
+                  trepidantem manum impuro, de quo diximus, eunucho, cum sane prius nullo reperto, a
+                  quo feriretur, exclamaret: 'Itane nec amicum habeo nec inimicum? Dedecorose vixi,
+                  turpius peream'. <milestone unit="par" n="8"/> Periit anno aetatis tricesimo
+                  secundo. Hunc Persae in tantum dilexerant, ut legatos mitterent orantes copiam
+                  construendi monumenti. <milestone unit="par" n="9"/> Ceterum adeo cunctae
+                  provinciae omnisque Roma interitu eius exultavit, ut plebs induta pilleis
+                  manumissionum tamquam saevo exempta domino triumpharet. </p>
             </div>
             <div type="cap" n="6">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Galba</hi>, nobili Sulpiciorum gente progenitus, imperavit menses septem diesque totidem. <milestone unit="par" n="2"/> Iste in adulescentes infamis, ad vescendum intemperans fuit, trium amicorum consilio, id est Vinii Cornelii Icelii cuncta disponens, adeo ut intra Palatinas aedes pariter habitarent et vulgo paedagogi dicerentur. <milestone unit="par" n="3"/> Hic ante sumptam dominationem multas provincias egregie administravit, militem severissime tractans, ita ut ingresso eo castra vulgaretur statim: 'Disce militare, miles; Galba est, non Gaetulicus'. <milestone unit="par" n="4"/> Cum septuagesimum tertium aetatis annum ageret, dum factione Othonis accensas legiones lorica tectus lenire contenderet, ad lacum Curtium caesus est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Galba</hi>, nobili Sulpiciorum gente progenitus, imperavit
+                  menses septem diesque totidem. <milestone unit="par" n="2"/> Iste in adulescentes
+                  infamis, ad vescendum intemperans fuit, trium amicorum consilio, id est Vinii
+                  Cornelii Icelii cuncta disponens, adeo ut intra Palatinas aedes pariter habitarent
+                  et vulgo paedagogi dicerentur. <milestone unit="par" n="3"/> Hic ante sumptam
+                  dominationem multas provincias egregie administravit, militem severissime
+                  tractans, ita ut ingresso eo castra vulgaretur statim: 'Disce militare, miles;
+                  Galba est, non Gaetulicus'. <milestone unit="par" n="4"/> Cum septuagesimum
+                  tertium aetatis annum ageret, dum factione Othonis accensas legiones lorica tectus
+                  lenire contenderet, ad lacum Curtium caesus est. </p>
             </div>
             <div type="cap" n="7">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Salvius Otho</hi>, splendidis ortus maioribus ex oppido Ferentano, imperavit menses tres, vita omni turpis, maxime adulescentia. <milestone unit="par" n="2"/> Hic a Vitellio primum apud Placentiam, dehinc apud Betriacum victus semet gladio transfixit anno aetatis tricesimo septimo, adeo amabilis militibus propriis, ut plerique corpore eius viso suis manibus interierint. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Salvius Otho</hi>, splendidis ortus maioribus ex oppido
+                  Ferentano, imperavit menses tres, vita omni turpis, maxime adulescentia.
+                     <milestone unit="par" n="2"/> Hic a Vitellio primum apud Placentiam, dehinc
+                  apud Betriacum victus semet gladio transfixit anno aetatis tricesimo septimo, adeo
+                  amabilis militibus propriis, ut plerique corpore eius viso suis manibus
+                  interierint. </p>
             </div>
             <div type="cap" n="8">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Vitellius</hi>, ortus familia nobili, patre Lucio Vitellio ter consule, imperavit menses octo. <milestone unit="par" n="2"/> Iste tumens crudelis avarusque cum profusione fuit. <milestone unit="par" n="3"/> Huius tempore Vespasianus in Oriente principatum arripuit; a cuius militibus certamine sub muris urbis habito superatus e palatio, quo se abdiderat Vitellius, vinctis a tergo manibus productus circumducitur ad spectaculum vulgi. <milestone unit="par" n="4"/> Ac ne homo impudens in extremis saltem malorum, quae gesserat, rubore faciem demitteret, subiecto in mentum gladio seminudus multis coeno fimoque et ceteris turpioribus dictu purgamentis vultum eius incessentibus per scalas Gemonias trahitur, ubi Sabinum, Vespasiani fratrem, necari permiserat. <milestone unit="par" n="5"/> Numerosis ictibus confossus interiit. Vixit annos quinquaginta septem. <milestone unit="par" n="6"/> Hi omnes, quos paucis attigi, praecipue Caesarum gens, adeo litteris culti atque eloquentia fuere, ut, ni cunctis vitiis absque Augusto nimii forent, profecto texissent modica flagitia. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Vitellius</hi>, ortus familia nobili, patre Lucio Vitellio ter
+                  consule, imperavit menses octo. <milestone unit="par" n="2"/> Iste tumens crudelis
+                  avarusque cum profusione fuit. <milestone unit="par" n="3"/> Huius tempore
+                  Vespasianus in Oriente principatum arripuit; a cuius militibus certamine sub muris
+                  urbis habito superatus e palatio, quo se abdiderat Vitellius, vinctis a tergo
+                  manibus productus circumducitur ad spectaculum vulgi. <milestone unit="par" n="4"
+                  /> Ac ne homo impudens in extremis saltem malorum, quae gesserat, rubore faciem
+                  demitteret, subiecto in mentum gladio seminudus multis coeno fimoque et ceteris
+                  turpioribus dictu purgamentis vultum eius incessentibus per scalas Gemonias
+                  trahitur, ubi Sabinum, Vespasiani fratrem, necari permiserat. <milestone
+                     unit="par" n="5"/> Numerosis ictibus confossus interiit. Vixit annos
+                  quinquaginta septem. <milestone unit="par" n="6"/> Hi omnes, quos paucis attigi,
+                  praecipue Caesarum gens, adeo litteris culti atque eloquentia fuere, ut, ni
+                  cunctis vitiis absque Augusto nimii forent, profecto texissent modica flagitia.
+               </p>
             </div>
             <div type="cap" n="9">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Vespasianus</hi> imperavit annos decem. <milestone unit="par" n="2"/> Huius inter cetera bona illud singulare fuit inimicitias oblivisci, adeo, ut Vitellii hostis filiam locupletissime dotatam splendidissimo coniungeret viro. <milestone unit="par" n="3"/> Ferebat patienter amicorum motus, contumeliis eorum, ut erat facetissimus, iocularibus respondens. Namque Licinium Mucianum, quo adiutore ad imperium pervenerat, fiducia meritorum insolentem lepide flectebat adhibito aliquo utrique familiari, id unum dicens: 'Nosti me virum esse'. <milestone unit="par" n="4"/> Sed quid mirum in amicis, cum etiam causidicorum obliqua dicta et philosophorum contumaciam contemneret? <milestone unit="par" n="5"/> Iste exsanguem diu fessumque terrarum orbem brevi refecit. Namque primum satellites tyrannidis, nisi qui forte atrocius longe processerant, flectere potius maluit quam excruciatos delere, prudentissime ratus nefaria ministeria a pluribus metu curari. <milestone unit="par" n="6"/> Praeterea legibus aequissimis monendoque, quodque vehementius est, vitae specie vitiorum plura aboleverat. <milestone unit="par" n="7"/> Infirmus tamen, uti quidam prave putant, adversus pecuniam, cum satis constet aerarii inopia et clade urbium novas eum neque postea habitas vectigalium pensiones exquisivisse. <milestone unit="par" n="8"/> Hic Romam deformem incendiis veteribus ac ruinis permissa, si domini deessent, volentibus aedificandi copia, Capitolium, aedem Pacis, Claudii monumenta reparavit multaque nova instituit. <milestone unit="par" n="9"/> Per omnes terras, qua ius Romanum est, renovatae urbes cultu egregio; viae operibus maximis munitae sunt. <milestone unit="par" n="10"/> Tunc cavati montes per Flaminiam sunt prono transgressui, quae vulgariter Pertunsa petra vocitatur. <milestone unit="par" n="11"/> Mille gentes compositae, cum ducentas aegerrime repperisset, extinctis saevitia tyrannorum plerisque. <milestone unit="par" n="12"/> Rex Parthorum Vologeses metu solo in pacem coactus est. <milestone unit="par" n="13"/> Syria, cui Palaestina nomen est, Ciliciaque ac Trachia et Commagene, quam hodie Augustophratensem nominamus, provinciis accessere. Iudaei quoque additi sunt. <milestone unit="par" n="14"/> Hic monentibus amicis, ut caveret a Mettio Pomposiano, de quo sermo percrebuerat regnaturum fore, consulem fecit, alludens tali cavillo: <milestone unit="par" n="15"/> 'Quandoque memor erit tanti beneficii'. Institutum vero uniforme omni imperio tenuit. Vigilare de nocte, publicisque actibus absolutis caros admittere, dum salutatur, calciamenta sumens et regium vestitum. Post autem negotiis, quaecunque advenissent, auditis exerceri vectatione, deinde requiescere; postremo, ubi lavisset, remissiore animo convivium curabat. <milestone unit="par" n="16"/> Plura dicere studium coegit imperatoris boni, quem ab Augusti morte post annos sex et quinquaginta Romana respublica exsanguis saevitia tyrannorum quasi fato quodam, ne penitus rueret, assecuta est. <milestone unit="par" n="17"/> Itaque annum agens vitae absque uno septuagesimum seriis ioca, quibus delectabatur, admiscens interiit. <milestone unit="par" n="18"/> Quippe primo cum crinitum sidus apparuisset: 'Istud', inquit, 'ad regem Persarum pertinet', cui capillus effusior. Deinde ventris eluvie fessus et assurgens: 'Stantem', ait, 'imperatorem excedere terris decet'. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Vespasianus</hi> imperavit annos decem. <milestone unit="par"
+                     n="2"/> Huius inter cetera bona illud singulare fuit inimicitias oblivisci,
+                  adeo, ut Vitellii hostis filiam locupletissime dotatam splendidissimo coniungeret
+                  viro. <milestone unit="par" n="3"/> Ferebat patienter amicorum motus, contumeliis
+                  eorum, ut erat facetissimus, iocularibus respondens. Namque Licinium Mucianum, quo
+                  adiutore ad imperium pervenerat, fiducia meritorum insolentem lepide flectebat
+                  adhibito aliquo utrique familiari, id unum dicens: 'Nosti me virum esse'.
+                     <milestone unit="par" n="4"/> Sed quid mirum in amicis, cum etiam causidicorum
+                  obliqua dicta et philosophorum contumaciam contemneret? <milestone unit="par"
+                     n="5"/> Iste exsanguem diu fessumque terrarum orbem brevi refecit. Namque
+                  primum satellites tyrannidis, nisi qui forte atrocius longe processerant, flectere
+                  potius maluit quam excruciatos delere, prudentissime ratus nefaria ministeria a
+                  pluribus metu curari. <milestone unit="par" n="6"/> Praeterea legibus aequissimis
+                  monendoque, quodque vehementius est, vitae specie vitiorum plura aboleverat.
+                     <milestone unit="par" n="7"/> Infirmus tamen, uti quidam prave putant, adversus
+                  pecuniam, cum satis constet aerarii inopia et clade urbium novas eum neque postea
+                  habitas vectigalium pensiones exquisivisse. <milestone unit="par" n="8"/> Hic
+                  Romam deformem incendiis veteribus ac ruinis permissa, si domini deessent,
+                  volentibus aedificandi copia, Capitolium, aedem Pacis, Claudii monumenta reparavit
+                  multaque nova instituit. <milestone unit="par" n="9"/> Per omnes terras, qua ius
+                  Romanum est, renovatae urbes cultu egregio; viae operibus maximis munitae sunt.
+                     <milestone unit="par" n="10"/> Tunc cavati montes per Flaminiam sunt prono
+                  transgressui, quae vulgariter Pertunsa petra vocitatur. <milestone unit="par"
+                     n="11"/> Mille gentes compositae, cum ducentas aegerrime repperisset, extinctis
+                  saevitia tyrannorum plerisque. <milestone unit="par" n="12"/> Rex Parthorum
+                  Vologeses metu solo in pacem coactus est. <milestone unit="par" n="13"/> Syria,
+                  cui Palaestina nomen est, Ciliciaque ac Trachia et Commagene, quam hodie
+                  Augustophratensem nominamus, provinciis accessere. Iudaei quoque additi sunt.
+                     <milestone unit="par" n="14"/> Hic monentibus amicis, ut caveret a Mettio
+                  Pomposiano, de quo sermo percrebuerat regnaturum fore, consulem fecit, alludens
+                  tali cavillo: <milestone unit="par" n="15"/> 'Quandoque memor erit tanti
+                  beneficii'. Institutum vero uniforme omni imperio tenuit. Vigilare de nocte,
+                  publicisque actibus absolutis caros admittere, dum salutatur, calciamenta sumens
+                  et regium vestitum. Post autem negotiis, quaecunque advenissent, auditis exerceri
+                  vectatione, deinde requiescere; postremo, ubi lavisset, remissiore animo convivium
+                  curabat. <milestone unit="par" n="16"/> Plura dicere studium coegit imperatoris
+                  boni, quem ab Augusti morte post annos sex et quinquaginta Romana respublica
+                  exsanguis saevitia tyrannorum quasi fato quodam, ne penitus rueret, assecuta est.
+                     <milestone unit="par" n="17"/> Itaque annum agens vitae absque uno
+                  septuagesimum seriis ioca, quibus delectabatur, admiscens interiit. <milestone
+                     unit="par" n="18"/> Quippe primo cum crinitum sidus apparuisset: 'Istud',
+                  inquit, 'ad regem Persarum pertinet', cui capillus effusior. Deinde ventris eluvie
+                  fessus et assurgens: 'Stantem', ait, 'imperatorem excedere terris decet'. </p>
             </div>
             <div type="cap" n="10">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Titus</hi>, vocabulo patris etiam <hi rend="expanded">Vespasianus</hi> dictus, matre liberta Domitilla nomine genitus, imperavit annos duos et menses duos diesque viginti. <milestone unit="par" n="2"/> Iste a puero praeclaris studiis probitatis militiae litterarum instantissime deditus, quo contenderit, animi et corporis muneribus ostendit. <milestone unit="par" n="3"/> Hic ubi patriae curam suscepit, incredibile est, quantum, quem imitabatur, anteierit, praecipue clementia liberalitate honorificentia ac pecuniae contemptu; quae eo amplius grata fuere, quod ex nonnullis a privato adhuc patratis asperior luxuriaeque et avaritiae amans credebatur fore. <milestone unit="par" n="4"/> Namque praefecturam praetorianam patre imperante adeptus suspectum quemque et oppositum sibi immissis, qui per theatra et castris invidiosa iactantes ad poenam poscerent, quasi criminis convictos oppressit. In quis Caecinam consularem adhibitum coenae, vixdum triclinio egressum, ob suspicionem stupratae Berenicis uxoris suae iugulari iussit. <milestone unit="par" n="5"/> Iurgia autem sub patre venumdata rapinarum cupidum<supplied>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Titus</hi>, vocabulo patris etiam <hi rend="expanded"
+                     >Vespasianus</hi> dictus, matre liberta Domitilla nomine genitus, imperavit
+                  annos duos et menses duos diesque viginti. <milestone unit="par" n="2"/> Iste a
+                  puero praeclaris studiis probitatis militiae litterarum instantissime deditus, quo
+                  contenderit, animi et corporis muneribus ostendit. <milestone unit="par" n="3"/>
+                  Hic ubi patriae curam suscepit, incredibile est, quantum, quem imitabatur,
+                  anteierit, praecipue clementia liberalitate honorificentia ac pecuniae contemptu;
+                  quae eo amplius grata fuere, quod ex nonnullis a privato adhuc patratis asperior
+                  luxuriaeque et avaritiae amans credebatur fore. <milestone unit="par" n="4"/>
+                  Namque praefecturam praetorianam patre imperante adeptus suspectum quemque et
+                  oppositum sibi immissis, qui per theatra et castris invidiosa iactantes ad poenam
+                  poscerent, quasi criminis convictos oppressit. In quis Caecinam consularem
+                  adhibitum coenae, vixdum triclinio egressum, ob suspicionem stupratae Berenicis
+                  uxoris suae iugulari iussit. <milestone unit="par" n="5"/> Iurgia autem sub patre
+                  venumdata rapinarum cupidum<supplied>
                      <gap/>
-                  </supplied>: unde Neronem cuncti opinantes vocantesque summam rerum nactum graviter acceperant. <milestone unit="par" n="6"/> Sed haec in melius conversa adeo ei immortalem gloriam contulere, ut deliciae atque amor humani generis appellaretur. <milestone unit="par" n="7"/> Denique ut subiit pondus regium, Berenicen nuptias suas sperantem regredi domum et enervatorum greges abire praecepit. <milestone unit="par" n="8"/> Quo facto quasi signum protulit mutatae intemperantiae. Dehinc cum donata concessave a prioribus principibus firmare insequentes solerent, simul imperium cepit, talia possidentibus edicto sponte cavit. <milestone unit="par" n="9"/> Quadam etiam die recordans vesperi nihil se cuiquam praestitisse venerando caelestique dicto: 'Amici', ait, 'perdidimus diem'; quod erat magnificae liberalitatis. <milestone unit="par" n="10"/> Clementiam vero usque eo perduxit, ut amplissimi ordinis duo cum adversus eum coniuravissent neque abnuere cogitatum scelus quirent, monuerit primo, post deductos in spectaculum se utrimque assidere iusserit petitoque ex industria mirmillonum, quorum pugnae visebantur, gladio quasi ad explorandam aciem uni atque alteri commiserit; quibus perculsis et constantiam mirantibus diceret: 'Videtisne potestates fato dari frustraque temptari facinus potiundi spe vel amittendi metu?' <milestone unit="par" n="11"/> Fratrem quoque Domitianum parantem insidias militumque animos sollicitantem flens saepius obtestatus est, ne parricidio assequi cuperet, quod et se volente esset obventurum ei et iam haberet, cum sit particeps potestatis. <milestone unit="par" n="12"/> Huius tempore mons Vesubius in Campania ardere coepit, incendiumque Romae sine nocturna requie per triduum fuit. <milestone unit="par" n="13"/> Lues quoque, quanta vix umquam antea, fuit. <milestone unit="par" n="14"/> Quibus tamen malis nullo vexato pecunia propria subvenit, cunctis remediorum generibus, nunc aegrotantes per semetipsum reficiens, nunc consolans suorum mortibus afflictos. <milestone unit="par" n="15"/> Vixit annos quadraginta unum, et in eodem, quo pater, apud Sabinos agro febri interiit. <milestone unit="par" n="16"/> Huius mors credi vix potest, quantum luctus urbi provinciisque intulerit, adeo ut eum delicias publicas, sicut diximus, appellantes quasi perpetuo custode orbatum terrarum orbem deflerent. </p>
+                  </supplied>: unde Neronem cuncti opinantes vocantesque summam rerum nactum
+                  graviter acceperant. <milestone unit="par" n="6"/> Sed haec in melius conversa
+                  adeo ei immortalem gloriam contulere, ut deliciae atque amor humani generis
+                  appellaretur. <milestone unit="par" n="7"/> Denique ut subiit pondus regium,
+                  Berenicen nuptias suas sperantem regredi domum et enervatorum greges abire
+                  praecepit. <milestone unit="par" n="8"/> Quo facto quasi signum protulit mutatae
+                  intemperantiae. Dehinc cum donata concessave a prioribus principibus firmare
+                  insequentes solerent, simul imperium cepit, talia possidentibus edicto sponte
+                  cavit. <milestone unit="par" n="9"/> Quadam etiam die recordans vesperi nihil se
+                  cuiquam praestitisse venerando caelestique dicto: 'Amici', ait, 'perdidimus diem';
+                  quod erat magnificae liberalitatis. <milestone unit="par" n="10"/> Clementiam vero
+                  usque eo perduxit, ut amplissimi ordinis duo cum adversus eum coniuravissent neque
+                  abnuere cogitatum scelus quirent, monuerit primo, post deductos in spectaculum se
+                  utrimque assidere iusserit petitoque ex industria mirmillonum, quorum pugnae
+                  visebantur, gladio quasi ad explorandam aciem uni atque alteri commiserit; quibus
+                  perculsis et constantiam mirantibus diceret: 'Videtisne potestates fato dari
+                  frustraque temptari facinus potiundi spe vel amittendi metu?' <milestone
+                     unit="par" n="11"/> Fratrem quoque Domitianum parantem insidias militumque
+                  animos sollicitantem flens saepius obtestatus est, ne parricidio assequi cuperet,
+                  quod et se volente esset obventurum ei et iam haberet, cum sit particeps
+                  potestatis. <milestone unit="par" n="12"/> Huius tempore mons Vesubius in Campania
+                  ardere coepit, incendiumque Romae sine nocturna requie per triduum fuit.
+                     <milestone unit="par" n="13"/> Lues quoque, quanta vix umquam antea, fuit.
+                     <milestone unit="par" n="14"/> Quibus tamen malis nullo vexato pecunia propria
+                  subvenit, cunctis remediorum generibus, nunc aegrotantes per semetipsum reficiens,
+                  nunc consolans suorum mortibus afflictos. <milestone unit="par" n="15"/> Vixit
+                  annos quadraginta unum, et in eodem, quo pater, apud Sabinos agro febri interiit.
+                     <milestone unit="par" n="16"/> Huius mors credi vix potest, quantum luctus urbi
+                  provinciisque intulerit, adeo ut eum delicias publicas, sicut diximus, appellantes
+                  quasi perpetuo custode orbatum terrarum orbem deflerent. </p>
             </div>
             <div type="cap" n="11">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Domitianus</hi>, Vespasiani et Domitillae libertae filius, germanus Titi, imperavit annos quindecim. <milestone unit="par" n="2"/> Iste primo clementiam simulans neque adeo iners domi belloque tolerantior videbatur; idcircoque Cattos Germanosque devicit. <milestone unit="par" n="3"/> Ius aequissime dixit. Romae multa aedificia vel coepta vel a fundamentis construxit. <milestone unit="par" n="4"/> Bibliothecas incendio consumptas petitis undique, praesertim Alexandria, exemplis reparavit. <milestone unit="par" n="5"/> Sagittarum tam doctus fuit, ut inter patentes digitos extentae manus viri procul positi spicula transvolarent. <milestone unit="par" n="6"/> Dehinc atrox caedibus bonorum supplicia agere coepit ac more C. Caligulae dominum sese deumque dici coegit; segnisque ridicule remotis omnibus muscarum agmina persequebatur. <milestone unit="par" n="7"/> Furens libidine, cuius foedum exercitium Graecorum lingua <foreign xml:lang="grc">
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Domitianus</hi>, Vespasiani et Domitillae libertae filius,
+                  germanus Titi, imperavit annos quindecim. <milestone unit="par" n="2"/> Iste primo
+                  clementiam simulans neque adeo iners domi belloque tolerantior videbatur;
+                  idcircoque Cattos Germanosque devicit. <milestone unit="par" n="3"/> Ius
+                  aequissime dixit. Romae multa aedificia vel coepta vel a fundamentis construxit.
+                     <milestone unit="par" n="4"/> Bibliothecas incendio consumptas petitis undique,
+                  praesertim Alexandria, exemplis reparavit. <milestone unit="par" n="5"/>
+                  Sagittarum tam doctus fuit, ut inter patentes digitos extentae manus viri procul
+                  positi spicula transvolarent. <milestone unit="par" n="6"/> Dehinc atrox caedibus
+                  bonorum supplicia agere coepit ac more C. Caligulae dominum sese deumque dici
+                  coegit; segnisque ridicule remotis omnibus muscarum agmina persequebatur.
+                     <milestone unit="par" n="7"/> Furens libidine, cuius foedum exercitium
+                  Graecorum lingua <foreign xml:lang="grc">
                      <hi rend="italic">κλινοπάλην</hi>
-                  </foreign> vocabat. <milestone unit="par" n="8"/> Hinc percontanti cuidam, quisquamne in palatio esset, responsum: Ne musca quidem. <milestone unit="par" n="9"/> His eius saevitiis ac maxime iniuria verborum, qua scortum vocari dolebat, accensus Antonius, curans Germaniam superiorem, imperium corripuit. <milestone unit="par" n="10"/> Quo per Norbanum Lappium acie strato Domitianus longe tetrior in omne hominum genus, etiam in suos, ferarum more grassabatur. <milestone unit="par" n="11"/> Igitur metu crudelitatis et conscientiae suae coniuravere plerique impulsoribus Parthenio procurante cubiculum et Stephano et tum ob fraudem interceptae pecuniae supplicium suspectante Clodiano, ascita etiam in consilium tyranni uxore Domitia ob amorem Paridis histrionis a principe cruciatus formidante. <milestone unit="par" n="12"/> Domitianum multis vulneribus confodiunt post annum quintum et quadragesimum vitae. <milestone unit="par" n="13"/> At senatus gladiatoris more funus efferri radendumque nomen decrevit. <milestone unit="par" n="14"/> Huius tempore saeculares ludi celebrati sunt.</p>
-                <p>
-                  <milestone unit="par" n="15"/> Hactenus Romae seu per Italiam orti imperium rexere, hinc advenae. Unde compertum est urbem Romam externorum virtute crevisse. Quid enim Nerva prudentius aut moderatius? Quid Traiano divinius? Quid praestantius Hadriano? </p>
+                  </foreign> vocabat. <milestone unit="par" n="8"/> Hinc percontanti cuidam,
+                  quisquamne in palatio esset, responsum: Ne musca quidem. <milestone unit="par"
+                     n="9"/> His eius saevitiis ac maxime iniuria verborum, qua scortum vocari
+                  dolebat, accensus Antonius, curans Germaniam superiorem, imperium corripuit.
+                     <milestone unit="par" n="10"/> Quo per Norbanum Lappium acie strato Domitianus
+                  longe tetrior in omne hominum genus, etiam in suos, ferarum more grassabatur.
+                     <milestone unit="par" n="11"/> Igitur metu crudelitatis et conscientiae suae
+                  coniuravere plerique impulsoribus Parthenio procurante cubiculum et Stephano et
+                  tum ob fraudem interceptae pecuniae supplicium suspectante Clodiano, ascita etiam
+                  in consilium tyranni uxore Domitia ob amorem Paridis histrionis a principe
+                  cruciatus formidante. <milestone unit="par" n="12"/> Domitianum multis vulneribus
+                  confodiunt post annum quintum et quadragesimum vitae. <milestone unit="par" n="13"
+                  /> At senatus gladiatoris more funus efferri radendumque nomen decrevit.
+                     <milestone unit="par" n="14"/> Huius tempore saeculares ludi celebrati
+                  sunt.</p>
+               <p>
+                  <milestone unit="par" n="15"/> Hactenus Romae seu per Italiam orti imperium
+                  rexere, hinc advenae. Unde compertum est urbem Romam externorum virtute crevisse.
+                  Quid enim Nerva prudentius aut moderatius? Quid Traiano divinius? Quid
+                  praestantius Hadriano? </p>
             </div>
             <div type="cap" n="12">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Cocceius Nerva</hi>, oppido Narniensi genitus, imperavit menses sedecim dies decem. <milestone unit="par" n="2"/> Iste cum imperium suscepisset, mox rumore orto vivere atque affore Domitianum perinde trepidavit, ut colore mutato verbis amissis vix consisteret. Sed a Parthenio confirmatus recepta fiducia ad sollemne delenimentum conversus est. <milestone unit="par" n="3"/> Qui cum in curiam a senatu gratanter exceptus esset, solus ex omnibus Arrius Antoninus, vir acer eique amicissimus, condicionem imperantium prudenter exprimens, amplexus eum, gratulari se ait senatui et populo provinciisque, ipsi autem nequaquam, cui satius fuerat malos semper principes eludere quam tanti oneris vim sustinentem haud molestiis modo et periculis subici, sed famae etiam inimicorum pariter et amicorum, qui cum se mereri omnia praesumant, si quicquam non extorserint, atrociores sunt ipsis quoque hostibus. <milestone unit="par" n="4"/> Iste quicquid antea poenae nomine tributis accesserat, indulsit; afflictas civitates relevavit; puellas puerosque natos parentibus egestosis sumptu publico per Italiae oppida ali iussit. <milestone unit="par" n="5"/> Hic ne accessu malivolorum terreretur, Iunii Maurici, constantis viri, dicto ita admonetur: Qui convivio familiari adhibitus cum Veientonem consulari honore functum quidem apud Domitianum, tamen multos occultis criminationibus persecutum adesse vidisset, inter colloquia mentione Catulli facta, calumniatoris praecipui, dicente Nerva: 'Quid nunc faceret, si Domitiano supervixisset?' 'Nobiscum', inquit Mauricus, 'cenaret'. Hic iurgiorum disceptator et scientissimus et frequens fuit. <milestone unit="par" n="6"/> Calpurnium Crassum promissis ingentibus animos militum pertemptantem, detectum confessumque Tarentum cum uxore removit patribus lenitatem eius increpantibus. Cumque interfectores Domitiani ad exitium poscerentur, tantum est consternatus, ut neque vomitum neque impetum ventris valuerit differre, <milestone unit="par" n="7"/> et tamen vehementer obstitit dictitans aequius esse mori quam auctoritatem imperii foedare proditis potentiae sumendae auctoribus. <milestone unit="par" n="8"/> Sed milites neglecto principe requisitos Petronium uno ictu, Parthenium vero demptis prius genitalibus et in os coniectis iugulavere <unclear/>redempto magnis sumptibus Casperio; qui scelere tam truci insolentior Nervam compulit referre apud populum gratias militibus, quia pessimos nefandosque omnium mortalium peremissent. <milestone unit="par" n="9"/> Hic Traianum in liberi locum inque partem imperii cooptavit; cum quo tribus vixit mensibus. <milestone unit="par" n="10"/> Qui dum suggerente ira voce quam maxima contra quendam Regulum nomine inclamaret, sudore correptus est. <milestone unit="par" n="11"/> Quo refrigescente horror corporis nimius initia febri praebuit, nec multo post vitam finivit anno aetatis sexagesimo tertio. <milestone unit="par" n="12"/> Cuius corpus a senatu, ut quondam Augusti, honore delatum in sepulcro Augusti sepultum est. Eo die, quo interiit, solis defectio facta est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Cocceius Nerva</hi>, oppido Narniensi genitus, imperavit
+                  menses sedecim dies decem. <milestone unit="par" n="2"/> Iste cum imperium
+                  suscepisset, mox rumore orto vivere atque affore Domitianum perinde trepidavit, ut
+                  colore mutato verbis amissis vix consisteret. Sed a Parthenio confirmatus recepta
+                  fiducia ad sollemne delenimentum conversus est. <milestone unit="par" n="3"/> Qui
+                  cum in curiam a senatu gratanter exceptus esset, solus ex omnibus Arrius
+                  Antoninus, vir acer eique amicissimus, condicionem imperantium prudenter
+                  exprimens, amplexus eum, gratulari se ait senatui et populo provinciisque, ipsi
+                  autem nequaquam, cui satius fuerat malos semper principes eludere quam tanti
+                  oneris vim sustinentem haud molestiis modo et periculis subici, sed famae etiam
+                  inimicorum pariter et amicorum, qui cum se mereri omnia praesumant, si quicquam
+                  non extorserint, atrociores sunt ipsis quoque hostibus. <milestone unit="par"
+                     n="4"/> Iste quicquid antea poenae nomine tributis accesserat, indulsit;
+                  afflictas civitates relevavit; puellas puerosque natos parentibus egestosis sumptu
+                  publico per Italiae oppida ali iussit. <milestone unit="par" n="5"/> Hic ne
+                  accessu malivolorum terreretur, Iunii Maurici, constantis viri, dicto ita
+                  admonetur: Qui convivio familiari adhibitus cum Veientonem consulari honore
+                  functum quidem apud Domitianum, tamen multos occultis criminationibus persecutum
+                  adesse vidisset, inter colloquia mentione Catulli facta, calumniatoris praecipui,
+                  dicente Nerva: 'Quid nunc faceret, si Domitiano supervixisset?' 'Nobiscum', inquit
+                  Mauricus, 'cenaret'. Hic iurgiorum disceptator et scientissimus et frequens fuit.
+                     <milestone unit="par" n="6"/> Calpurnium Crassum promissis ingentibus animos
+                  militum pertemptantem, detectum confessumque Tarentum cum uxore removit patribus
+                  lenitatem eius increpantibus. Cumque interfectores Domitiani ad exitium
+                  poscerentur, tantum est consternatus, ut neque vomitum neque impetum ventris
+                  valuerit differre, <milestone unit="par" n="7"/> et tamen vehementer obstitit
+                  dictitans aequius esse mori quam auctoritatem imperii foedare proditis potentiae
+                  sumendae auctoribus. <milestone unit="par" n="8"/> Sed milites neglecto principe
+                  requisitos Petronium uno ictu, Parthenium vero demptis prius genitalibus et in os
+                  coniectis iugulavere <unclear/>redempto magnis sumptibus Casperio; qui scelere tam
+                  truci insolentior Nervam compulit referre apud populum gratias militibus, quia
+                  pessimos nefandosque omnium mortalium peremissent. <milestone unit="par" n="9"/>
+                  Hic Traianum in liberi locum inque partem imperii cooptavit; cum quo tribus vixit
+                  mensibus. <milestone unit="par" n="10"/> Qui dum suggerente ira voce quam maxima
+                  contra quendam Regulum nomine inclamaret, sudore correptus est. <milestone
+                     unit="par" n="11"/> Quo refrigescente horror corporis nimius initia febri
+                  praebuit, nec multo post vitam finivit anno aetatis sexagesimo tertio. <milestone
+                     unit="par" n="12"/> Cuius corpus a senatu, ut quondam Augusti, honore delatum
+                  in sepulcro Augusti sepultum est. Eo die, quo interiit, solis defectio facta est.
+               </p>
             </div>
             <div type="cap" n="13">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Ulpius Traianus</hi>, ex urbe Tudertina, Ulpius ab avo dictus, Traianus a Traio paterni generis auctore vel de nomine Traiani patris sic appellatus, imperavit annis viginti. <milestone unit="par" n="2"/> Iste talem se reipublicae praebuit, qualem vix aegreque exprimere valuerint summorum scriptorum miranda ingenia. <milestone unit="par" n="3"/> Hic imperium apud Agrippinam, nobilem Galliae coloniam, suscepit, habens diligentiam in re militari, in civilibus lenitatem, in sublevandis civitatibus largitionem. <milestone unit="par" n="4"/> Cumque duo sint, quae ab egregiis principibus exspectentur, sanctitas domi, in armis fortitudo, utrobique prudentia, tantus erat in eo maximarum rerum modus, ut quasi temperamento quodam virtutes miscuisse videretur, nisi quod cibo vinoque paululum deditus erat. <milestone unit="par" n="5"/> Liberalis in amicos et, tamquam vitae condicione par, societatibus perfrui. <milestone unit="par" n="6"/> Hic ob honorem Surae, cuius studio imperium arripuerat, lavacra condidit. <milestone unit="par" n="7"/> De quo supervacaneum videtur cuncta velle nominatim promere, cum satis sit excultum atque emendatum dixisse. <milestone unit="par" n="8"/> Fuit enim patiens laboris, studiosus optimi cuiusque ac bellicosi; magis simpliciora ingenia aut eruditissimos, quamvis ipse parcae esset scientiae moderateque eloquens, diligebat. <milestone unit="par" n="9"/> Iustitiae vero ac iuris humani divinique tam repertor novi quam inveterati custos. <milestone unit="par" n="10"/> Quae omnia eo maiora visebantur, quo per multos atque atroces tyrannos perdito atque prostrato statu Romano in remedium tantorum malorum divinitus credebatur opportune datus, usque eo, ut adveniens imperium eius pleraque mirifica denuntiaverint. In quis praecipuum cornicem e fastigio Capitolii Atticis sermonibus effatam esse: <foreign xml:lang="grc">
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Ulpius Traianus</hi>, ex urbe Tudertina, Ulpius ab avo dictus,
+                  Traianus a Traio paterni generis auctore vel de nomine Traiani patris sic
+                  appellatus, imperavit annis viginti. <milestone unit="par" n="2"/> Iste talem se
+                  reipublicae praebuit, qualem vix aegreque exprimere valuerint summorum scriptorum
+                  miranda ingenia. <milestone unit="par" n="3"/> Hic imperium apud Agrippinam,
+                  nobilem Galliae coloniam, suscepit, habens diligentiam in re militari, in
+                  civilibus lenitatem, in sublevandis civitatibus largitionem. <milestone unit="par"
+                     n="4"/> Cumque duo sint, quae ab egregiis principibus exspectentur, sanctitas
+                  domi, in armis fortitudo, utrobique prudentia, tantus erat in eo maximarum rerum
+                  modus, ut quasi temperamento quodam virtutes miscuisse videretur, nisi quod cibo
+                  vinoque paululum deditus erat. <milestone unit="par" n="5"/> Liberalis in amicos
+                  et, tamquam vitae condicione par, societatibus perfrui. <milestone unit="par"
+                     n="6"/> Hic ob honorem Surae, cuius studio imperium arripuerat, lavacra
+                  condidit. <milestone unit="par" n="7"/> De quo supervacaneum videtur cuncta velle
+                  nominatim promere, cum satis sit excultum atque emendatum dixisse. <milestone
+                     unit="par" n="8"/> Fuit enim patiens laboris, studiosus optimi cuiusque ac
+                  bellicosi; magis simpliciora ingenia aut eruditissimos, quamvis ipse parcae esset
+                  scientiae moderateque eloquens, diligebat. <milestone unit="par" n="9"/> Iustitiae
+                  vero ac iuris humani divinique tam repertor novi quam inveterati custos.
+                     <milestone unit="par" n="10"/> Quae omnia eo maiora visebantur, quo per multos
+                  atque atroces tyrannos perdito atque prostrato statu Romano in remedium tantorum
+                  malorum divinitus credebatur opportune datus, usque eo, ut adveniens imperium eius
+                  pleraque mirifica denuntiaverint. In quis praecipuum cornicem e fastigio Capitolii
+                  Atticis sermonibus effatam esse: <foreign xml:lang="grc">
                      <hi rend="italic">καλῶς ἔσται</hi>
-                  </foreign>. <milestone unit="par" n="11"/> Huius exusti corporis cineres relati Romam humatique Traiani foro sub eius columna, et imago superposita, sicut triumphantes solent, in urbem invecta, senatu praeeunte et exercitu. <milestone unit="par" n="12"/> Eo tempore multo perniciosius quam sub Nerva Tiberis inundavit magna clade aedium proximarum; et terrae motus gravis per provincias multas atroxque pestilentia famesque et incendia facta sunt. <milestone unit="par" n="13"/> Quibus omnibus Traianus per exquisita remedia plurimum opitulatus est, statuens, ne domorum altitudo sexaginta superaret pedes ob ruinas faciles et sumptus, si quando talia contingerent, exitiosos. <milestone unit="par" n="14"/> Unde merito pater patriae dictus est. Vixit annos sexaginta quattuor. </p>
+                  </foreign>. <milestone unit="par" n="11"/> Huius exusti corporis cineres relati
+                  Romam humatique Traiani foro sub eius columna, et imago superposita, sicut
+                  triumphantes solent, in urbem invecta, senatu praeeunte et exercitu. <milestone
+                     unit="par" n="12"/> Eo tempore multo perniciosius quam sub Nerva Tiberis
+                  inundavit magna clade aedium proximarum; et terrae motus gravis per provincias
+                  multas atroxque pestilentia famesque et incendia facta sunt. <milestone unit="par"
+                     n="13"/> Quibus omnibus Traianus per exquisita remedia plurimum opitulatus est,
+                  statuens, ne domorum altitudo sexaginta superaret pedes ob ruinas faciles et
+                  sumptus, si quando talia contingerent, exitiosos. <milestone unit="par" n="14"/>
+                  Unde merito pater patriae dictus est. Vixit annos sexaginta quattuor. </p>
             </div>
             <div type="cap" n="14">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Aelius Adrianus</hi>, stirpis Italae, Aelio Adriano, Traiani principis consobrino, Adriae orto genitus, quod oppidum agri Piceni etiam mari Adriatico nomen dedit, imperavit annis viginti duobus. <milestone unit="par" n="2"/> Hic Graecis litteris impensius eruditus a plerisque Graeculus appellatus est. Atheniensium studia moresque hausit potitus non sermone tantum, sed et ceteris disciplinis, canendi psallendi medendique scientia, musicus geometra pictor fictorque ex aere vel marmore proxime Polycletus et Euphranoras. Proinde omnino ad ista et facetus, ut elegantius umquam raro quicquam humanae res expertae videantur. <milestone unit="par" n="3"/> Memor supra quam cuiquam credibile est, locos negotia milites, absentes quoque, nominibus recensere. <milestone unit="par" n="4"/> Immensi laboris, quippe qui provincias omnes passibus circumierit agmen comitantium praevertens, cum oppida universa restitueret, augeret ordinibus. <milestone unit="par" n="5"/> Namque ad specimen legionum militarium fabros perpendiculatores architectos genusque cunctum exstruendorum moenium seu decorandorum in cohortes centuriaverat. <milestone unit="par" n="6"/> Varius multiplex multiformis; ad vitia atque virtutes quasi arbiter genitus, impetum mentis quodam artificio regens, ingenium invidum triste lascivum et ad ostentationem sui insolens callide tegebat; continentiam facilitatem clementiam simulans contraque dissimulans ardorem gloriae, quo flagrabat. <milestone unit="par" n="7"/> Acer nimis ad lacessendum pariter et respondendum seriis ioco maledictis; referre carmen carmini, dictum dictui, prorsus ut meditatum crederes adversus omnia. <milestone unit="par" n="8"/> Huius uxor Sabina, dum prope servilibus iniuriis afficitur, ad mortem voluntariam compulsa. Quae palam iactabat se, quod immane ingenium probavisset, elaborasse, ne ex eo ad humani generis perniciem gravidaretur. <milestone unit="par" n="9"/> Hic morbo subcutaneo, quem diu placide pertulerat, victus, dolore ardens impatiensque plures e senatu exstinxit. <milestone unit="par" n="10"/> A regibus multis pace occultius muneribus impetrata, iactabat palam plus se otio adeptum quam armis ceteros. <milestone unit="par" n="11"/> Officia sane publica et palatina nec non militiae in eam formam statuit, quae paucis per Constantinum immutatis hodie perseverat. <milestone unit="par" n="12"/> Vixit annos sexaginta duos; dehinc miserabili exitu consumptus est, cruciatu membrorum fere omnium confectus, in tantum, ut crebro sese interficiendum ministrorum fidissimis precans offerret, ac ne in semetipsum saeviret, custodia carissimorum servaretur. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Aelius Adrianus</hi>, stirpis Italae, Aelio Adriano, Traiani
+                  principis consobrino, Adriae orto genitus, quod oppidum agri Piceni etiam mari
+                  Adriatico nomen dedit, imperavit annis viginti duobus. <milestone unit="par" n="2"
+                  /> Hic Graecis litteris impensius eruditus a plerisque Graeculus appellatus est.
+                  Atheniensium studia moresque hausit potitus non sermone tantum, sed et ceteris
+                  disciplinis, canendi psallendi medendique scientia, musicus geometra pictor
+                  fictorque ex aere vel marmore proxime Polycletus et Euphranoras. Proinde omnino ad
+                  ista et facetus, ut elegantius umquam raro quicquam humanae res expertae
+                  videantur. <milestone unit="par" n="3"/> Memor supra quam cuiquam credibile est,
+                  locos negotia milites, absentes quoque, nominibus recensere. <milestone unit="par"
+                     n="4"/> Immensi laboris, quippe qui provincias omnes passibus circumierit agmen
+                  comitantium praevertens, cum oppida universa restitueret, augeret ordinibus.
+                     <milestone unit="par" n="5"/> Namque ad specimen legionum militarium fabros
+                  perpendiculatores architectos genusque cunctum exstruendorum moenium seu
+                  decorandorum in cohortes centuriaverat. <milestone unit="par" n="6"/> Varius
+                  multiplex multiformis; ad vitia atque virtutes quasi arbiter genitus, impetum
+                  mentis quodam artificio regens, ingenium invidum triste lascivum et ad
+                  ostentationem sui insolens callide tegebat; continentiam facilitatem clementiam
+                  simulans contraque dissimulans ardorem gloriae, quo flagrabat. <milestone
+                     unit="par" n="7"/> Acer nimis ad lacessendum pariter et respondendum seriis
+                  ioco maledictis; referre carmen carmini, dictum dictui, prorsus ut meditatum
+                  crederes adversus omnia. <milestone unit="par" n="8"/> Huius uxor Sabina, dum
+                  prope servilibus iniuriis afficitur, ad mortem voluntariam compulsa. Quae palam
+                  iactabat se, quod immane ingenium probavisset, elaborasse, ne ex eo ad humani
+                  generis perniciem gravidaretur. <milestone unit="par" n="9"/> Hic morbo
+                  subcutaneo, quem diu placide pertulerat, victus, dolore ardens impatiensque plures
+                  e senatu exstinxit. <milestone unit="par" n="10"/> A regibus multis pace occultius
+                  muneribus impetrata, iactabat palam plus se otio adeptum quam armis ceteros.
+                     <milestone unit="par" n="11"/> Officia sane publica et palatina nec non
+                  militiae in eam formam statuit, quae paucis per Constantinum immutatis hodie
+                  perseverat. <milestone unit="par" n="12"/> Vixit annos sexaginta duos; dehinc
+                  miserabili exitu consumptus est, cruciatu membrorum fere omnium confectus, in
+                  tantum, ut crebro sese interficiendum ministrorum fidissimis precans offerret, ac
+                  ne in semetipsum saeviret, custodia carissimorum servaretur. </p>
             </div>
             <div type="cap" n="15">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Antoninus Fulvius</hi> seu Boionius dictus, postea etiam <hi rend="expanded">Pius</hi> cognominatus, imperavit annos viginti tres. <milestone unit="par" n="2"/> Iste ab Hadriano in filium adoptatus, cuius gener fuerat, tantae bonitatis in principatu fuit, ut haud dubie sine exemplo vixerit, <milestone unit="par" n="3"/> quamvis eum Numae contulerit aetas sua, cum orbem terrae nullo bello per annos viginti tres auctoritate sola rexerit, adeo trementibus eum atque amantibus cunctis regibus nationibusque et populis, ut parentem seu patronum magis quam dominum imperatoremve reputarent, omnesque in morem caelestium propitium optantes de controversiis inter se iudicem poscerent. <milestone unit="par" n="4"/> Quin etiam Indi Bactri Hyrcani legatos misere iustitia tanti imperatoris comperta, quam ornabat vultu serie pulchro, procerus membra, decenter validus. <milestone unit="par" n="5"/> Priusquam salutandus prodiret, degustans panis aliquantulum, ne frigescente circum praecordia per ieiunium sanguine viribus exesis interciperetur eoque actui publicorum minime sufficeret, quae incredibili diligentia ad speciem optimi patrisfamilias exsequebatur. <milestone unit="par" n="6"/> Appetentia gloriae carens et ostentatione, adeo mansuetus, ut instantibus patribus ad eos, qui contra eum coniuraverant, persequendos compresserit quaestionem, praefatus necesse non esse sceleris in semetipsum cupidos pertinacius indagari, ne, si plures reperirentur, quantis odio esset, intellegeretur. <milestone unit="par" n="7"/> Igitur apud Lorios, villa propria, milibus passuum duodecim ab urbe febri paucorum dierum post tres atque viginti annos imperii consumptus est. <milestone unit="par" n="8"/> Ob cuius honorem templa sacerdotes atque infinita alia decreta sunt. <milestone unit="par" n="9"/> Usque eo autem mitis fuit, ut, cum ob inopiae frumentariae suspicionem lapidibus a plebe Romana perstringeretur, maluerit ratione exposita placare quam ulcisci seditionem. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Antoninus Fulvius</hi> seu Boionius dictus, postea etiam <hi
+                     rend="expanded">Pius</hi> cognominatus, imperavit annos viginti tres.
+                     <milestone unit="par" n="2"/> Iste ab Hadriano in filium adoptatus, cuius gener
+                  fuerat, tantae bonitatis in principatu fuit, ut haud dubie sine exemplo vixerit,
+                     <milestone unit="par" n="3"/> quamvis eum Numae contulerit aetas sua, cum orbem
+                  terrae nullo bello per annos viginti tres auctoritate sola rexerit, adeo
+                  trementibus eum atque amantibus cunctis regibus nationibusque et populis, ut
+                  parentem seu patronum magis quam dominum imperatoremve reputarent, omnesque in
+                  morem caelestium propitium optantes de controversiis inter se iudicem poscerent.
+                     <milestone unit="par" n="4"/> Quin etiam Indi Bactri Hyrcani legatos misere
+                  iustitia tanti imperatoris comperta, quam ornabat vultu serie pulchro, procerus
+                  membra, decenter validus. <milestone unit="par" n="5"/> Priusquam salutandus
+                  prodiret, degustans panis aliquantulum, ne frigescente circum praecordia per
+                  ieiunium sanguine viribus exesis interciperetur eoque actui publicorum minime
+                  sufficeret, quae incredibili diligentia ad speciem optimi patrisfamilias
+                  exsequebatur. <milestone unit="par" n="6"/> Appetentia gloriae carens et
+                  ostentatione, adeo mansuetus, ut instantibus patribus ad eos, qui contra eum
+                  coniuraverant, persequendos compresserit quaestionem, praefatus necesse non esse
+                  sceleris in semetipsum cupidos pertinacius indagari, ne, si plures reperirentur,
+                  quantis odio esset, intellegeretur. <milestone unit="par" n="7"/> Igitur apud
+                  Lorios, villa propria, milibus passuum duodecim ab urbe febri paucorum dierum post
+                  tres atque viginti annos imperii consumptus est. <milestone unit="par" n="8"/> Ob
+                  cuius honorem templa sacerdotes atque infinita alia decreta sunt. <milestone
+                     unit="par" n="9"/> Usque eo autem mitis fuit, ut, cum ob inopiae frumentariae
+                  suspicionem lapidibus a plebe Romana perstringeretur, maluerit ratione exposita
+                  placare quam ulcisci seditionem. </p>
             </div>
             <div type="cap" n="16">
                <p>
-                  <milestone unit="par" n="1"/> Marcus Aurelius <hi rend="expanded">Antoninus</hi> imperavit annos decem et octo. <milestone unit="par" n="2"/> Iste virtutum omnium caelestisque ingenii exstitit aerumnisque publicis quasi defensor obiectus est. Etenim nisi ad illa tempora natus esset, profecto quasi uno lapsu ruissent omnia status Romani. <milestone unit="par" n="3"/> Quippe ab armis quies nusquam erat, perque omnem Orientem Illyricum Italiam Galliamque bella fervebant; terrae motus non sine interitu civitatum, inundationes fluminum, lues crebrae, locustarum species agris infestae, prorsus ut prope nihil, quo summis angoribus atteri mortales solent, dici seu cogitari queat, quod non illo imperante saevierit. <milestone unit="par" n="4"/> Credo divinitus attributum, ut, dum mundi lex seu natura <unclear/>aliudve quid hominibus incognitum gignit, rectorum consiliis tamquam medicinae remediis leniantur. <milestone unit="par" n="5"/> Is propinquum suum Lucium Annium Verum ad imperii partem novo benivolentiae genere ascivit. Qui Verus, inter Altinum atque Concordiam iter faciens, ictu sanguinis, quem morbum Graeci <foreign xml:lang="grc">
+                  <milestone unit="par" n="1"/> Marcus Aurelius <hi rend="expanded">Antoninus</hi>
+                  imperavit annos decem et octo. <milestone unit="par" n="2"/> Iste virtutum omnium
+                  caelestisque ingenii exstitit aerumnisque publicis quasi defensor obiectus est.
+                  Etenim nisi ad illa tempora natus esset, profecto quasi uno lapsu ruissent omnia
+                  status Romani. <milestone unit="par" n="3"/> Quippe ab armis quies nusquam erat,
+                  perque omnem Orientem Illyricum Italiam Galliamque bella fervebant; terrae motus
+                  non sine interitu civitatum, inundationes fluminum, lues crebrae, locustarum
+                  species agris infestae, prorsus ut prope nihil, quo summis angoribus atteri
+                  mortales solent, dici seu cogitari queat, quod non illo imperante saevierit.
+                     <milestone unit="par" n="4"/> Credo divinitus attributum, ut, dum mundi lex seu
+                  natura <unclear/>aliudve quid hominibus incognitum gignit, rectorum consiliis
+                  tamquam medicinae remediis leniantur. <milestone unit="par" n="5"/> Is propinquum
+                  suum Lucium Annium Verum ad imperii partem novo benivolentiae genere ascivit. Qui
+                  Verus, inter Altinum atque Concordiam iter faciens, ictu sanguinis, quem morbum
+                  Graeci <foreign xml:lang="grc">
                      <hi rend="italic">ἀπόπληξιν</hi>
-                  </foreign> vocant, undecimo imperii anno exstinctus est. <milestone unit="par" n="6"/> Carminum, maxime tragicorum, studiosus, ingenii asperi atque lascivi. <milestone unit="par" n="7"/> Post cuius obitum Marcus Antoninus rempublicam solus tenuit. A principio vitae tranquillissimus, adeo, ut ab infantia vultum nec ex gaudio nec ex maerore mutaverit. Philosophiae studens litterarumque Graecarum <supplied>peritissimus</supplied>. <milestone unit="par" n="8"/> Hic permisit viris clarioribus, ut convivia eodem cultu, quo ipse, et ministris similibus exhiberent. <milestone unit="par" n="9"/> Hic cum aerario exhausto largitiones, quas militibus impenderet, non haberet, neque indicere provincialibus aut senatui aliquid vellet, instrumentum regii cultus facta in foro Traiani sectione distraxit, vasa aurea, pocula crystallina et murrina, uxoriam ac suam sericam et auream vestem, multa ornamenta gemmarum, ac per duos continuos menses venditio habita est multumque auri redactum. <milestone unit="par" n="10"/> Post victoriam tamen emptoribus pretia restituit, qui reddere comparata voluerunt; molestus nulli fuit, qui maluit semel empta retinere. <milestone unit="par" n="11"/> Huius tempore Cassius tyrannidem arripiens exstinctus est. <milestone unit="par" n="12"/> Ipse vitae anno quinquagesimo nono apud Bendobonam morbo consumptus est. <milestone unit="par" n="13"/> De eius morte nuntio Romam pervecto confusa luctu publico urbe senatus in curiam veste tetra amictus lacrimans convenit. <milestone unit="par" n="14"/> Et quod de Romulo aegre creditum est, omnes pari consensu praesumpserunt Marcum caelo receptum esse. Ob cuius honorem templa columnae multaque alia decreta sunt. </p>
+                  </foreign> vocant, undecimo imperii anno exstinctus est. <milestone unit="par"
+                     n="6"/> Carminum, maxime tragicorum, studiosus, ingenii asperi atque lascivi.
+                     <milestone unit="par" n="7"/> Post cuius obitum Marcus Antoninus rempublicam
+                  solus tenuit. A principio vitae tranquillissimus, adeo, ut ab infantia vultum nec
+                  ex gaudio nec ex maerore mutaverit. Philosophiae studens litterarumque Graecarum
+                     <supplied>peritissimus</supplied>. <milestone unit="par" n="8"/> Hic permisit
+                  viris clarioribus, ut convivia eodem cultu, quo ipse, et ministris similibus
+                  exhiberent. <milestone unit="par" n="9"/> Hic cum aerario exhausto largitiones,
+                  quas militibus impenderet, non haberet, neque indicere provincialibus aut senatui
+                  aliquid vellet, instrumentum regii cultus facta in foro Traiani sectione
+                  distraxit, vasa aurea, pocula crystallina et murrina, uxoriam ac suam sericam et
+                  auream vestem, multa ornamenta gemmarum, ac per duos continuos menses venditio
+                  habita est multumque auri redactum. <milestone unit="par" n="10"/> Post victoriam
+                  tamen emptoribus pretia restituit, qui reddere comparata voluerunt; molestus nulli
+                  fuit, qui maluit semel empta retinere. <milestone unit="par" n="11"/> Huius
+                  tempore Cassius tyrannidem arripiens exstinctus est. <milestone unit="par" n="12"
+                  /> Ipse vitae anno quinquagesimo nono apud Bendobonam morbo consumptus est.
+                     <milestone unit="par" n="13"/> De eius morte nuntio Romam pervecto confusa
+                  luctu publico urbe senatus in curiam veste tetra amictus lacrimans convenit.
+                     <milestone unit="par" n="14"/> Et quod de Romulo aegre creditum est, omnes pari
+                  consensu praesumpserunt Marcum caelo receptum esse. Ob cuius honorem templa
+                  columnae multaque alia decreta sunt. </p>
             </div>
             <div type="cap" n="17">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Aurelius Commodus</hi>, Antonini filius, Antoninus et ipse dictus, imperavit annos tredecim. Hic qualis futurus esset, in ipso primordio ostendit. <milestone unit="par" n="2"/> Nam cum in supremis moneretur a parente attritos iam barbaros ne permitteret vires recipere, responderat ab incolumi quamvis paulatim negotia perfici posse, a mortuo nihil. <milestone unit="par" n="3"/> Saevior omnibus libidine atque avaritia, crudelitate, nulli fidus, magisque in eos atrox, quos amplissimis honoribus donisque ingentibus extulerat. <milestone unit="par" n="4"/> In tantum depravatus, ut gladiatoriis armis saepissime in amphitheatro dimicaverit. <milestone unit="par" n="5"/> Huic Marcia, generis libertini, forma tamen meretriciisque artibus pollens, cum animum eius penitus devinxisset, egresso e balneo veneni poculum obtulit. <milestone unit="par" n="6"/> Ad extremum ab immisso validissimo palaestrita compressis faucibus exspiravit anno vitae tricesimo secundoque. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Aurelius Commodus</hi>, Antonini filius, Antoninus et ipse
+                  dictus, imperavit annos tredecim. Hic qualis futurus esset, in ipso primordio
+                  ostendit. <milestone unit="par" n="2"/> Nam cum in supremis moneretur a parente
+                  attritos iam barbaros ne permitteret vires recipere, responderat ab incolumi
+                  quamvis paulatim negotia perfici posse, a mortuo nihil. <milestone unit="par"
+                     n="3"/> Saevior omnibus libidine atque avaritia, crudelitate, nulli fidus,
+                  magisque in eos atrox, quos amplissimis honoribus donisque ingentibus extulerat.
+                     <milestone unit="par" n="4"/> In tantum depravatus, ut gladiatoriis armis
+                  saepissime in amphitheatro dimicaverit. <milestone unit="par" n="5"/> Huic Marcia,
+                  generis libertini, forma tamen meretriciisque artibus pollens, cum animum eius
+                  penitus devinxisset, egresso e balneo veneni poculum obtulit. <milestone
+                     unit="par" n="6"/> Ad extremum ab immisso validissimo palaestrita compressis
+                  faucibus exspiravit anno vitae tricesimo secundoque. </p>
             </div>
             <div type="cap" n="18">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Helvius Pertinax</hi> imperavit dies octoginta quinque. Iste coactus imperium repugnansque suscipiens tale cognomentum sortitus est. <milestone unit="par" n="2"/> Origine ortus sordida, praefecturam urbi agens imperator effectus scelere Iuliani multis vulneribus obtruncatur annos natus septem atque sexaginta. Huius caput tota urbe circumvectum est. <milestone unit="par" n="3"/> Hoc exitu obiit vir ad humanae conversationis exemplum per laboris genera universa ad summos provectus, usque eo, ut fortunae vocaretur pila. <milestone unit="par" n="4"/> Nam libertino genitus patre apud Ligures in agro squalido Lollii Gentiani, cuius in praefectura quoque clientem se esse libentissime fatebatur, fuit doctor litterarum, quae a grammaticis traduntur. Blandus magis quam beneficus, unde eum Graeco nomine <foreign xml:lang="grc">
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Helvius Pertinax</hi> imperavit dies octoginta quinque. Iste
+                  coactus imperium repugnansque suscipiens tale cognomentum sortitus est. <milestone
+                     unit="par" n="2"/> Origine ortus sordida, praefecturam urbi agens imperator
+                  effectus scelere Iuliani multis vulneribus obtruncatur annos natus septem atque
+                  sexaginta. Huius caput tota urbe circumvectum est. <milestone unit="par" n="3"/>
+                  Hoc exitu obiit vir ad humanae conversationis exemplum per laboris genera universa
+                  ad summos provectus, usque eo, ut fortunae vocaretur pila. <milestone unit="par"
+                     n="4"/> Nam libertino genitus patre apud Ligures in agro squalido Lollii
+                  Gentiani, cuius in praefectura quoque clientem se esse libentissime fatebatur,
+                  fuit doctor litterarum, quae a grammaticis traduntur. Blandus magis quam
+                  beneficus, unde eum Graeco nomine <foreign xml:lang="grc">
                      <hi rend="italic">χρηστολόγον</hi>
-                  </foreign> appellavere. <milestone unit="par" n="5"/> Numquam iniuria accepta ad ulciscendum ductus. Amabat simplicitatem, communem se affatu, convivio, incessu praebebat. <milestone unit="par" n="6"/> Huic mortuo Divi nomen decretum est; ob cuius laudem ingeminatis ad vocis usque defectum plausibus acclamatum est: 'Pertinace imperante securi viximus, neminem timuimus, patri pio, patri senatus, patri omnium bonorum'. </p>
+                  </foreign> appellavere. <milestone unit="par" n="5"/> Numquam iniuria accepta ad
+                  ulciscendum ductus. Amabat simplicitatem, communem se affatu, convivio, incessu
+                  praebebat. <milestone unit="par" n="6"/> Huic mortuo Divi nomen decretum est; ob
+                  cuius laudem ingeminatis ad vocis usque defectum plausibus acclamatum est:
+                  'Pertinace imperante securi viximus, neminem timuimus, patri pio, patri senatus,
+                  patri omnium bonorum'. </p>
             </div>
             <div type="cap" n="19">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Didius Iulianus</hi>, ortu Mediolanensis, imperavit mensibus septem. Vir nobilis iure peritissimus factiosus praeceps regni avidus. <milestone unit="par" n="2"/> Hoc tempore Niger Pescennius apud Antiochiam, in Pannoniae Sabaria Septimius Severus creantur Augusti. <milestone unit="par" n="3"/> Ab hoc Severo Iulianus in abditas palatii balneas ductus extenta damnatorum modo cervice decollatur caputque eius in rostris ponitur. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Didius Iulianus</hi>, ortu Mediolanensis, imperavit mensibus
+                  septem. Vir nobilis iure peritissimus factiosus praeceps regni avidus. <milestone
+                     unit="par" n="2"/> Hoc tempore Niger Pescennius apud Antiochiam, in Pannoniae
+                  Sabaria Septimius Severus creantur Augusti. <milestone unit="par" n="3"/> Ab hoc
+                  Severo Iulianus in abditas palatii balneas ductus extenta damnatorum modo cervice
+                  decollatur caputque eius in rostris ponitur. </p>
             </div>
             <div type="cap" n="20">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Septimius Severus</hi> imperavit annos decem et octo. <milestone unit="par" n="2"/> Hic Pescennium interemit, hominem omnium turpitudinum. Sub eo etiam Albinus, qui in Gallia se Caesarem fecerat, apud Lugdunum occiditur. <milestone unit="par" n="3"/> Hic Severus filios suos successores reliquit, Bassianum et Getam. <milestone unit="par" n="4"/> Hic in Britannia vallum per triginta duo passuum milia a mari ad mare deduxit. <milestone unit="par" n="5"/> Fuit bellicosissimus omnium, qui ante eum fuerunt. Acer ingenio, ad omnia, quae intendisset, in finem perseverans. Benivolentia, quo inclinasset, mirabili ac perpetua. Ad quaerendum diligens, ad largiendum liberalis. <milestone unit="par" n="6"/> In amicos inimicosque pariter vehemens, quippe qui Lateranum Cilonem Anullinum Bassum ceterosque alios ditaret, aedibus quoque memoratu dignis, quarum praecipuas videmus Parthorum quae dicuntur ac Laterani. <milestone unit="par" n="7"/> Hic nulli in dominatu suo permisit honores venumdari. <milestone unit="par" n="8"/> Latinis litteris sufficienter instructus, Graecis sermonibus eruditus, Punica eloquentia promptior, quippe genitus apud Leptim provinciae Africae.<milestone unit="par" n="9"/> Is dum membrorum omnium, maxime pedum, dolorem pati nequiret, veneni vice, quod ei negabatur, cibum gravis ac plurimae carnis avidius invasit, quem cum conficere non posset, cruditate pressus exspiravit. <milestone unit="par" n="10"/> Vixit annos sexaginta quinque. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Septimius Severus</hi> imperavit annos decem et octo.
+                     <milestone unit="par" n="2"/> Hic Pescennium interemit, hominem omnium
+                  turpitudinum. Sub eo etiam Albinus, qui in Gallia se Caesarem fecerat, apud
+                  Lugdunum occiditur. <milestone unit="par" n="3"/> Hic Severus filios suos
+                  successores reliquit, Bassianum et Getam. <milestone unit="par" n="4"/> Hic in
+                  Britannia vallum per triginta duo passuum milia a mari ad mare deduxit. <milestone
+                     unit="par" n="5"/> Fuit bellicosissimus omnium, qui ante eum fuerunt. Acer
+                  ingenio, ad omnia, quae intendisset, in finem perseverans. Benivolentia, quo
+                  inclinasset, mirabili ac perpetua. Ad quaerendum diligens, ad largiendum
+                  liberalis. <milestone unit="par" n="6"/> In amicos inimicosque pariter vehemens,
+                  quippe qui Lateranum Cilonem Anullinum Bassum ceterosque alios ditaret, aedibus
+                  quoque memoratu dignis, quarum praecipuas videmus Parthorum quae dicuntur ac
+                  Laterani. <milestone unit="par" n="7"/> Hic nulli in dominatu suo permisit honores
+                  venumdari. <milestone unit="par" n="8"/> Latinis litteris sufficienter instructus,
+                  Graecis sermonibus eruditus, Punica eloquentia promptior, quippe genitus apud
+                  Leptim provinciae Africae.<milestone unit="par" n="9"/> Is dum membrorum omnium,
+                  maxime pedum, dolorem pati nequiret, veneni vice, quod ei negabatur, cibum gravis
+                  ac plurimae carnis avidius invasit, quem cum conficere non posset, cruditate
+                  pressus exspiravit. <milestone unit="par" n="10"/> Vixit annos sexaginta quinque.
+               </p>
             </div>
             <div type="cap" n="21">
                <p>
-                  <milestone unit="par" n="1"/> Aurelius Antoninus <hi rend="expanded">Bassianus Caracalla</hi>, Severi filius, Lugduni genitus, imperavit solus annos sex. <milestone unit="par" n="2"/> Hic Bassianus ex avi materni nomine dictus est. At cum e Gallia vestem plurimam devexisset talaresque caracallas fecisset coegissetque plebem ad se salutandum indutam talibus introire, de nomine huiusce vestis Caracalla cognominatus est. <milestone unit="par" n="3"/> Hic fratrem suum Getam peremit; ob quam causam furore poenas dedit Dirarum insectatione, quae non immerito ultrices vocantur; a quo post furore convaluit. <milestone unit="par" n="4"/> Hic corpore Alexandri Macedonis conspecto Magnum atque Alexandrum se iussit appellari, assentantium fallaciis eo perductus, uti truci fronte et ad laevum humerum conversa cervice, quod in ore Alexandri notaverat, incedens fidem vultus simillimi persuaderet sibi. <milestone unit="par" n="5"/> Fuit impatientis libidinis, quippe qui novercam suam duxit uxorem.<milestone unit="par" n="6"/> Cum Carras iter faceret, apud Edessam secedens ad officia naturalia a milite, qui quasi ad custodiam sequebatur, interfectus est. <milestone unit="par" n="7"/> Vixit annos fere triginta. Corpus eius Romam relatum est. </p>
+                  <milestone unit="par" n="1"/> Aurelius Antoninus <hi rend="expanded">Bassianus
+                     Caracalla</hi>, Severi filius, Lugduni genitus, imperavit solus annos sex.
+                     <milestone unit="par" n="2"/> Hic Bassianus ex avi materni nomine dictus est.
+                  At cum e Gallia vestem plurimam devexisset talaresque caracallas fecisset
+                  coegissetque plebem ad se salutandum indutam talibus introire, de nomine huiusce
+                  vestis Caracalla cognominatus est. <milestone unit="par" n="3"/> Hic fratrem suum
+                  Getam peremit; ob quam causam furore poenas dedit Dirarum insectatione, quae non
+                  immerito ultrices vocantur; a quo post furore convaluit. <milestone unit="par"
+                     n="4"/> Hic corpore Alexandri Macedonis conspecto Magnum atque Alexandrum se
+                  iussit appellari, assentantium fallaciis eo perductus, uti truci fronte et ad
+                  laevum humerum conversa cervice, quod in ore Alexandri notaverat, incedens fidem
+                  vultus simillimi persuaderet sibi. <milestone unit="par" n="5"/> Fuit impatientis
+                  libidinis, quippe qui novercam suam duxit uxorem.<milestone unit="par" n="6"/> Cum
+                  Carras iter faceret, apud Edessam secedens ad officia naturalia a milite, qui
+                  quasi ad custodiam sequebatur, interfectus est. <milestone unit="par" n="7"/>
+                  Vixit annos fere triginta. Corpus eius Romam relatum est. </p>
             </div>
             <div type="cap" n="22">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Macrinus</hi> cum Diadumeno filio ab exercitu imperatores creati imperaverunt menses quattuordecim et ab eodem exercitu obtruncantur pro eo, quod Macrinus militarem luxuriam stipendiaque profusiora comprimeret. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Macrinus</hi> cum Diadumeno filio ab exercitu imperatores
+                  creati imperaverunt menses quattuordecim et ab eodem exercitu obtruncantur pro eo,
+                  quod Macrinus militarem luxuriam stipendiaque profusiora comprimeret. </p>
             </div>
             <div type="cap" n="23">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Aurelius Antoninus Varius</hi>, idem <hi rend="expanded">Heliogabalus</hi> dictus, Caracallae ex Soemea consobrina occulte stuprata filius, imperavit biennio et mensibus octo. <milestone unit="par" n="2"/> Huius matris Soemeae avus Bassianus nomine fuerat Solis sacerdos; quem Phoenices, unde erat, Heliogabalum nominabant, a quo iste Heliogabalus dictus est. <milestone unit="par" n="3"/> Is cum Romam ingenti militum et senatus exspectatione venisset, probris se omnibus contaminavit. Cupiditatem stupri, quam assequi naturae defectu nondum poterat, in se convertens muliebri nomine Bassianam se pro Bassiano iusserat appellari. Vestalem virginem quasi matrimonio iungens suo abscisisque genitalibus Matri se Magnae sacravit. <milestone unit="par" n="4"/> Hic Marcellum, qui post Alexander dictus est, consobrinum suum Caesarem fecit. <milestone unit="par" n="5"/> Ipse tumultu militari interfectus est. <milestone unit="par" n="6"/> Huius corpus per urbis vias more canini cadaveris a militibus tractum est militari cavillo appellantium indomitae rabidaeque libidinis catulam. Novissime cum angustum foramen cloacae corpus minime reciperet, usque ad Tiberim deductum, adiecto pondere, ne unquam emergeret, in fluvium proiectum est. <milestone unit="par" n="7"/> Vixit annos sedecim, atque ex re, quae acciderat, Tiberinus Tractitiusque appellatus est.</p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Aurelius Antoninus Varius</hi>, idem <hi rend="expanded"
+                     >Heliogabalus</hi> dictus, Caracallae ex Soemea consobrina occulte stuprata
+                  filius, imperavit biennio et mensibus octo. <milestone unit="par" n="2"/> Huius
+                  matris Soemeae avus Bassianus nomine fuerat Solis sacerdos; quem Phoenices, unde
+                  erat, Heliogabalum nominabant, a quo iste Heliogabalus dictus est. <milestone
+                     unit="par" n="3"/> Is cum Romam ingenti militum et senatus exspectatione
+                  venisset, probris se omnibus contaminavit. Cupiditatem stupri, quam assequi
+                  naturae defectu nondum poterat, in se convertens muliebri nomine Bassianam se pro
+                  Bassiano iusserat appellari. Vestalem virginem quasi matrimonio iungens suo
+                  abscisisque genitalibus Matri se Magnae sacravit. <milestone unit="par" n="4"/>
+                  Hic Marcellum, qui post Alexander dictus est, consobrinum suum Caesarem fecit.
+                     <milestone unit="par" n="5"/> Ipse tumultu militari interfectus est. <milestone
+                     unit="par" n="6"/> Huius corpus per urbis vias more canini cadaveris a
+                  militibus tractum est militari cavillo appellantium indomitae rabidaeque libidinis
+                  catulam. Novissime cum angustum foramen cloacae corpus minime reciperet, usque ad
+                  Tiberim deductum, adiecto pondere, ne unquam emergeret, in fluvium proiectum est.
+                     <milestone unit="par" n="7"/> Vixit annos sedecim, atque ex re, quae acciderat,
+                  Tiberinus Tractitiusque appellatus est.</p>
             </div>
             <div type="cap" n="24">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Severus Alexander</hi> imperavit annos tredecim. Hic bonus reipublicae, fuit aerumnosus <supplied>sibi</supplied>. <milestone unit="par" n="2"/> Sub hoc imperante Taurinus Augustus effectus ob timorem ipse se Euphrate fluvio abiecit. <milestone unit="par" n="3"/> Tunc etiam Maximinus regnum arripuit pluribus de exercitu corruptis. <milestone unit="par" n="4"/> Alexander vero cum deseri se ab stipatoribus vidisset, matrem sibi causam fuisse mortis exclamans accurrenti percussori obvoluto capite cervices valide compressas praebuit anno vitae vicesimo sexto. <milestone unit="par" n="5"/> Huius mater Mammaea eo filium coegerat, ut illa ipsa permodica, si mensae prandioque superessent, quamvis <supplied>semesa alteri</supplied> convivio reponerentur.</p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Severus Alexander</hi> imperavit annos tredecim. Hic bonus
+                  reipublicae, fuit aerumnosus <supplied>sibi</supplied>. <milestone unit="par"
+                     n="2"/> Sub hoc imperante Taurinus Augustus effectus ob timorem ipse se
+                  Euphrate fluvio abiecit. <milestone unit="par" n="3"/> Tunc etiam Maximinus regnum
+                  arripuit pluribus de exercitu corruptis. <milestone unit="par" n="4"/> Alexander
+                  vero cum deseri se ab stipatoribus vidisset, matrem sibi causam fuisse mortis
+                  exclamans accurrenti percussori obvoluto capite cervices valide compressas
+                  praebuit anno vitae vicesimo sexto. <milestone unit="par" n="5"/> Huius mater
+                  Mammaea eo filium coegerat, ut illa ipsa permodica, si mensae prandioque
+                  superessent, quamvis <supplied>semesa alteri</supplied> convivio reponerentur.</p>
             </div>
             <div type="cap" n="25">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Iulius Maximinus Thrax</hi>, ex militaribus, imperavit annos tres. <milestone unit="par" n="2"/> Is dum persequitur pecuniosos, insontes pariter noxiosque, apud Aquileiam seditione militum discerptus est una cum filio, conclamantibus cunctis militari ioco ex pessimo genere nec catulum habendum. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Iulius Maximinus Thrax</hi>, ex militaribus, imperavit annos
+                  tres. <milestone unit="par" n="2"/> Is dum persequitur pecuniosos, insontes
+                  pariter noxiosque, apud Aquileiam seditione militum discerptus est una cum filio,
+                  conclamantibus cunctis militari ioco ex pessimo genere nec catulum habendum. </p>
             </div>
             <div type="cap" n="26">
                <p>
-                  <milestone unit="par" n="1"/> Huius imperio duo <hi rend="expanded">Gordiani</hi>, pater et filius, principatum arripientes, unus post unum interiere. <milestone unit="par" n="2"/> Pari etiam tenore Pupienus et Balbinus regnum invadentes perempti sunt.</p>
+                  <milestone unit="par" n="1"/> Huius imperio duo <hi rend="expanded">Gordiani</hi>,
+                  pater et filius, principatum arripientes, unus post unum interiere. <milestone
+                     unit="par" n="2"/> Pari etiam tenore Pupienus et Balbinus regnum invadentes
+                  perempti sunt.</p>
             </div>
             <div type="cap" n="27">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Gordianus</hi>, nepos Gordiani ex filia, ortus Romae clarissimo patre, imperavit annos sex. <milestone unit="par" n="2"/> Apud Ctesiphontem a Philippo praefecto praetorio accensis in seditionem militibus occiditur anno vitae undevicesimo. <milestone unit="par" n="3"/> Corpus eius prope fines Romani Persicique imperii positum nomen loco dedit Sepulcrum Gordiani. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Gordianus</hi>, nepos Gordiani ex filia, ortus Romae
+                  clarissimo patre, imperavit annos sex. <milestone unit="par" n="2"/> Apud
+                  Ctesiphontem a Philippo praefecto praetorio accensis in seditionem militibus
+                  occiditur anno vitae undevicesimo. <milestone unit="par" n="3"/> Corpus eius prope
+                  fines Romani Persicique imperii positum nomen loco dedit Sepulcrum Gordiani. </p>
             </div>
             <div type="cap" n="28">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Marcus Iulius Philippus</hi> imperavit annos quinque. <milestone unit="par" n="2"/> Veronae ab exercitu interfectus est medio capite supra ordines dentium praeciso. <milestone unit="par" n="3"/> Filius autem eius Gaius Iulius Saturninus, quem potentiae sociaverat, Romae occiditur agens vitae annum duodecimum, adeo severi et tristis animi, ut iam tum a quinquennii aetate nullo prorsus cuiusquam commento ad ridendum solvi potuerit patremque ludis saecularibus petulantius cachinnantem, quamquam adhuc tener, vultu notaverit aversato. <milestone unit="par" n="4"/> Is Philippus humillimo ortus loco fuit, patre nobilissimo latronum ductore. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Marcus Iulius Philippus</hi> imperavit annos quinque.
+                     <milestone unit="par" n="2"/> Veronae ab exercitu interfectus est medio capite
+                  supra ordines dentium praeciso. <milestone unit="par" n="3"/> Filius autem eius
+                  Gaius Iulius Saturninus, quem potentiae sociaverat, Romae occiditur agens vitae
+                  annum duodecimum, adeo severi et tristis animi, ut iam tum a quinquennii aetate
+                  nullo prorsus cuiusquam commento ad ridendum solvi potuerit patremque ludis
+                  saecularibus petulantius cachinnantem, quamquam adhuc tener, vultu notaverit
+                  aversato. <milestone unit="par" n="4"/> Is Philippus humillimo ortus loco fuit,
+                  patre nobilissimo latronum ductore. </p>
             </div>
             <div type="cap" n="29">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Decius</hi> e Pannonia inferiore, Bubaliae natus, imperavit menses triginta. <milestone unit="par" n="2"/> Hic Decium filium suum Caesarem fecit; vir artibus cunctis virtutibusque instructus, placidus et communis domi, in armis promptissimus. <milestone unit="par" n="3"/> In solo barbarico inter confusas turbas gurgite paludis submersus est, ita ut nec cadaver eius potuerit inveniri. <milestone unit="par" n="4"/> Filius vero eius bello exstinctus est. Vixit annos quinquaginta. <milestone unit="par" n="5"/> Huius temporibus Valens Lucinianus imperator effectus est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Decius</hi> e Pannonia inferiore, Bubaliae natus, imperavit
+                  menses triginta. <milestone unit="par" n="2"/> Hic Decium filium suum Caesarem
+                  fecit; vir artibus cunctis virtutibusque instructus, placidus et communis domi, in
+                  armis promptissimus. <milestone unit="par" n="3"/> In solo barbarico inter
+                  confusas turbas gurgite paludis submersus est, ita ut nec cadaver eius potuerit
+                  inveniri. <milestone unit="par" n="4"/> Filius vero eius bello exstinctus est.
+                  Vixit annos quinquaginta. <milestone unit="par" n="5"/> Huius temporibus Valens
+                  Lucinianus imperator effectus est. </p>
             </div>
             <div type="cap" n="30">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Vibius Gallus</hi> cum Volusiano filio imperaverunt annos duos. <milestone unit="par" n="2"/> Horum temporibus Hostilianus Perpenna a senatu imperator creatus, nec multo post pestilentia consumptus est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Vibius Gallus</hi> cum Volusiano filio imperaverunt annos
+                  duos. <milestone unit="par" n="2"/> Horum temporibus Hostilianus Perpenna a senatu
+                  imperator creatus, nec multo post pestilentia consumptus est. </p>
             </div>
             <div type="cap" n="31">
                <p>
-                  <milestone unit="par" n="1"/> Sub his etiam <hi rend="expanded">Aemilianus</hi> in Moesia imperator effectus est; contra quem ambo profecti apud Interamnam ab exercitu suo caeduntur, anno aetatis pater septimo circiter et quadragesimo, creati in insula Meninge, quae nunc Girba dicitur; <milestone unit="par" n="2"/> Aemilianus vero mense quarto dominatus apud Spoletium, sive pontem, quem ab eius caede Sanguinarium accepisse nomen ferunt, inter Ocricolum Narniamque, Spoletium et urbem Romam regione media positum. Fuit autem Maurus genere, pugnax nec tamen praeceps. <milestone unit="par" n="3"/> Vixit annis tribus minus quinquaginta. </p>
+                  <milestone unit="par" n="1"/> Sub his etiam <hi rend="expanded">Aemilianus</hi> in
+                  Moesia imperator effectus est; contra quem ambo profecti apud Interamnam ab
+                  exercitu suo caeduntur, anno aetatis pater septimo circiter et quadragesimo,
+                  creati in insula Meninge, quae nunc Girba dicitur; <milestone unit="par" n="2"/>
+                  Aemilianus vero mense quarto dominatus apud Spoletium, sive pontem, quem ab eius
+                  caede Sanguinarium accepisse nomen ferunt, inter Ocricolum Narniamque, Spoletium
+                  et urbem Romam regione media positum. Fuit autem Maurus genere, pugnax nec tamen
+                  praeceps. <milestone unit="par" n="3"/> Vixit annis tribus minus quinquaginta.
+               </p>
             </div>
             <div type="cap" n="32">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Licinius Valerianus</hi>, cognomento Colobius, imperavit annos quindecim, parentibus ortus splendissimis, stolidus tamen et multum iners, neque ad usum aliquem publici officii consilio seu gestis accommodatus. <milestone unit="par" n="2"/> Hic filium suum Gallienum Augustum fecit Gallienique filium, Cornelium Valerianum, Caesarem. <milestone unit="par" n="3"/> His imperantibus Regillianus in Moesia, Cassius Latienus Postumus in Gallia Gallieni filio interfecto imperatores effecti sunt. <milestone unit="par" n="4"/> Pari modo Aelianus apud Mogontiacum, in Aegypto Aemilianus, apud Macedonas Valens, Mediolani Aureolus dominatum invasere. <milestone unit="par" n="5"/> Valerianus vero in Mesopotamia bellum gerens, a Sapore Persarum rege superatus, mox etiam captus, apud Parthos ignobili servitute consenuit. <milestone unit="par" n="6"/> Nam quamdiu vixit, rex eiusdem provinciae incurvato eo pedem cervicibus eius imponens equum conscendere solitus erat. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Licinius Valerianus</hi>, cognomento Colobius, imperavit annos
+                  quindecim, parentibus ortus splendissimis, stolidus tamen et multum iners, neque
+                  ad usum aliquem publici officii consilio seu gestis accommodatus. <milestone
+                     unit="par" n="2"/> Hic filium suum Gallienum Augustum fecit Gallienique filium,
+                  Cornelium Valerianum, Caesarem. <milestone unit="par" n="3"/> His imperantibus
+                  Regillianus in Moesia, Cassius Latienus Postumus in Gallia Gallieni filio
+                  interfecto imperatores effecti sunt. <milestone unit="par" n="4"/> Pari modo
+                  Aelianus apud Mogontiacum, in Aegypto Aemilianus, apud Macedonas Valens, Mediolani
+                  Aureolus dominatum invasere. <milestone unit="par" n="5"/> Valerianus vero in
+                  Mesopotamia bellum gerens, a Sapore Persarum rege superatus, mox etiam captus,
+                  apud Parthos ignobili servitute consenuit. <milestone unit="par" n="6"/> Nam
+                  quamdiu vixit, rex eiusdem provinciae incurvato eo pedem cervicibus eius imponens
+                  equum conscendere solitus erat. </p>
             </div>
             <div type="cap" n="33">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Gallienus</hi> quidem in loco Cornelii filii sui Salonianum, alterum filium, subrogavit, amori diverso pellicum deditus Saloninae coniugis et concubinae, quam per pactionem concessa parte superioris Pannoniae a patre, Marcomannorum rege, matrimonii specie susceperat Pipam nomine. <milestone unit="par" n="2"/> Novissime adversus Aureolum profectus est. Quem cum apud pontem, qui ex eius nomine Aureolus appellatur, obtentum detrusumque Mediolanum obsedit, eiusdem Aureoli commento a suis interiit. <milestone unit="par" n="3"/> Regnavit annos quindecim, septem cum patre, octo solus. Vixit annos quinquaginta. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Gallienus</hi> quidem in loco Cornelii filii sui Salonianum,
+                  alterum filium, subrogavit, amori diverso pellicum deditus Saloninae coniugis et
+                  concubinae, quam per pactionem concessa parte superioris Pannoniae a patre,
+                  Marcomannorum rege, matrimonii specie susceperat Pipam nomine. <milestone
+                     unit="par" n="2"/> Novissime adversus Aureolum profectus est. Quem cum apud
+                  pontem, qui ex eius nomine Aureolus appellatur, obtentum detrusumque Mediolanum
+                  obsedit, eiusdem Aureoli commento a suis interiit. <milestone unit="par" n="3"/>
+                  Regnavit annos quindecim, septem cum patre, octo solus. Vixit annos quinquaginta.
+               </p>
             </div>
             <div type="cap" n="34">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Claudius</hi> imperavit anno uno mensibus novem. <milestone unit="par" n="2"/> Hunc plerique putant Gordiano satum, dum adulescens a muliere matura institueretur ad uxorem. Hic Claudius Gallieni morientis sententia imperator designatur, ad quem Ticini positum per Gallonium Basilium indumenta regia direxerat, exstinctoque a suis Aureolo, receptis legionibus adversum gentem Alamannorum haud procul a lacu Benaco dimicans tantam multitudinem fudit, ut aegre pars dimidia superfuerit. <milestone unit="par" n="3"/> His diebus Victorinus regnum cepit. Claudius vero cum ex fatalibus libris, quos inspici praeceperat, cognovisset sententiae in senatu dicendae primi morte remedium desiderari, Pomponio Basso, qui tunc erat, se offerente ipse vitam suam haud passus responsa frustrari dono reipublicae dedit, praefatus neminem tanti ordinis primas habere, quam imperatorem. <milestone unit="par" n="4"/> Ea res sicut erat cunctis grata, non divi vocabulum modo, sed ex auro statuam prope ipsum Iovis simulacrum atque in curia imaginem auream proceres sacravere. <milestone unit="par" n="5"/> Huic successit frater eius Quintillus. Is paucis diebus imperium tenens interemptus est. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Claudius</hi> imperavit anno uno mensibus novem. <milestone
+                     unit="par" n="2"/> Hunc plerique putant Gordiano satum, dum adulescens a
+                  muliere matura institueretur ad uxorem. Hic Claudius Gallieni morientis sententia
+                  imperator designatur, ad quem Ticini positum per Gallonium Basilium indumenta
+                  regia direxerat, exstinctoque a suis Aureolo, receptis legionibus adversum gentem
+                  Alamannorum haud procul a lacu Benaco dimicans tantam multitudinem fudit, ut aegre
+                  pars dimidia superfuerit. <milestone unit="par" n="3"/> His diebus Victorinus
+                  regnum cepit. Claudius vero cum ex fatalibus libris, quos inspici praeceperat,
+                  cognovisset sententiae in senatu dicendae primi morte remedium desiderari,
+                  Pomponio Basso, qui tunc erat, se offerente ipse vitam suam haud passus responsa
+                  frustrari dono reipublicae dedit, praefatus neminem tanti ordinis primas habere,
+                  quam imperatorem. <milestone unit="par" n="4"/> Ea res sicut erat cunctis grata,
+                  non divi vocabulum modo, sed ex auro statuam prope ipsum Iovis simulacrum atque in
+                  curia imaginem auream proceres sacravere. <milestone unit="par" n="5"/> Huic
+                  successit frater eius Quintillus. Is paucis diebus imperium tenens interemptus
+                  est. </p>
             </div>
             <div type="cap" n="35">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Aurelianus</hi>, genitus patre mediocri et, ut quidam ferunt, Aurelii clarissimi senatoris colono inter Daciam et Macedoniam, imperavit annis quinque, mensibus sex. <milestone unit="par" n="2"/> Iste haud dissimilis fuit magno Alexandro seu Caesari dictatori. Nam Romanum orbem triennio ab invasoribus receptavit, cum Alexander annis tredecim per victorias ingentes ad Indiam pervenerit et Gaius Caesar decennio subegerit Gallos, adversum cives quadriennio congressus. Iste in Italia tribus proeliis victor fuit, apud Placentiam, iuxta amnem Metaurum ac fanum Fortunae, postremo Ticinensibus campis. <milestone unit="par" n="3"/> Huius tempore apud Dalmatas Septimius imperator effectus mox a suis obtruncatur. <milestone unit="par" n="4"/> Hoc tempore in urbe Roma monetarii rebellarunt, quos Aurelianus victos ultima crudelitate compescuit. <milestone unit="par" n="5"/> Iste primus apud Romanos diadema capiti innexuit, gemmisque et aurata omni veste, quod adhuc fere incognitum Romanis moribus visebatur, usus est. <milestone unit="par" n="6"/> Hic muris validioribus et laxioribus urbem saepsit. Porcinae carnis usum populo instituit. <milestone unit="par" n="7"/> Hic Tetricum, qui imperator ab exercitu in Galliis effectus fuerat, correctorem Lucaniae provexit, aspergens hominem eleganti ioco sublimius habendum regere aliquam Italiae partem quam trans Alpes regnare. <milestone unit="par" n="8"/> Novissime fraude servi sui, qui ad quosdam militares viros, amicos ipsius, nomina pertulit annotata, falso manum eius imitatus, tamquam Aurelianus ipsos pararet occidere, ab iisdem interfectus est in itineris medio, quod inter Constantinopolim et Heracleam est. <milestone unit="par" n="9"/> Fuit saevus et sanguinarius et trux omni tempore, etiam filii sororis interfector. <milestone unit="par" n="10"/> Hoc tempore septem mensibus interregni species evenit. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Aurelianus</hi>, genitus patre mediocri et, ut quidam ferunt,
+                  Aurelii clarissimi senatoris colono inter Daciam et Macedoniam, imperavit annis
+                  quinque, mensibus sex. <milestone unit="par" n="2"/> Iste haud dissimilis fuit
+                  magno Alexandro seu Caesari dictatori. Nam Romanum orbem triennio ab invasoribus
+                  receptavit, cum Alexander annis tredecim per victorias ingentes ad Indiam
+                  pervenerit et Gaius Caesar decennio subegerit Gallos, adversum cives quadriennio
+                  congressus. Iste in Italia tribus proeliis victor fuit, apud Placentiam, iuxta
+                  amnem Metaurum ac fanum Fortunae, postremo Ticinensibus campis. <milestone
+                     unit="par" n="3"/> Huius tempore apud Dalmatas Septimius imperator effectus mox
+                  a suis obtruncatur. <milestone unit="par" n="4"/> Hoc tempore in urbe Roma
+                  monetarii rebellarunt, quos Aurelianus victos ultima crudelitate compescuit.
+                     <milestone unit="par" n="5"/> Iste primus apud Romanos diadema capiti innexuit,
+                  gemmisque et aurata omni veste, quod adhuc fere incognitum Romanis moribus
+                  visebatur, usus est. <milestone unit="par" n="6"/> Hic muris validioribus et
+                  laxioribus urbem saepsit. Porcinae carnis usum populo instituit. <milestone
+                     unit="par" n="7"/> Hic Tetricum, qui imperator ab exercitu in Galliis effectus
+                  fuerat, correctorem Lucaniae provexit, aspergens hominem eleganti ioco sublimius
+                  habendum regere aliquam Italiae partem quam trans Alpes regnare. <milestone
+                     unit="par" n="8"/> Novissime fraude servi sui, qui ad quosdam militares viros,
+                  amicos ipsius, nomina pertulit annotata, falso manum eius imitatus, tamquam
+                  Aurelianus ipsos pararet occidere, ab iisdem interfectus est in itineris medio,
+                  quod inter Constantinopolim et Heracleam est. <milestone unit="par" n="9"/> Fuit
+                  saevus et sanguinarius et trux omni tempore, etiam filii sororis interfector.
+                     <milestone unit="par" n="10"/> Hoc tempore septem mensibus interregni species
+                  evenit. </p>
             </div>
             <div type="cap" n="36">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Tacitus</hi> post hunc suscepit imperium, vir egregie moratus; qui ducentesimo imperii die apud Tarsum febri moritur. <milestone unit="par" n="2"/> Huic successit Florianus. Sed cum magna pars exercitus Equitium Probum, militiae peritum, legisset, Florianus dierum sexaginta quasi per ludum imperio usus incisis a semetipso venis effuso sanguine consumptus est.</p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Tacitus</hi> post hunc suscepit imperium, vir egregie moratus;
+                  qui ducentesimo imperii die apud Tarsum febri moritur. <milestone unit="par" n="2"
+                  /> Huic successit Florianus. Sed cum magna pars exercitus Equitium Probum,
+                  militiae peritum, legisset, Florianus dierum sexaginta quasi per ludum imperio
+                  usus incisis a semetipso venis effuso sanguine consumptus est.</p>
             </div>
             <div type="cap" n="37">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Probus</hi>, genitus patre agresti hortorum studioso Dalmatio nomine, imperavit annos sex. <milestone unit="par" n="2"/> Iste Saturninum in Oriente, Proculum et Bonosum Agrippinae imperatores effectos oppressit. <milestone unit="par" n="3"/> Vineas Gallos et Pannonios habere permisit. Opere militari Almam montem apud Sirmium et Aureum apud Moesiam superiorem vineis conseruit. <milestone unit="par" n="4"/> Hic Sirmii in turri ferrata occiditur. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Probus</hi>, genitus patre agresti hortorum studioso Dalmatio
+                  nomine, imperavit annos sex. <milestone unit="par" n="2"/> Iste Saturninum in
+                  Oriente, Proculum et Bonosum Agrippinae imperatores effectos oppressit. <milestone
+                     unit="par" n="3"/> Vineas Gallos et Pannonios habere permisit. Opere militari
+                  Almam montem apud Sirmium et Aureum apud Moesiam superiorem vineis conseruit.
+                     <milestone unit="par" n="4"/> Hic Sirmii in turri ferrata occiditur. </p>
             </div>
             <div type="cap" n="38">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Carus</hi>, Narbonae natus, imperavit annos duos. <milestone unit="par" n="2"/> Iste confestim Carinum et Numerianum Caesares fecit. <milestone unit="par" n="3"/> Hic apud Ctesiphonta ictu fulminis interiit. <milestone unit="par" n="4"/> Numerianus quoque, filius eius, cum oculorum dolore correptus in lecticula veheretur, impulsore Apro, qui socer eius erat, per insidias occisus est. <milestone unit="par" n="5"/> Cum dolo occultaretur ipsius mors, quousque Aper invadere posset imperium, foetore cadaveris scelus est proditum. <milestone unit="par" n="6"/> Hinc Sabinus Iulianus invadens imperium a Carino in Campis Veronensibus occiditur. <milestone unit="par" n="7"/> Hic Carinus omnibus se sceleribus inquinavit. Plurimos innoxios fictis criminibus occidit. Matrimonia nobilium corrupit. Condiscipulis quoque, qui eum in auditorio verbi fatigatione taxaverunt, perniciosus fuit. <milestone unit="par" n="8"/> Ad extremum trucidatur eius praecipue tribuni dextera, cuius dicebatur coniugem polluisse. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Carus</hi>, Narbonae natus, imperavit annos duos. <milestone
+                     unit="par" n="2"/> Iste confestim Carinum et Numerianum Caesares fecit.
+                     <milestone unit="par" n="3"/> Hic apud Ctesiphonta ictu fulminis interiit.
+                     <milestone unit="par" n="4"/> Numerianus quoque, filius eius, cum oculorum
+                  dolore correptus in lecticula veheretur, impulsore Apro, qui socer eius erat, per
+                  insidias occisus est. <milestone unit="par" n="5"/> Cum dolo occultaretur ipsius
+                  mors, quousque Aper invadere posset imperium, foetore cadaveris scelus est
+                  proditum. <milestone unit="par" n="6"/> Hinc Sabinus Iulianus invadens imperium a
+                  Carino in Campis Veronensibus occiditur. <milestone unit="par" n="7"/> Hic Carinus
+                  omnibus se sceleribus inquinavit. Plurimos innoxios fictis criminibus occidit.
+                  Matrimonia nobilium corrupit. Condiscipulis quoque, qui eum in auditorio verbi
+                  fatigatione taxaverunt, perniciosus fuit. <milestone unit="par" n="8"/> Ad
+                  extremum trucidatur eius praecipue tribuni dextera, cuius dicebatur coniugem
+                  polluisse. </p>
             </div>
             <div type="cap" n="39">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Diocletianus</hi> Dalmata, Anulini senatoris libertinus, matre pariter atque oppido nomine Dioclea, quorum vocabulis, donec imperium sumeret, Diocles appellatus, ubi orbis Romani potentiam cepit, Graium nomen in Romanum morem convertit, imperavit annis viginti quinque. <milestone unit="par" n="2"/> Is Maximianum Augustum effecit; Constantium et Galerium Maximianum, cognomento Armentarium, Caesares creavit, tradens Constantio Theodoram, Herculii Maximiani privignam, abiecta uxore priori. <milestone unit="par" n="3"/> Hoc tempore Charausio in Galliis, Achilleus apud Aegyptum, Iulianus in Italia imperatores effecti diverso exitu periere. <milestone unit="par" n="4"/> E quibus Iulianus acto per costas pugione in ignem se abiecit. </p>
-                <p>
-                  <milestone unit="par" n="5"/> Diocletianus vero apud Nicomediam sponte imperiales fasces relinquens in propriis agris consenuit. <milestone unit="par" n="6"/> Qui dum ab Herculio atque Galerio ad recipiendum imperium rogaretur, tamquam pestem aliquam detestans in hunc modum respondit: 'Utinam Salonae possetis visere olera nostris manibus instituta, profecto numquam istud temptandum iudicaretis'. <milestone unit="par" n="7"/> Vixit annos sexaginta octo, ex quis communi habitu prope novem egit. Morte consumptus est, ut satis patuit, per formidinem voluntaria. Quippe cum a Constantino atque Licinio vocatus ad festa nuptiarum per senectam, quo minus interesse valeret, excusavisset, rescriptis minacibus acceptis, quibus increpabatur Maxentio favisse ac Maximino favere, suspectans necem dedecorosam venenum dicitur hausisse. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Diocletianus</hi> Dalmata, Anulini senatoris libertinus, matre
+                  pariter atque oppido nomine Dioclea, quorum vocabulis, donec imperium sumeret,
+                  Diocles appellatus, ubi orbis Romani potentiam cepit, Graium nomen in Romanum
+                  morem convertit, imperavit annis viginti quinque. <milestone unit="par" n="2"/> Is
+                  Maximianum Augustum effecit; Constantium et Galerium Maximianum, cognomento
+                  Armentarium, Caesares creavit, tradens Constantio Theodoram, Herculii Maximiani
+                  privignam, abiecta uxore priori. <milestone unit="par" n="3"/> Hoc tempore
+                  Charausio in Galliis, Achilleus apud Aegyptum, Iulianus in Italia imperatores
+                  effecti diverso exitu periere. <milestone unit="par" n="4"/> E quibus Iulianus
+                  acto per costas pugione in ignem se abiecit. </p>
+               <p>
+                  <milestone unit="par" n="5"/> Diocletianus vero apud Nicomediam sponte imperiales
+                  fasces relinquens in propriis agris consenuit. <milestone unit="par" n="6"/> Qui
+                  dum ab Herculio atque Galerio ad recipiendum imperium rogaretur, tamquam pestem
+                  aliquam detestans in hunc modum respondit: 'Utinam Salonae possetis visere olera
+                  nostris manibus instituta, profecto numquam istud temptandum iudicaretis'.
+                     <milestone unit="par" n="7"/> Vixit annos sexaginta octo, ex quis communi
+                  habitu prope novem egit. Morte consumptus est, ut satis patuit, per formidinem
+                  voluntaria. Quippe cum a Constantino atque Licinio vocatus ad festa nuptiarum per
+                  senectam, quo minus interesse valeret, excusavisset, rescriptis minacibus
+                  acceptis, quibus increpabatur Maxentio favisse ac Maximino favere, suspectans
+                  necem dedecorosam venenum dicitur hausisse. </p>
             </div>
             <div type="cap" n="40">
                <p>
-                  <milestone unit="par" n="1"/> His diebus <hi rend="expanded">Constantius</hi>, Constantini pater, atque <hi rend="expanded">Armentarius</hi>, Caesares, Augusti appellantur, creatis Caesaribus Severo per Italiam, Maximino, Galerii sororis filio, per Orientem; eodemque tempore Constantinus Caesar efficitur. <milestone unit="par" n="2"/> Maxentius imperator in villa sex milibus ab urbe discreta, itinere Lavicano, dehinc Licinius Augustus efficitur, parique modo Alexander apud Carthaginem imperator fit; similique modo Valens imperator creatur, quorum exitus iste fuit:</p>
-                <p>
-                  <milestone unit="par" n="3"/> Severus Caesar ab Herculio Maximiano Romae ad Tres Tabernas exstinguitur, funusque eius Gallieni sepulcro infertur, quod ex urbe abest per Appiam milibus novem. <milestone unit="par" n="4"/> Galerius Maximianus consumptis genitalibus defecit. <milestone unit="par" n="5"/> Maximianus Herculius a Constantino apud Massiliam obsessus, deinde captus, poenas dedit mortis genere postremo, fractis laqueo cervicibus. <milestone unit="par" n="6"/> Alexander a Constantini exercitu iugulatur. <milestone unit="par" n="7"/> Maxentius, dum adversus Constantinum congreditur, paulo superius a ponte Mulvio in pontem navigiis compositum ab latere ingredi festinans lapsu equi in profundum demersus est; voratumque limo pondere thoracis corpus vix repertum. <milestone unit="par" n="8"/> Maximinus apud Tarsum morte simplici periit. <milestone unit="par" n="9"/> Valens a Licinio morte multatur.</p>
-                <p>
-                  <milestone unit="par" n="10"/> Fuerunt autem morum huiusmodi: Aurelius Maximianus, cognomento Herculius, ferus natura, ardens libidine, consiliis stolidus, ortu agresti Pannonioque. Nam etiam nunc haud longe Sirmio eminet locus palatio ibidem constructo, ubi parentes eius exercebant opera mercenaria. <milestone unit="par" n="11"/> Aetate interiit sexagenarius, annorum viginti imperator. <milestone unit="par" n="12"/> Genuit ex Eutropia, Syra muliere, Maxentium et Faustam, coniugem Constantini; cuius patri Constantio tradiderat Theodoram privignam. <milestone unit="par" n="13"/> Sed Maxentium suppositum ferunt arte muliebri tenere mariti animum laborantis auspicio gratissimi partus coepti a puero. <milestone unit="par" n="14"/> Is Maxentius carus nulli umquam fuit, ne patri aut socero quidem Galerio. <milestone unit="par" n="15"/> Galerius autem fuit (licet inculta agrestique iustitia) satis laudabilis, pulcher corpore, eximius et felix bellator, ortus parentibus agrariis, pastor armentorum, unde ei cognomen Armentarius fuit. <milestone unit="par" n="16"/> Ortus Dacia Ripensi ibique sepultus est; quem locum Romulianum ex vocabulo Romulae matris appellarat. <milestone unit="par" n="17"/> Is insolenter affirmare ausus est matrem more Olympiadis, Alexandri Magni creatricis, compressam dracone semet concepisse. <milestone unit="par" n="18"/> Galerius Maximinus, sorore Armentarii progenitus veroque nomine ante imperium Daca dictus, Caesar quadriennio, dehinc per Orientem Augustus triennio fuit, ortu quidem atque instituto pastorali, verum sapientissimi cuiusque ac litteratorum cultor, ingenio quieto, vini avidior. <milestone unit="par" n="19"/> Quo ebrius quaedam corrupta mente aspera iubebat; quod cum pigeret factum, differri, quae praecepisset, in tempus sobrium ac matutinum statuit. <milestone unit="par" n="20"/> Alexander fuit Phryx origine, ingenio timidus, inferior adversus laborem vitio senectae aetatis. </p>
+                  <milestone unit="par" n="1"/> His diebus <hi rend="expanded">Constantius</hi>,
+                  Constantini pater, atque <hi rend="expanded">Armentarius</hi>, Caesares, Augusti
+                  appellantur, creatis Caesaribus Severo per Italiam, Maximino, Galerii sororis
+                  filio, per Orientem; eodemque tempore Constantinus Caesar efficitur. <milestone
+                     unit="par" n="2"/> Maxentius imperator in villa sex milibus ab urbe discreta,
+                  itinere Lavicano, dehinc Licinius Augustus efficitur, parique modo Alexander apud
+                  Carthaginem imperator fit; similique modo Valens imperator creatur, quorum exitus
+                  iste fuit:</p>
+               <p>
+                  <milestone unit="par" n="3"/> Severus Caesar ab Herculio Maximiano Romae ad Tres
+                  Tabernas exstinguitur, funusque eius Gallieni sepulcro infertur, quod ex urbe
+                  abest per Appiam milibus novem. <milestone unit="par" n="4"/> Galerius Maximianus
+                  consumptis genitalibus defecit. <milestone unit="par" n="5"/> Maximianus Herculius
+                  a Constantino apud Massiliam obsessus, deinde captus, poenas dedit mortis genere
+                  postremo, fractis laqueo cervicibus. <milestone unit="par" n="6"/> Alexander a
+                  Constantini exercitu iugulatur. <milestone unit="par" n="7"/> Maxentius, dum
+                  adversus Constantinum congreditur, paulo superius a ponte Mulvio in pontem
+                  navigiis compositum ab latere ingredi festinans lapsu equi in profundum demersus
+                  est; voratumque limo pondere thoracis corpus vix repertum. <milestone unit="par"
+                     n="8"/> Maximinus apud Tarsum morte simplici periit. <milestone unit="par"
+                     n="9"/> Valens a Licinio morte multatur.</p>
+               <p>
+                  <milestone unit="par" n="10"/> Fuerunt autem morum huiusmodi: Aurelius Maximianus,
+                  cognomento Herculius, ferus natura, ardens libidine, consiliis stolidus, ortu
+                  agresti Pannonioque. Nam etiam nunc haud longe Sirmio eminet locus palatio ibidem
+                  constructo, ubi parentes eius exercebant opera mercenaria. <milestone unit="par"
+                     n="11"/> Aetate interiit sexagenarius, annorum viginti imperator. <milestone
+                     unit="par" n="12"/> Genuit ex Eutropia, Syra muliere, Maxentium et Faustam,
+                  coniugem Constantini; cuius patri Constantio tradiderat Theodoram privignam.
+                     <milestone unit="par" n="13"/> Sed Maxentium suppositum ferunt arte muliebri
+                  tenere mariti animum laborantis auspicio gratissimi partus coepti a puero.
+                     <milestone unit="par" n="14"/> Is Maxentius carus nulli umquam fuit, ne patri
+                  aut socero quidem Galerio. <milestone unit="par" n="15"/> Galerius autem fuit
+                  (licet inculta agrestique iustitia) satis laudabilis, pulcher corpore, eximius et
+                  felix bellator, ortus parentibus agrariis, pastor armentorum, unde ei cognomen
+                  Armentarius fuit. <milestone unit="par" n="16"/> Ortus Dacia Ripensi ibique
+                  sepultus est; quem locum Romulianum ex vocabulo Romulae matris appellarat.
+                     <milestone unit="par" n="17"/> Is insolenter affirmare ausus est matrem more
+                  Olympiadis, Alexandri Magni creatricis, compressam dracone semet concepisse.
+                     <milestone unit="par" n="18"/> Galerius Maximinus, sorore Armentarii progenitus
+                  veroque nomine ante imperium Daca dictus, Caesar quadriennio, dehinc per Orientem
+                  Augustus triennio fuit, ortu quidem atque instituto pastorali, verum sapientissimi
+                  cuiusque ac litteratorum cultor, ingenio quieto, vini avidior. <milestone
+                     unit="par" n="19"/> Quo ebrius quaedam corrupta mente aspera iubebat; quod cum
+                  pigeret factum, differri, quae praecepisset, in tempus sobrium ac matutinum
+                  statuit. <milestone unit="par" n="20"/> Alexander fuit Phryx origine, ingenio
+                  timidus, inferior adversus laborem vitio senectae aetatis. </p>
             </div>
             <div type="cap" n="41">
                <p>
-                  <milestone unit="par" n="1"/> His omnibus absumptis imperii iura penes <hi rend="expanded">Constantinum</hi> et <hi rend="expanded">Licinium</hi> devenere. <milestone unit="par" n="2"/> Constantinus, Constantii imperatoris et Helenae filius, imperavit annos triginta. Hic dum iuvenculus a Galerio in urbe Roma religionis specie obses teneretur, fugam arripiens atque ad frustrandos insequentes publica iumenta, quaqua iter egerat, interfecit et ad patrem in Britanniam pervenit; et forte iisdem diebus ibidem Constantium parentem fata ultima perurgebant. <milestone unit="par" n="3"/> Quo mortuo cunctis, qui aderant, annitentibus, sed praecipue Croco, Alamannorum rege, auxilii gratia Constantium comitato imperium capit. <milestone unit="par" n="4"/> Hic sororem suam Constantiam Licinio Mediolanum accito coniungit; filiumque suum Crispum nomine, ex Minervina concubina susceptum, item Constantinum iisdem diebus natum oppido Arelatensi Licinianumque, Licinii filium, mensium fere viginti, Caesares effecit. <milestone unit="par" n="5"/> Verum enimvero ut imperia difficile concordiam custodiunt, discidium inter Licinium Constantinumque exoritur; primumque apud Cibalas iuxta paludem Hiulcam nomine Constantino nocte castra Licinii irrumpente Licinius fugam petiit Byzantiumque fuga volucri pervenit. <milestone unit="par" n="6"/> Ibi Martinianum, officiorum magistrum, Caesarem creat. <milestone unit="par" n="7"/> Dehinc Constantinus acie potior apud Bithyniam adegit Licinium pacta salute indumentum regium offerre per uxorem. Inde Thessalonicam missum paulo post eum Martinianumque iugulari iubet. <milestone unit="par" n="8"/> Hic Licinius annum dominationis fere post quartumdecimum, vitae proxime sexagesimum occidit: avaritiae cupidine omnium pessimus neque alienus a luxu venerio, asper admodum, haud mediocriter impatiens, infestus litteris, quas per inscitiam immodicam virus ac pestem publicam nominabat, praecipue forensem industriam. <milestone unit="par" n="9"/> Agraribus plane ac rusticantibus, quod ab eo genere ortus altusque erat, satis utilis ac militiae custos ad veterum instituta severissimus. <milestone unit="par" n="10"/> Spadonum et aulicorum omnium vehemens domitor tineas soricesque palatii eos appellans.</p>
-                <p>
-                  <milestone unit="par" n="11"/> At Constantinus obtento totius Romani imperii mira bellorum felicitate regimine Fausta coniuge, ut putant, suggerente Crispum filium necari iubet. <milestone unit="par" n="12"/> Dehinc uxorem suam Faustam in balneas ardentes coniectam interemit, cum eum mater Helena dolore nimio nepotis increparet. <milestone unit="par" n="13"/> Fuit vero ultra, quam aestimari potest, laudis avidus. Hic Traianum herbam parietariam ob titulos multis aedibus inscriptos appellare solitus erat. Hic pontem in Danubio construxit. <milestone unit="par" n="14"/> Habitum regium gemmis et caput exornans perpetuo diademate. Commodissimus tamen rebus multis fuit: calumnias sedare legibus severissimis, nutrire artes bonas, praecipue studia litterarum, legere ipse scribere meditari audire legationes et querimonias provinciarum. <milestone unit="par" n="15"/> Cumque liberis filioque fratris Delmatio Caesaribus confirmatis tres et sexaginta annos vixisset, ex quibus dimidios ita, ut tredecim solus imperaret, morbo consumptus est. <milestone unit="par" n="16"/> Irrisor potius quam blandus. Unde proverbio vulgari Trachala, decem annis praestantissimus, duodecim sequentibus latro, decem novissimis pupillus ob profusiones immodicas nominatus. <milestone unit="par" n="17"/> Corpus sepultum in Byzantio, Constantinopoli dicta. <milestone unit="par" n="18"/> Quo mortuo Delmatius militum vi necatur.</p>
-                <p>
-                  <milestone unit="par" n="19"/> Ita ad tres orbis Romani redacta dominatio est, Constantinum et Constantium ac Constantem, filios Constantini. <milestone unit="par" n="20"/> Hi singuli has partes regendas habuerunt: Constantinus iunior cuncta trans Alpes, Constantius a freto Propontidis Asiam atque Orientem, Constans Illyricum Italiamque et Africam, Delmatius Thraciam Macedoniamque et Achaiam, Annibalianus, Delmatii Caesaris consanguineus, Armeniam nationesque circumsocias.</p>
-                <p>
-                  <milestone unit="par" n="21"/> Interim ob Italiae Africaeque ius dissentire statim Constantinus et Constans. Constantinus latrocinii specie dum incautus foedeque temulentus in aliena irruit, obtruncatus est proiectusque in fluvium, cui nomen Alsa est, non longe ab Aquileia. <milestone unit="par" n="22"/> Constans vero venandi cupidine dum per silvas saltusque erraret, conspiravere aliquanti militares in eius necem, auctoribus Chrestio et Marcellino simulque Magnentio: qui ubi patrandi negotii dies placuit, Marcellinus natalem filii simulans plerosque ad cenam rogat. Itaque in multam noctem convivio celebrato Magnentius quasi ad ventris solita secedens habitum venerabilem capit. <milestone unit="par" n="23"/> Ea re cognita Constans fugere conatus apud Helenam, oppidum Pyrenaeo proximum, a Gaisone cum lectissimis misso interficitur anno tertio decimo Augustae dominationis (nam Caesar triennio fuerat), aevi septimo vicesimoque. <milestone unit="par" n="24"/> Hic fuit debilis pedibus manibusque articulorum dolore, fortunatus caeli temperie, fructuum proventu, nulla a barbaris formidine; quae profecto maiora fierent, si provinciarum rectores non pretio, sed iudicio provexisset. <milestone unit="par" n="25"/> Huius morte cognita Vetranio magister militum imperium in Pannonia apud Mursiam corripuit; quem Constantius non post multos dies regno exuit, grandaevae aetati non vitam modo, sed etiam voluptarium otium concedens. Fuit autem prope ad stultitiam simplicissimus. </p>
+                  <milestone unit="par" n="1"/> His omnibus absumptis imperii iura penes <hi
+                     rend="expanded">Constantinum</hi> et <hi rend="expanded">Licinium</hi>
+                  devenere. <milestone unit="par" n="2"/> Constantinus, Constantii imperatoris et
+                  Helenae filius, imperavit annos triginta. Hic dum iuvenculus a Galerio in urbe
+                  Roma religionis specie obses teneretur, fugam arripiens atque ad frustrandos
+                  insequentes publica iumenta, quaqua iter egerat, interfecit et ad patrem in
+                  Britanniam pervenit; et forte iisdem diebus ibidem Constantium parentem fata
+                  ultima perurgebant. <milestone unit="par" n="3"/> Quo mortuo cunctis, qui aderant,
+                  annitentibus, sed praecipue Croco, Alamannorum rege, auxilii gratia Constantium
+                  comitato imperium capit. <milestone unit="par" n="4"/> Hic sororem suam
+                  Constantiam Licinio Mediolanum accito coniungit; filiumque suum Crispum nomine, ex
+                  Minervina concubina susceptum, item Constantinum iisdem diebus natum oppido
+                  Arelatensi Licinianumque, Licinii filium, mensium fere viginti, Caesares effecit.
+                     <milestone unit="par" n="5"/> Verum enimvero ut imperia difficile concordiam
+                  custodiunt, discidium inter Licinium Constantinumque exoritur; primumque apud
+                  Cibalas iuxta paludem Hiulcam nomine Constantino nocte castra Licinii irrumpente
+                  Licinius fugam petiit Byzantiumque fuga volucri pervenit. <milestone unit="par"
+                     n="6"/> Ibi Martinianum, officiorum magistrum, Caesarem creat. <milestone
+                     unit="par" n="7"/> Dehinc Constantinus acie potior apud Bithyniam adegit
+                  Licinium pacta salute indumentum regium offerre per uxorem. Inde Thessalonicam
+                  missum paulo post eum Martinianumque iugulari iubet. <milestone unit="par" n="8"/>
+                  Hic Licinius annum dominationis fere post quartumdecimum, vitae proxime
+                  sexagesimum occidit: avaritiae cupidine omnium pessimus neque alienus a luxu
+                  venerio, asper admodum, haud mediocriter impatiens, infestus litteris, quas per
+                  inscitiam immodicam virus ac pestem publicam nominabat, praecipue forensem
+                  industriam. <milestone unit="par" n="9"/> Agraribus plane ac rusticantibus, quod
+                  ab eo genere ortus altusque erat, satis utilis ac militiae custos ad veterum
+                  instituta severissimus. <milestone unit="par" n="10"/> Spadonum et aulicorum
+                  omnium vehemens domitor tineas soricesque palatii eos appellans.</p>
+               <p>
+                  <milestone unit="par" n="11"/> At Constantinus obtento totius Romani imperii mira
+                  bellorum felicitate regimine Fausta coniuge, ut putant, suggerente Crispum filium
+                  necari iubet. <milestone unit="par" n="12"/> Dehinc uxorem suam Faustam in balneas
+                  ardentes coniectam interemit, cum eum mater Helena dolore nimio nepotis
+                  increparet. <milestone unit="par" n="13"/> Fuit vero ultra, quam aestimari potest,
+                  laudis avidus. Hic Traianum herbam parietariam ob titulos multis aedibus
+                  inscriptos appellare solitus erat. Hic pontem in Danubio construxit. <milestone
+                     unit="par" n="14"/> Habitum regium gemmis et caput exornans perpetuo diademate.
+                  Commodissimus tamen rebus multis fuit: calumnias sedare legibus severissimis,
+                  nutrire artes bonas, praecipue studia litterarum, legere ipse scribere meditari
+                  audire legationes et querimonias provinciarum. <milestone unit="par" n="15"/>
+                  Cumque liberis filioque fratris Delmatio Caesaribus confirmatis tres et sexaginta
+                  annos vixisset, ex quibus dimidios ita, ut tredecim solus imperaret, morbo
+                  consumptus est. <milestone unit="par" n="16"/> Irrisor potius quam blandus. Unde
+                  proverbio vulgari Trachala, decem annis praestantissimus, duodecim sequentibus
+                  latro, decem novissimis pupillus ob profusiones immodicas nominatus. <milestone
+                     unit="par" n="17"/> Corpus sepultum in Byzantio, Constantinopoli dicta.
+                     <milestone unit="par" n="18"/> Quo mortuo Delmatius militum vi necatur.</p>
+               <p>
+                  <milestone unit="par" n="19"/> Ita ad tres orbis Romani redacta dominatio est,
+                  Constantinum et Constantium ac Constantem, filios Constantini. <milestone
+                     unit="par" n="20"/> Hi singuli has partes regendas habuerunt: Constantinus
+                  iunior cuncta trans Alpes, Constantius a freto Propontidis Asiam atque Orientem,
+                  Constans Illyricum Italiamque et Africam, Delmatius Thraciam Macedoniamque et
+                  Achaiam, Annibalianus, Delmatii Caesaris consanguineus, Armeniam nationesque
+                  circumsocias.</p>
+               <p>
+                  <milestone unit="par" n="21"/> Interim ob Italiae Africaeque ius dissentire statim
+                  Constantinus et Constans. Constantinus latrocinii specie dum incautus foedeque
+                  temulentus in aliena irruit, obtruncatus est proiectusque in fluvium, cui nomen
+                  Alsa est, non longe ab Aquileia. <milestone unit="par" n="22"/> Constans vero
+                  venandi cupidine dum per silvas saltusque erraret, conspiravere aliquanti
+                  militares in eius necem, auctoribus Chrestio et Marcellino simulque Magnentio: qui
+                  ubi patrandi negotii dies placuit, Marcellinus natalem filii simulans plerosque ad
+                  cenam rogat. Itaque in multam noctem convivio celebrato Magnentius quasi ad
+                  ventris solita secedens habitum venerabilem capit. <milestone unit="par" n="23"/>
+                  Ea re cognita Constans fugere conatus apud Helenam, oppidum Pyrenaeo proximum, a
+                  Gaisone cum lectissimis misso interficitur anno tertio decimo Augustae
+                  dominationis (nam Caesar triennio fuerat), aevi septimo vicesimoque. <milestone
+                     unit="par" n="24"/> Hic fuit debilis pedibus manibusque articulorum dolore,
+                  fortunatus caeli temperie, fructuum proventu, nulla a barbaris formidine; quae
+                  profecto maiora fierent, si provinciarum rectores non pretio, sed iudicio
+                  provexisset. <milestone unit="par" n="25"/> Huius morte cognita Vetranio magister
+                  militum imperium in Pannonia apud Mursiam corripuit; quem Constantius non post
+                  multos dies regno exuit, grandaevae aetati non vitam modo, sed etiam voluptarium
+                  otium concedens. Fuit autem prope ad stultitiam simplicissimus. </p>
             </div>
             <div type="cap" n="42">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Constantius</hi> Gallum fratrem patruelem Caesarem pronuntiat, sororem Constantinam illi coniungens. <milestone unit="par" n="2"/> Magnentius quoque Decentium consanguineum suum trans Alpes Caesarem creavit. <milestone unit="par" n="3"/> His diebus Romae Nepotianus, Eutropiae Constantini sororis filius, hortantibus perditis Augusti nomen rapit; eum octavo die vicesimoque Magnentius oppressit. <milestone unit="par" n="4"/> Hoc tempore Constantius cum Magnentio apud Mursiam dimicans vicit. In quo bello paene nusquam amplius Romanae consumptae sunt vires totiusque imperii fortuna pessumdata. <milestone unit="par" n="5"/> Dehinc cum se Magnentius in Italiam recepisset, apud Ticinum plures fudit incautius et, ut in victoria solet, audacius persequentes. <milestone unit="par" n="6"/> Nec multo post apud Lugdunum coangustatus gladio occulte proviso ictum pulsu parietis iuvans transfosso latere, ut erat vasti corporis, vulnere naribusque et ore cruorem effundens mense imperii quadragesimo secundo, aetatis anno prope quinquagesimo exspiravit. <milestone unit="par" n="7"/> Ortus parentibus barbaris, qui Galliam inhabitant; legendi studio promptus, sermonis acer, animi tumidi et immodice timidus; artifex tamen ad occultandam audaciae specie formidinem. <milestone unit="par" n="8"/> Eius morte audita Decentius laqueo fascia composito vitam finivit. <milestone unit="par" n="9"/> Hoc tempore Gallus Caesar a Constantio occiditur. Imperavit annos quattuor. <milestone unit="par" n="10"/> Silvanus imperator effectus die imperii vicesimo octavo perimitur. Fuit ingenio blandissimus. <milestone unit="par" n="11"/> Quamquam barbaro patre genitus, tamen institutione Romana satis cultus et patiens.</p>
-                <p>
-                  <milestone unit="par" n="12"/> Constantius Claudium Iulianum, fratrem Galli, honore Caesaris assumit annos natum fere tres atque viginti. <milestone unit="par" n="13"/> Iste in campis Argentoratensibus apud Gallias cum paucis militibus infinitas hostium copias delevit. <milestone unit="par" n="14"/> Stabant acervi montium similes, fluebat cruor fluminum modo; captus rex nobilis Nodomarius; fusi omnes optimates; redditus limes Romanae possessionis; ac postmodum cum Alamannis dimicans potentissimum eorum regem Badomarium cepit. <milestone unit="par" n="15"/> Hic a militibus Gallicanis Augustus pronuntiatur. <milestone unit="par" n="16"/> Hinc Constantius urgere legationibus, in statum nomenque pristinum revertatur. Iulianus mandatis mollioribus refert se sub nomine celsi imperii multo officiosius pariturum. <milestone unit="par" n="17"/> His Constantius magis magisque ardens dolore atque, ut erat talium impatiens, in radicibus Tauri montis apud Mopsocrenen febri acerrima, quam indignatio nimia vigiliis augebat, interiit anno aevi quarto et quadragesimo, imperii nono atque tricesimo, verum Augustus quarto vicesimoque: octo solus, cum fratribus atque Magnentio sedecim, quindecim Caesar. <milestone unit="par" n="18"/> Felix bellis civilibus, externis lacrimabilis; mirus artifex in sagittis; a cibo vinoque et somno multum temperans, patiens laboris, facundiae cupidus; quam cum assequi tarditate ingenii non posset, aliis invidebat. <milestone unit="par" n="19"/> Spadonum aulicorumque amori deditus et uxorum; quibus contentus nulla libidine transversa aut iniusta polluebatur. <milestone unit="par" n="20"/> Sed ex coniugibus, quas plurimas sortitus est, praecipue Eusebiam dilexit, decoram quidem, verum per Adamantias et Gorgonias et alia importuna ministeria vexantem famam viri contra, quam feminis modestioribus mos est; quarum saepe praecepta maritos iuvant.<milestone unit="par" n="21"/> Namque ut ceteras omittam, Pompeia Plotina incredibile dictu est quanto auxerit gloriam Traiani; cuius procuratores cum provincias calumniis agitarent, adeo ut unus ex his diceretur locupletium quemque ita convenire: 'Quare habes?' Alter: 'Unde habes?' Tertius: 'Pone, quod habes', illa coniugem corripuit atque increpans, quod laudis suae esset incuriosus, talem reddidit, ut postea exactiones improbas detestans fiscum lienem vocaret, quod eo crescente artus reliqui tabescunt. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Constantius</hi> Gallum fratrem patruelem Caesarem pronuntiat,
+                  sororem Constantinam illi coniungens. <milestone unit="par" n="2"/> Magnentius
+                  quoque Decentium consanguineum suum trans Alpes Caesarem creavit. <milestone
+                     unit="par" n="3"/> His diebus Romae Nepotianus, Eutropiae Constantini sororis
+                  filius, hortantibus perditis Augusti nomen rapit; eum octavo die vicesimoque
+                  Magnentius oppressit. <milestone unit="par" n="4"/> Hoc tempore Constantius cum
+                  Magnentio apud Mursiam dimicans vicit. In quo bello paene nusquam amplius Romanae
+                  consumptae sunt vires totiusque imperii fortuna pessumdata. <milestone unit="par"
+                     n="5"/> Dehinc cum se Magnentius in Italiam recepisset, apud Ticinum plures
+                  fudit incautius et, ut in victoria solet, audacius persequentes. <milestone
+                     unit="par" n="6"/> Nec multo post apud Lugdunum coangustatus gladio occulte
+                  proviso ictum pulsu parietis iuvans transfosso latere, ut erat vasti corporis,
+                  vulnere naribusque et ore cruorem effundens mense imperii quadragesimo secundo,
+                  aetatis anno prope quinquagesimo exspiravit. <milestone unit="par" n="7"/> Ortus
+                  parentibus barbaris, qui Galliam inhabitant; legendi studio promptus, sermonis
+                  acer, animi tumidi et immodice timidus; artifex tamen ad occultandam audaciae
+                  specie formidinem. <milestone unit="par" n="8"/> Eius morte audita Decentius
+                  laqueo fascia composito vitam finivit. <milestone unit="par" n="9"/> Hoc tempore
+                  Gallus Caesar a Constantio occiditur. Imperavit annos quattuor. <milestone
+                     unit="par" n="10"/> Silvanus imperator effectus die imperii vicesimo octavo
+                  perimitur. Fuit ingenio blandissimus. <milestone unit="par" n="11"/> Quamquam
+                  barbaro patre genitus, tamen institutione Romana satis cultus et patiens.</p>
+               <p>
+                  <milestone unit="par" n="12"/> Constantius Claudium Iulianum, fratrem Galli,
+                  honore Caesaris assumit annos natum fere tres atque viginti. <milestone unit="par"
+                     n="13"/> Iste in campis Argentoratensibus apud Gallias cum paucis militibus
+                  infinitas hostium copias delevit. <milestone unit="par" n="14"/> Stabant acervi
+                  montium similes, fluebat cruor fluminum modo; captus rex nobilis Nodomarius; fusi
+                  omnes optimates; redditus limes Romanae possessionis; ac postmodum cum Alamannis
+                  dimicans potentissimum eorum regem Badomarium cepit. <milestone unit="par" n="15"
+                  /> Hic a militibus Gallicanis Augustus pronuntiatur. <milestone unit="par" n="16"
+                  /> Hinc Constantius urgere legationibus, in statum nomenque pristinum revertatur.
+                  Iulianus mandatis mollioribus refert se sub nomine celsi imperii multo officiosius
+                  pariturum. <milestone unit="par" n="17"/> His Constantius magis magisque ardens
+                  dolore atque, ut erat talium impatiens, in radicibus Tauri montis apud Mopsocrenen
+                  febri acerrima, quam indignatio nimia vigiliis augebat, interiit anno aevi quarto
+                  et quadragesimo, imperii nono atque tricesimo, verum Augustus quarto vicesimoque:
+                  octo solus, cum fratribus atque Magnentio sedecim, quindecim Caesar. <milestone
+                     unit="par" n="18"/> Felix bellis civilibus, externis lacrimabilis; mirus
+                  artifex in sagittis; a cibo vinoque et somno multum temperans, patiens laboris,
+                  facundiae cupidus; quam cum assequi tarditate ingenii non posset, aliis invidebat.
+                     <milestone unit="par" n="19"/> Spadonum aulicorumque amori deditus et uxorum;
+                  quibus contentus nulla libidine transversa aut iniusta polluebatur. <milestone
+                     unit="par" n="20"/> Sed ex coniugibus, quas plurimas sortitus est, praecipue
+                  Eusebiam dilexit, decoram quidem, verum per Adamantias et Gorgonias et alia
+                  importuna ministeria vexantem famam viri contra, quam feminis modestioribus mos
+                  est; quarum saepe praecepta maritos iuvant.<milestone unit="par" n="21"/> Namque
+                  ut ceteras omittam, Pompeia Plotina incredibile dictu est quanto auxerit gloriam
+                  Traiani; cuius procuratores cum provincias calumniis agitarent, adeo ut unus ex
+                  his diceretur locupletium quemque ita convenire: 'Quare habes?' Alter: 'Unde
+                  habes?' Tertius: 'Pone, quod habes', illa coniugem corripuit atque increpans, quod
+                  laudis suae esset incuriosus, talem reddidit, ut postea exactiones improbas
+                  detestans fiscum lienem vocaret, quod eo crescente artus reliqui tabescunt. </p>
             </div>
             <div type="cap" n="43">
                <p>
-                  <milestone unit="par" n="1"/> Igitur <hi rend="expanded">Iulianus</hi>, redacta ad unum se orbis Romani curatione, gloriae nimis cupidus in Persas proficiscitur. <milestone unit="par" n="2"/> Illic a transfuga quodam in insidias deductus, cum eum hinc inde Parthi urgerent, e castris iam positis arrepto tantum clipeo procurrit. <milestone unit="par" n="3"/> Cumque inconsulto ardore nititur ordines ad proelium componere, ab uno ex hostibus et quidem fugiente conto percutitur. <milestone unit="par" n="4"/> Relatusque in tabernaculum rursusque ad hortandos suos egressus, paulatim sanguine vacuatus, circa noctis fere medium defecit, praefatus consulto sese de imperio nihil mandare, ne, uti solet in multitudine discrepantibus studiis<unclear/> amico ex invidia, reipublicae discordia exercitus periculum pararet. <milestone unit="par" n="5"/> Fuerat in eo litterarum ac negotiorum ingens scientia, aequaverat  philosophos et Graecorum sapientissimos. <milestone unit="par" n="6"/> Vsu promptior corporis, quo validus quidem, sed brevis fuit. <milestone unit="par" n="7"/> Haec minuebat quarundam rerum neglectus modus. Cupido laudis immodica; cultus numinum superstitiosus; audax plus, quam imperatorem decet, cui salus propria cum semper ad securitatem omnium, <supplied>tum</supplied> in bello maxime conservanda est. <milestone unit="par" n="8"/> Ita illum cupido gloriae flagrantior pervicerat, ut neque terrae motu neque plerisque praesagiis, quibus vetabatur petere Persidem, adductus sit finem ponere ardori, ac ne noctu quidem visus ingens globus caelo labi ante diem belli cautum praestiterit. </p>
+                  <milestone unit="par" n="1"/> Igitur <hi rend="expanded">Iulianus</hi>, redacta ad
+                  unum se orbis Romani curatione, gloriae nimis cupidus in Persas proficiscitur.
+                     <milestone unit="par" n="2"/> Illic a transfuga quodam in insidias deductus,
+                  cum eum hinc inde Parthi urgerent, e castris iam positis arrepto tantum clipeo
+                  procurrit. <milestone unit="par" n="3"/> Cumque inconsulto ardore nititur ordines
+                  ad proelium componere, ab uno ex hostibus et quidem fugiente conto percutitur.
+                     <milestone unit="par" n="4"/> Relatusque in tabernaculum rursusque ad hortandos
+                  suos egressus, paulatim sanguine vacuatus, circa noctis fere medium defecit,
+                  praefatus consulto sese de imperio nihil mandare, ne, uti solet in multitudine
+                  discrepantibus studiis<unclear/> amico ex invidia, reipublicae discordia exercitus
+                  periculum pararet. <milestone unit="par" n="5"/> Fuerat in eo litterarum ac
+                  negotiorum ingens scientia, aequaverat philosophos et Graecorum sapientissimos.
+                     <milestone unit="par" n="6"/> Vsu promptior corporis, quo validus quidem, sed
+                  brevis fuit. <milestone unit="par" n="7"/> Haec minuebat quarundam rerum neglectus
+                  modus. Cupido laudis immodica; cultus numinum superstitiosus; audax plus, quam
+                  imperatorem decet, cui salus propria cum semper ad securitatem omnium,
+                     <supplied>tum</supplied> in bello maxime conservanda est. <milestone unit="par"
+                     n="8"/> Ita illum cupido gloriae flagrantior pervicerat, ut neque terrae motu
+                  neque plerisque praesagiis, quibus vetabatur petere Persidem, adductus sit finem
+                  ponere ardori, ac ne noctu quidem visus ingens globus caelo labi ante diem belli
+                  cautum praestiterit. </p>
             </div>
             <div type="cap" n="44">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Iovianus</hi>, genitus patre Varroniano, incola agri Singidonensis provinciae Pannoniae, imperavit menses octo. <milestone unit="par" n="2"/> Eius patri, cum liberos crebros amitteret, praeceptum somnio est, eum, qui iam instante uxoris partu edendus foret, diceret Iovianum. <milestone unit="par" n="3"/> Hic fuit insignis corpore, laetus ingenio, litterarum studiosus. <milestone unit="par" n="4"/> Hic a Perside hieme aspera mediaque Constantinopolim accelerans, cruditate stomachi, tectorio novi operis gravatus repente interiit, annos gerens proxime quadraginta. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Iovianus</hi>, genitus patre Varroniano, incola agri
+                  Singidonensis provinciae Pannoniae, imperavit menses octo. <milestone unit="par"
+                     n="2"/> Eius patri, cum liberos crebros amitteret, praeceptum somnio est, eum,
+                  qui iam instante uxoris partu edendus foret, diceret Iovianum. <milestone
+                     unit="par" n="3"/> Hic fuit insignis corpore, laetus ingenio, litterarum
+                  studiosus. <milestone unit="par" n="4"/> Hic a Perside hieme aspera mediaque
+                  Constantinopolim accelerans, cruditate stomachi, tectorio novi operis gravatus
+                  repente interiit, annos gerens proxime quadraginta. </p>
             </div>
             <div type="cap" n="45">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Valentinianus</hi> imperavit annos duodecim minus diebus centum. <milestone unit="par" n="2"/> Huius pater Gratianus, mediocri stirpe ortus apud Cibalas, Funarius appellatus est, eo quod venalicium funem portanti quinque milites nequirent extorquere. <milestone unit="par" n="3"/> Eo merito ascitus in militiam usque ad praefecturae praetorianae potentiam conscendit; ob cuius apud milites commendationem Valentiniano imperium resistenti oggeritur. <milestone unit="par" n="4"/> Hic Valentem consanguineum suum sibi socium in imperio ascivit ac demum Gratianum filium necdum plene puberem hortatu socrus et uxoris Augustum creavit. <milestone unit="par" n="5"/> Hic Valentinianus fuit vultu decens, sollers ingenio, animo gravis, sermone cultissimus, quamquam esset ad loquendum parcus, severus, vehemens, infectus vitiis maximeque avaritiae; cuius cupitor ipse fuit acer, et in his, quae memoraturus sum, Hadriano proximus: <milestone unit="par" n="6"/> pingere venustissime, meminisse, nova arma meditari, fingere cera seu limo simulacra, prudenter uti locis, temporibus, sermone; atque, ut breviter concludam, si ei foedis hominibus, quis sese quasi fidissimis prudentissimisque dederat, carere aut probatis eruditisque monitoribus uti licuisset, perfectus haud dubie princeps enituisset. <milestone unit="par" n="7"/> Huius tempore Firmus apud Mauritaniam regnum invadens exstinguitur. <milestone unit="par" n="8"/> Valentinianus apud Bergentionem legationi Quadorum respondens, anno aevi quinto et quinquagesimo impetu sanguinis voce amissa, sensu integer, exspiravit. <milestone unit="par" n="9"/> Quod quidem intemperantia cibi ac saturitate, qua artus diffuderat, accidisse plures retulere. <milestone unit="par" n="10"/> Itaque eo mortuo Valentinianus adhuc quadriennis auctore Equitio ac Merobaude e propinquo, ubi cum matre fuerat, allatus creatur imperator. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Valentinianus</hi> imperavit annos duodecim minus diebus
+                  centum. <milestone unit="par" n="2"/> Huius pater Gratianus, mediocri stirpe ortus
+                  apud Cibalas, Funarius appellatus est, eo quod venalicium funem portanti quinque
+                  milites nequirent extorquere. <milestone unit="par" n="3"/> Eo merito ascitus in
+                  militiam usque ad praefecturae praetorianae potentiam conscendit; ob cuius apud
+                  milites commendationem Valentiniano imperium resistenti oggeritur. <milestone
+                     unit="par" n="4"/> Hic Valentem consanguineum suum sibi socium in imperio
+                  ascivit ac demum Gratianum filium necdum plene puberem hortatu socrus et uxoris
+                  Augustum creavit. <milestone unit="par" n="5"/> Hic Valentinianus fuit vultu
+                  decens, sollers ingenio, animo gravis, sermone cultissimus, quamquam esset ad
+                  loquendum parcus, severus, vehemens, infectus vitiis maximeque avaritiae; cuius
+                  cupitor ipse fuit acer, et in his, quae memoraturus sum, Hadriano proximus:
+                     <milestone unit="par" n="6"/> pingere venustissime, meminisse, nova arma
+                  meditari, fingere cera seu limo simulacra, prudenter uti locis, temporibus,
+                  sermone; atque, ut breviter concludam, si ei foedis hominibus, quis sese quasi
+                  fidissimis prudentissimisque dederat, carere aut probatis eruditisque monitoribus
+                  uti licuisset, perfectus haud dubie princeps enituisset. <milestone unit="par"
+                     n="7"/> Huius tempore Firmus apud Mauritaniam regnum invadens exstinguitur.
+                     <milestone unit="par" n="8"/> Valentinianus apud Bergentionem legationi
+                  Quadorum respondens, anno aevi quinto et quinquagesimo impetu sanguinis voce
+                  amissa, sensu integer, exspiravit. <milestone unit="par" n="9"/> Quod quidem
+                  intemperantia cibi ac saturitate, qua artus diffuderat, accidisse plures retulere.
+                     <milestone unit="par" n="10"/> Itaque eo mortuo Valentinianus adhuc quadriennis
+                  auctore Equitio ac Merobaude e propinquo, ubi cum matre fuerat, allatus creatur
+                  imperator. </p>
             </div>
             <div type="cap" n="46">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Valens</hi> una cum Valentiniano germano suo, de quo diximus, regnavit annos tredecim, menses quinque. <milestone unit="par" n="2"/> Hic Valens cum Gothis lacrimabili bello commisso sagittis saucius in casa deportatur vilissima; ubi supervenientibus Gothis ignique supposito incendio concrematus est. <milestone unit="par" n="3"/> In quo probanda haec fuere: fuit possessoribus consultor bonus; mutare iudices rarius; in amicos fidus; irasci sine noxa ac periculo cuiusquam; sane valde timidus. <milestone unit="par" n="4"/> Huius temporibus Procopius tyrannidem invadens exstinguitur. </p>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Valens</hi> una cum Valentiniano germano suo, de quo diximus,
+                  regnavit annos tredecim, menses quinque. <milestone unit="par" n="2"/> Hic Valens
+                  cum Gothis lacrimabili bello commisso sagittis saucius in casa deportatur
+                  vilissima; ubi supervenientibus Gothis ignique supposito incendio concrematus est.
+                     <milestone unit="par" n="3"/> In quo probanda haec fuere: fuit possessoribus
+                  consultor bonus; mutare iudices rarius; in amicos fidus; irasci sine noxa ac
+                  periculo cuiusquam; sane valde timidus. <milestone unit="par" n="4"/> Huius
+                  temporibus Procopius tyrannidem invadens exstinguitur. </p>
             </div>
             <div type="cap" n="47">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Gratianus</hi>, genitus Sirmii, imperavit cum patre Valentiniano annos octo, dies octoginta quinque; cum patruo et fratre tres; cum eodem fratre ac Theodosio quattuor, et his omnibus accedente Arcadio menses sex. <milestone unit="par" n="2"/> Hic apud Argentariam oppidum Galliae triginta Alamannorum milia in bello exstinxit. <milestone unit="par" n="3"/> Hic cum animadvertisset Thraciam Daciamque tamquam genitales terras possidentibus Gothis Taifalisque atque omni pernicie atrocioribus Hunnis et Alanis extremum periculum instare nomini Romano, accito ab Hispania Theodosio cunctis faventibus degenti annum a tricesimo tertium imperium committit. <milestone unit="par" n="4"/> Fuit autem Gratianus litteris haud mediocriter institutus: carmen facere, ornate loqui, explicare controversias rhetorum more; nihil aliud die noctuque agere quam spiculis meditari summaeque voluptatis divinaeque artis credere ferire destinata. <milestone unit="par" n="5"/> Parcus cibi somnique et vini ac libidinis victor; cunctisque esset plenus bonis, si ad cognoscendam reipublicae regendae scientiam animum intendisset, a qua prope alienus non modo voluntate, sed etiam exercitio fuit. <milestone unit="par" n="6"/> Nam dum exercitum negligeret et paucos ex Alanis, quos ingenti auro ad se transtulerat, anteferret veteri ac Romano militi, adeoque barbarorum comitatu et prope amicitia capi<supplied>
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Gratianus</hi>, genitus Sirmii, imperavit cum patre
+                  Valentiniano annos octo, dies octoginta quinque; cum patruo et fratre tres; cum
+                  eodem fratre ac Theodosio quattuor, et his omnibus accedente Arcadio menses sex.
+                     <milestone unit="par" n="2"/> Hic apud Argentariam oppidum Galliae triginta
+                  Alamannorum milia in bello exstinxit. <milestone unit="par" n="3"/> Hic cum
+                  animadvertisset Thraciam Daciamque tamquam genitales terras possidentibus Gothis
+                  Taifalisque atque omni pernicie atrocioribus Hunnis et Alanis extremum periculum
+                  instare nomini Romano, accito ab Hispania Theodosio cunctis faventibus degenti
+                  annum a tricesimo tertium imperium committit. <milestone unit="par" n="4"/> Fuit
+                  autem Gratianus litteris haud mediocriter institutus: carmen facere, ornate loqui,
+                  explicare controversias rhetorum more; nihil aliud die noctuque agere quam
+                  spiculis meditari summaeque voluptatis divinaeque artis credere ferire destinata.
+                     <milestone unit="par" n="5"/> Parcus cibi somnique et vini ac libidinis victor;
+                  cunctisque esset plenus bonis, si ad cognoscendam reipublicae regendae scientiam
+                  animum intendisset, a qua prope alienus non modo voluntate, sed etiam exercitio
+                  fuit. <milestone unit="par" n="6"/> Nam dum exercitum negligeret et paucos ex
+                  Alanis, quos ingenti auro ad se transtulerat, anteferret veteri ac Romano militi,
+                  adeoque barbarorum comitatu et prope amicitia capi<supplied>
                      <gap/>
-                  </supplied>, ut nonnumquam eodem habitu iter faceret, odia contra se militum excitavit. <milestone unit="par" n="7"/> Hoc tempore cum Maximus apud Britanniam tyrannidem arripuisset et in Galliam transmisisset, ab infensis Gratiano legionibus exceptus Gratianum fugavit nec mora exstinxit. Qui vixit annos XXIX. </p>
+                  </supplied>, ut nonnumquam eodem habitu iter faceret, odia contra se militum
+                  excitavit. <milestone unit="par" n="7"/> Hoc tempore cum Maximus apud Britanniam
+                  tyrannidem arripuisset et in Galliam transmisisset, ab infensis Gratiano
+                  legionibus exceptus Gratianum fugavit nec mora exstinxit. Qui vixit annos XXIX.
+               </p>
             </div>
             <div type="cap" n="48">
                <p>
-                  <milestone unit="par" n="1"/> 
-                  <hi rend="expanded">Theodosius</hi>, genitus patre Honorio, matre Thermantia, genere Hispanus, originem a Traiano principe trahens, a Gratiano Augusto apud Sirmium imperator effectus regnavit annos decem et septem. <milestone unit="par" n="2"/> Huic ferunt nomen somnio parentes monitos sacravisse, ut Latine intellegimus a deo datum. <milestone unit="par" n="3"/> De hoc etiam oraculo in Asia divulgatum est eum Valenti successurum, cuius nomen e <foreign xml:lang="grc">
+                  <milestone unit="par" n="1"/>
+                  <hi rend="expanded">Theodosius</hi>, genitus patre Honorio, matre Thermantia,
+                  genere Hispanus, originem a Traiano principe trahens, a Gratiano Augusto apud
+                  Sirmium imperator effectus regnavit annos decem et septem. <milestone unit="par"
+                     n="2"/> Huic ferunt nomen somnio parentes monitos sacravisse, ut Latine
+                  intellegimus a deo datum. <milestone unit="par" n="3"/> De hoc etiam oraculo in
+                  Asia divulgatum est eum Valenti successurum, cuius nomen e <foreign xml:lang="grc">
                      <hi rend="italic">Θ</hi>
                   </foreign> et <foreign xml:lang="grc">
                      <hi rend="italic">Ε</hi>
@@ -346,14 +1306,66 @@
                      <hi rend="italic">Ο</hi>
                   </foreign> atque <foreign xml:lang="grc">
                      <hi rend="italic">Δ</hi>
-                  </foreign> Graecis litteris initiaretur. <milestone unit="par" n="4"/> Qua cognatione principii deceptus Theodorus, cum sibi imperium deberi praesumeret, scelestae cupidinis supplicia persolverat. <milestone unit="par" n="5"/> Fuit autem Theodosius propagator reipublicae atque defensor eximius. Nam Hunnos et Gothos, qui eam sub Valente defatigassent, diversis proeliis vicit. Cum Persis quoque petitus pacem pepigit. <milestone unit="par" n="6"/> Maximum autem tyrannum, qui Gratianum interfecerat et sibi Gallias vindicabat, apud Aquileiam exstinxit Victoremque eius filium, intra infantiae annos a Maximo patre Augustum factum, necavit. <milestone unit="par" n="7"/> Eugenium quoque tyrannum atque Arbogasten superavit deletis eorum decem milibus pugnatorum. Hic etenim Eugenius, confisus viribus Arbogastis, postquam apud Viennam Valentinianum exstinxerat, regnum invasit; sed mox simul cum vita imperium perdidit.</p>
-                <p>
-                  <milestone unit="par" n="8"/> Fuit autem Theodosius moribus et corpore Traiano similis, quantum scripta veterum et picturae docent: sic eminens status, membra eadem, par caesaries, os absque eo, quod illi aliquantum vellendo steriles genae neque tam ingentes oculi erant, nescio an et tanta gratia tantusque flos in facie seu tanta dignitas in incessu. <milestone unit="par" n="9"/> Mens vero prorsus similis, adeo ut nihil dici queat, quod non ex libris in istum videatur transferri. Clemens animus, misericors, communis, solo habitu differre se ceteris putans; in omnes homines honorificus, verum effusius in bonos; simplicia ingenia aeque diligere, erudita mirari, sed innoxia; largiri magno animo magna; amare cives vel privato contubernio cognitos eosque honoribus pecunia beneficiis ceteris munerare, praesertim quorum erga se vel patrem aspero casu officia probaverat. <milestone unit="par" n="10"/> Illa tamen, quibus Traianus aspersus est, vinolentiam scilicet et cupidinem triumphandi usque eo detestatus, ut bella non moverit, sed invenerit, prohibueritque lege ministeria lasciva psaltriasque comissationibus adhiberi, tantum pudori tribuens et continentiae, ut consobrinarum nuptias vetuerit tamquam sororum. <milestone unit="par" n="11"/> Litteris, si nimium perfectos contemplemur, mediocriter doctus; sagax plane multumque diligens ad noscenda maiorum gesta. <milestone unit="par" n="12"/> E quibus non desinebat exsecrari, quorum facta superba crudelia libertatique infesta legerat, ut Cinnam Marium Syllamque atque universos dominantium, praecipue tamen perfidos et ingratos. <milestone unit="par" n="13"/> Irasci sane rebus indignis, sed flecti cito; unde modica dilatione emolliebantur aliquando severa praecepta. <milestone unit="par" n="14"/> Habuitque a natura, quod Augustus a philosophiae doctore. <milestone unit="par" n="15"/> Qui cum vidisset eum facile commoveri, ne asperum aliquid statueret, monuit, ubi irasci coepisset, quattuor atque viginti Graecas litteras memoria recenseret, ut illa concitatio, quae momenti est, mente alio traducta parvi temporis interiectu languesceret. </p>
-                <p>
-                  <milestone unit="par" n="16"/> Melior haud dubie, quod est rarae virtutis, post auctam annis potentiam regalem multoque maxime post civilem victoriam. <milestone unit="par" n="17"/> Nam et annonae curam sollicitius attendere et auri argentique grande pondus sublati atque expensi a tyranno multis e suo restituere, cum benigni principum et quidem vix fundos solerent nudos ac deformata praedia concedere. <milestone unit="par" n="18"/> Iam illa minutiora et, ut dicitur, intra aulam, quae quidem, quia occulta sunt, magis naturae hominum curiosae oculos auresque ad se trahunt: patruum colere tamquam genitorem, fratris mortui sororisque liberos habere pro suis, cognatos affinesque parentis animo complecti, elegans laetumque convivium dare, non tamen sumptuosum, miscere colloquia pro personis, studia dignitatibus, sermone cum gravitate iocundo; blandus pater, concors maritus. <milestone unit="par" n="19"/> Exercebatur neque ad illecebram neque ad lassitudinem; ambulationibus magis, cum esset otium, reficiebat animum ac vescendi continentia valetudinem regebat; sicque in pace rebus humanis annum agens quinquagesimum apud Mediolanum excessit utramque rempublicam utrisque filiis, id est Arcadio et Honorio, quietam relinquens. <milestone unit="par" n="20"/> Corpus eius eodem anno Constantinopolim translatum atque sepultum est. </p>
-            </div>
-        </div> 
+                  </foreign> Graecis litteris initiaretur. <milestone unit="par" n="4"/> Qua
+                  cognatione principii deceptus Theodorus, cum sibi imperium deberi praesumeret,
+                  scelestae cupidinis supplicia persolverat. <milestone unit="par" n="5"/> Fuit
+                  autem Theodosius propagator reipublicae atque defensor eximius. Nam Hunnos et
+                  Gothos, qui eam sub Valente defatigassent, diversis proeliis vicit. Cum Persis
+                  quoque petitus pacem pepigit. <milestone unit="par" n="6"/> Maximum autem
+                  tyrannum, qui Gratianum interfecerat et sibi Gallias vindicabat, apud Aquileiam
+                  exstinxit Victoremque eius filium, intra infantiae annos a Maximo patre Augustum
+                  factum, necavit. <milestone unit="par" n="7"/> Eugenium quoque tyrannum atque
+                  Arbogasten superavit deletis eorum decem milibus pugnatorum. Hic etenim Eugenius,
+                  confisus viribus Arbogastis, postquam apud Viennam Valentinianum exstinxerat,
+                  regnum invasit; sed mox simul cum vita imperium perdidit.</p>
+               <p>
+                  <milestone unit="par" n="8"/> Fuit autem Theodosius moribus et corpore Traiano
+                  similis, quantum scripta veterum et picturae docent: sic eminens status, membra
+                  eadem, par caesaries, os absque eo, quod illi aliquantum vellendo steriles genae
+                  neque tam ingentes oculi erant, nescio an et tanta gratia tantusque flos in facie
+                  seu tanta dignitas in incessu. <milestone unit="par" n="9"/> Mens vero prorsus
+                  similis, adeo ut nihil dici queat, quod non ex libris in istum videatur
+                  transferri. Clemens animus, misericors, communis, solo habitu differre se ceteris
+                  putans; in omnes homines honorificus, verum effusius in bonos; simplicia ingenia
+                  aeque diligere, erudita mirari, sed innoxia; largiri magno animo magna; amare
+                  cives vel privato contubernio cognitos eosque honoribus pecunia beneficiis ceteris
+                  munerare, praesertim quorum erga se vel patrem aspero casu officia probaverat.
+                     <milestone unit="par" n="10"/> Illa tamen, quibus Traianus aspersus est,
+                  vinolentiam scilicet et cupidinem triumphandi usque eo detestatus, ut bella non
+                  moverit, sed invenerit, prohibueritque lege ministeria lasciva psaltriasque
+                  comissationibus adhiberi, tantum pudori tribuens et continentiae, ut consobrinarum
+                  nuptias vetuerit tamquam sororum. <milestone unit="par" n="11"/> Litteris, si
+                  nimium perfectos contemplemur, mediocriter doctus; sagax plane multumque diligens
+                  ad noscenda maiorum gesta. <milestone unit="par" n="12"/> E quibus non desinebat
+                  exsecrari, quorum facta superba crudelia libertatique infesta legerat, ut Cinnam
+                  Marium Syllamque atque universos dominantium, praecipue tamen perfidos et
+                  ingratos. <milestone unit="par" n="13"/> Irasci sane rebus indignis, sed flecti
+                  cito; unde modica dilatione emolliebantur aliquando severa praecepta. <milestone
+                     unit="par" n="14"/> Habuitque a natura, quod Augustus a philosophiae doctore.
+                     <milestone unit="par" n="15"/> Qui cum vidisset eum facile commoveri, ne
+                  asperum aliquid statueret, monuit, ubi irasci coepisset, quattuor atque viginti
+                  Graecas litteras memoria recenseret, ut illa concitatio, quae momenti est, mente
+                  alio traducta parvi temporis interiectu languesceret. </p>
+               <p>
+                  <milestone unit="par" n="16"/> Melior haud dubie, quod est rarae virtutis, post
+                  auctam annis potentiam regalem multoque maxime post civilem victoriam. <milestone
+                     unit="par" n="17"/> Nam et annonae curam sollicitius attendere et auri
+                  argentique grande pondus sublati atque expensi a tyranno multis e suo restituere,
+                  cum benigni principum et quidem vix fundos solerent nudos ac deformata praedia
+                  concedere. <milestone unit="par" n="18"/> Iam illa minutiora et, ut dicitur, intra
+                  aulam, quae quidem, quia occulta sunt, magis naturae hominum curiosae oculos
+                  auresque ad se trahunt: patruum colere tamquam genitorem, fratris mortui
+                  sororisque liberos habere pro suis, cognatos affinesque parentis animo complecti,
+                  elegans laetumque convivium dare, non tamen sumptuosum, miscere colloquia pro
+                  personis, studia dignitatibus, sermone cum gravitate iocundo; blandus pater,
+                  concors maritus. <milestone unit="par" n="19"/> Exercebatur neque ad illecebram
+                  neque ad lassitudinem; ambulationibus magis, cum esset otium, reficiebat animum ac
+                  vescendi continentia valetudinem regebat; sicque in pace rebus humanis annum agens
+                  quinquagesimum apud Mediolanum excessit utramque rempublicam utrisque filiis, id
+                  est Arcadio et Honorio, quietam relinquens. <milestone unit="par" n="20"/> Corpus
+                  eius eodem anno Constantinopolim translatum atque sepultum est. </p>
+         </div>
       </body>
-    </text>
+   </text>
 
 </TEI>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -80,6 +80,11 @@
             <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
+      <revisionDesc>
+         <change who="Vincent Giovannangeli" when="2021-04-26">Suppression de la seconde ligne qui empêchait la validation du fichier, 
+            déplacement de la balise div fermante qui gênait le Passage level parsing, ajout de la langue, correction de la balise cRefPattern, 
+            du Xpath et ajout d'un revisionDesc pour indiquer l'auteur et la date de la correction</change>
+      </revisionDesc>
    </teiHeader>
 
    <text>

--- a/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0044/stoa003/stoa0044.stoa003.digilibLT-lat1.xml
@@ -76,7 +76,11 @@
          </editorialDecl>
 
       </encodingDesc>
-
+      <profileDesc>
+         <langUsage>
+            <language ident="lat">Latino</language>
+         </langUsage>
+      </profileDesc>
    </teiHeader>
 
    <text>


### PR DESCRIPTION
Issue #82 

**Fichier XML CapiTains 5/5 corrigé** :octocat: 

Nom du fichier: `stoa0044.stoa003.digilibLT-lat1.xml`
Titre de l'oeuvre: _Epitome de Caesaribus_

NB: c'était le dernier fichier de l'issue #8 !

Afin de rendre le document compatible avec CapiTainS, j'ai effectué les corrections suivantes :

- [x] Dans la balise `cRefPattern`, précision de ce que l'on extraie: transformation de "unknown" en "chapters"

- [x] Correction du Xpath

- [x] Ajout de balises `profileDesc,` `langUsage` et `language` pour indiquer la langue du document

- [x] Ajout de balises `revisionDesc` et `change` pour indiquer la date et l'auteur des corrections

- [x] Suppression de la seconde ligne, qui posait des problèmes de validation du fichier

- [x] Déplacement de la balise `</div>` qui produisait une erreur dans le _Passage level parsing_