### PR TITLE
(1/5) Correction du fichier phi996.phi004

### DIFF
--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -80,6 +80,9 @@
             <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
+      <revisionDesc>
+         <change who="Romain Verny" when="2021-04-27">Précision du langage référencé dans le teiHeader et numérotation des paragraphes dans le body</change>
+      </revisionDesc>
 
    </teiHeader>
 

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -88,7 +88,7 @@
 
       <body xml:lang="lat" n="urn:cts:latinLit:phi996.phi004.digilibLT-lat1">
          <div>
-            <p>P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla,
+            <p n="1">P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla,
                patre Vergilio rustico uico Andico, qui abest a Mantua milia passuum XXX, tenui
                facultate nutritus. Sed cum iam summis eloquentiae doctoribus uacaret, in belli
                ciuilis tempora incidit, quod Augustus aduersus Antonium gessit; primumque post
@@ -106,7 +106,7 @@
                <l>Mantua me genuit, Calabri rapuere, tenet nunc</l>
                <l>Parthenope: cecini pascua rura duces.</l>
             </lg>
-            <p>Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non
+            <p n="2">Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non
                edidisset, extaret, quod Seruius Varus hoc testatur epigrammate:</p>
             <lg>
                <l>Iusserat haec rapidis aboleri carmina flammis</l>

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="unknown" matchPattern="(\w+)"
+            <cRefPattern n="paragraph" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
-               <p>This pointer pattern extracts unknown</p>
+               <p>This pointer pattern extracts paragraphs</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>
@@ -81,7 +81,13 @@
          </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change who="Romain Verny" when="2021-04-27">Précision du langage référencé dans le teiHeader et numérotation des paragraphes dans le body</change>
+         <change who="Romain Verny" when="2021-04-27">
+            <list>
+               <item>langUsage : correction du langage référencé ("la" en "lat")</item>
+               <item>body : numérotation des paragraphes</item>
+               <item>cRefpattern : indiquation que le pointer extrait des paragraphes</item>
+            </list>
+         </change>
       </revisionDesc>
 
    </teiHeader>

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="paragraph" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
-               <p>This pointer pattern extracts paragraphs</p>
+            <cRefPattern n="fulltext" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts fulltext</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>
@@ -85,7 +85,7 @@
             <list>
                <item>langUsage : correction du langage référencé ("la" en "lat")</item>
                <item>body : numérotation des paragraphes</item>
-               <item>cRefpattern : indiquation que le pointer extrait des paragraphes</item>
+               <item>cRefpattern : modification du xpath pour extraire l'ensemble du passage principal plutôt que les paragraphes</item>
             </list>
          </change>
       </revisionDesc>

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -77,7 +77,7 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
 

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -27,52 +27,60 @@
          </publicationStmt>
          <sourceDesc>
             <p>
-               <hi rend="italic">Vitae Vergilianae antiquae</hi>, recc. G. Brugnoli et F. Stok, Romae 1997, 193-200.</p>
+               <hi rend="italic">Vitae Vergilianae antiquae</hi>, recc. G. Brugnoli et F. Stok,
+               Romae 1997, 193-200.</p>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS">
+            <cRefPattern n="unknown" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
+               <p>This pointer pattern extracts unknown</p>
+            </cRefPattern>
+         </refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
          </projectDesc>
          <editorialDecl>
-    
+
             <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
             <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-     l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-     e commenti e ogni altro contenuto redatto da editori moderni. </p>
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
             <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-     correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-     distinzione u/v minuscole.</p>
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
             <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
             <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-     grassetto, corsivo, spaziatura espansa.</p>
+               grassetto, corsivo, spaziatura espansa.</p>
             <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-     &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-               <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-     si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-     [...]<lb/> lacuna integrata dagli editori:
-     &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-    </p>
-            <p>Sono stati marcati i termini in lingua greca
-     &lt;foreign xml:lang="grc"&gt;αβγ&lt;/foreign&gt;
-    </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-      [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αβγ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
          </editorialDecl>
-   
+
       </encodingDesc>
       <profileDesc>
          <langUsage>
             <language ident="la">Latino</language>
          </langUsage>
       </profileDesc>
-  
+
    </teiHeader>
 
    <text>
@@ -80,12 +88,26 @@
 
       <body xml:lang="lat" n="urn:cts:latinLit:phi996.phi004.digilibLT-lat1">
          <div>
-            <p>P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla, patre Vergilio rustico uico Andico, qui abest a Mantua milia passuum XXX, tenui facultate nutritus. Sed cum iam summis eloquentiae doctoribus uacaret, in belli ciuilis tempora incidit, quod Augustus aduersus Antonium gessit; primumque post Mutinense bellum ueteranis <supplied>agros cedere coactus</supplied>, postea restitutus beneficio Alpheni Vari Asinii Pollionis et Cornelii Galli, quibus in Bucolicis adulatur, deinde per gratiam Maecenatis in amicitiam Caesaris ductus est. Vixit pluribus annis liberali in otio secutus Epicuri sectam, insigni concordia et familiaritate usus Quintilii Tuccae et Vari. Scripsit Bucolica annos natus octo et XX, Theocritum secutus; Georgica, Hesiodum et Varronem. Aeneida ingressus bello Cantabrico - hoc quoque ingenti industria - ab Augusto usque ad sestertium centies honestatus est. Decessit in Calabria annum agens quinquagesimum et primum heredibus Augusto et Maecenate cum Proculo minore fratre. Cuius sepulcro, quod est in uia Puteolana, hoc legitur epigramma:</p>
+            <p>P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla,
+               patre Vergilio rustico uico Andico, qui abest a Mantua milia passuum XXX, tenui
+               facultate nutritus. Sed cum iam summis eloquentiae doctoribus uacaret, in belli
+               ciuilis tempora incidit, quod Augustus aduersus Antonium gessit; primumque post
+               Mutinense bellum ueteranis <supplied>agros cedere coactus</supplied>, postea
+               restitutus beneficio Alpheni Vari Asinii Pollionis et Cornelii Galli, quibus in
+               Bucolicis adulatur, deinde per gratiam Maecenatis in amicitiam Caesaris ductus est.
+               Vixit pluribus annis liberali in otio secutus Epicuri sectam, insigni concordia et
+               familiaritate usus Quintilii Tuccae et Vari. Scripsit Bucolica annos natus octo et
+               XX, Theocritum secutus; Georgica, Hesiodum et Varronem. Aeneida ingressus bello
+               Cantabrico - hoc quoque ingenti industria - ab Augusto usque ad sestertium centies
+               honestatus est. Decessit in Calabria annum agens quinquagesimum et primum heredibus
+               Augusto et Maecenate cum Proculo minore fratre. Cuius sepulcro, quod est in uia
+               Puteolana, hoc legitur epigramma:</p>
             <lg>
                <l>Mantua me genuit, Calabri rapuere, tenet nunc</l>
                <l>Parthenope: cecini pascua rura duces.</l>
             </lg>
-            <p>Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non edidisset, extaret, quod Seruius Varus hoc testatur epigrammate:</p>
+            <p>Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non
+               edidisset, extaret, quod Seruius Varus hoc testatur epigrammate:</p>
             <lg>
                <l>Iusserat haec rapidis aboleri carmina flammis</l>
                <l>Vergilius, Phrygium quae cecinere ducem.</l>
@@ -93,8 +115,8 @@
                <l>non sinis et Latiae consulis historiae.</l>
             </lg>
          </div>
-   
-   
+
+
       </body>
    </text>
 

--- a/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
+++ b/data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml
@@ -84,7 +84,7 @@
          <change who="Romain Verny" when="2021-04-27">
             <list>
                <item>langUsage : correction du langage référencé ("la" en "lat")</item>
-               <item>body : numérotation des paragraphes</item>
+               <item>body : numérotation artificielle de la div</item>
                <item>cRefpattern : modification du xpath pour extraire l'ensemble du passage principal plutôt que les paragraphes</item>
             </list>
          </change>
@@ -96,8 +96,8 @@
 
 
       <body xml:lang="lat" n="urn:cts:latinLit:phi996.phi004.digilibLT-lat1">
-         <div>
-            <p n="1">P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla,
+         <div n="full">
+            <p>P. Vergilius Maro natus Idibus Octobris Crasso et Pompeio conss. matre Magia Polla,
                patre Vergilio rustico uico Andico, qui abest a Mantua milia passuum XXX, tenui
                facultate nutritus. Sed cum iam summis eloquentiae doctoribus uacaret, in belli
                ciuilis tempora incidit, quod Augustus aduersus Antonium gessit; primumque post
@@ -115,7 +115,7 @@
                <l>Mantua me genuit, Calabri rapuere, tenet nunc</l>
                <l>Parthenope: cecini pascua rura duces.</l>
             </lg>
-            <p n="2">Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non
+            <p>Aeneis seruata ab Augusto, quamuis ipse testamento damnat, ne quid eorum, quae non
                edidisset, extaret, quod Seruius Varus hoc testatur epigrammate:</p>
             <lg>
                <l>Iusserat haec rapidis aboleri carmina flammis</l>


### PR DESCRIPTION
### **Correction du fichier phi996.phi004 correspondant à l'issue #84** 

Pour rappel, le chemin vers le fichier est le suivant :
`data/phi996/phi004/phi996.phi004.digilibLT-lat1.xml`

Corrections effectuées pour rendre le fichier compatible avec CapiTainS :

- [x] `TEI/teiHeader/profileDesc/langUsage` : correction du "la" en "lat" pour indiquer la langue utilisée
- [x] `TEI/text/body/div/p` : numérotation des paragraphes
- [x] `TEI/teiHeader/encodingDesc/refsDecl/cRefPattern` : indication que le pointer extrait des paragraphes