### PR TITLE
(2/5) Correction du fichier stoa0012a.stoa001

### DIFF
--- a/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
     <teiHeader>
         <fileDesc>
@@ -86,6 +85,7 @@
                     <item>profileDes/langUsage/language : correction de l'indicateur de la langue utilisée ("la" en "lat")</item>
                     <item>encodingDesc/RefsDecl/cRefPattern : suppression d'une référence dans le xpath à une div inexistante</item>
                     <item>text/body : numérotation des paragraphes</item>
+                    <item>suppression de la déclaration RNGSchema</item>
                 </list>
             </change>
         </revisionDesc>

--- a/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
@@ -85,6 +85,7 @@
                 <list>
                     <item>profileDes/langUsage/language : correction de l'indicateur de la langue utilisée ("la" en "lat")</item>
                     <item>encodingDesc/RefsDecl/cRefPattern : suppression d'une référence dans le xpath à une div inexistante</item>
+                    <item>text/body : numérotation des paragraphes</item>
                 </list>
             </change>
         </revisionDesc>
@@ -92,13 +93,13 @@
     
     <text>
         <body xml:lang="lat" n="urn:cts:latinLit:stoa0012a.stoa001.digilibLT-lat1">
-            <p>
+            <p n="1">
                 <milestone unit="page" n="p. 20 Thulin"/>
                 <gap/> aduersantur, ne quid in rerum natura finitum esse uideatur. ac si rationis
                 actum uniuersaliter adprehendere<del>t</del> proponimus, ut ab initio quodam ad
                     certa<supplied>m</supplied> finium dispositionem procedit et exigit ornatum,
                 silentio transire nequeo. </p>
-            <p> Si enim uox, quam uaria uerborum significatione<del>m</del> diuidimus, naturalis
+            <p n="2"> Si enim uox, quam uaria uerborum significatione<del>m</del> diuidimus, naturalis
                 est, uerborum significatio naturaliter sui exigit institutionem. ipsa quoque
                 litterarum initia necessariam habent substitutionem. nisi enim constet linearum
                 illam figurationem capere nomen et esse aliquid, itemque similiter certas uocis
@@ -116,7 +117,7 @@
                 animus, alia procul et semotior<supplied>e</supplied> ratione<del>m</del>
                     continet<del>ur</del>; ad quae cognoscenda ne uulgaribus abducamur opinionibus,
                 ratio non deerit.</p>
-            <p>Ac <supplied>si</supplied> instituamus adposita<supplied>s</supplied> disputationes
+            <p n="3">Ac <supplied>si</supplied> instituamus adposita<supplied>s</supplied> disputationes
                 in trac<supplied>ta</supplied>tum aut ordine<del>m</del> persequamur, quam multa
                 praecedunt, quibus ad hanc disputandam materia<supplied>m</supplied> instrui
                 debeamus! tali enim operatione<del>m</del> naturae regimur, ut uniuersa, ad quae
@@ -140,10 +141,10 @@
                 experimenti copia, perferendi quoque suffeceri<del>n</del>t facultas, poterit
                     labor<del>ar</del>i <milestone unit="page" n="p. 22 Thulin"/> nostro non inter
                     minim<supplied>ar</supplied>um utilitatium profectus locus uindicari.</p>
-            <p>Quoniam itaque de controuersiis meminimus agrorum, hae quot partibus dividantur et in
+            <p n="4">Quoniam itaque de controuersiis meminimus agrorum, hae quot partibus dividantur et in
                 quot genera possessionum aut quas habea<supplied>n</supplied>t qualitates,
                 tractemus.</p>
-            <p>Quom autem quaerendum uideatur, quid sit ager et ubi sit, ad ordinem mundi partesque
+            <p n="5">Quom autem quaerendum uideatur, quid sit ager et ubi sit, ad ordinem mundi partesque
                 reuocamur. mundus autem, uti<del>n</del> stoici decer<supplied>n</supplied>unt, unus
                 esse intelligitur: sed qualis quantus, geometricis spectaminibus aperitur. eo enim
                 elementorum natura terrae aequilibratur. huius terrae pars die<del>i</del> fulget,
@@ -169,14 +170,14 @@
                     Lib<supplied>ya Nilus. ex his argument</supplied>aliter inclinamentorum condicio
                     cognoscet<supplied>ur</supplied>, intra quae ager imperii Romani spatioso fine
                 diffunditur, cuius controuersias generaliter exsequi proposuimus.</p>
-            <p>
+            <p n="6">
                 <milestone unit="page" n="p. 23 Thulin"/> Ager est <unclear/>finiruris <gap/> non
                 praetermittimus nomina consent<supplied>i</supplied>entia condicionibus
                 possessionum.</p>
-            <p>Prima enim condicio possidendi haec extat per Italiam; ubi nullus a<del>iu</del>ger
+            <p n="7">Prima enim condicio possidendi haec extat per Italiam; ubi nullus a<del>iu</del>ger
                 est tributarius, sed aut colonicus aut municipalis, aut alicuius castelli aut
                 conciliabuli, aut saltus priuati.</p>
-            <p>At si ad prouincias respiciamus, habent agros colonici quidem iuris, <del>habent et
+            <p n="8">At si ad prouincias respiciamus, habent agros colonici quidem iuris, <del>habent et
                     colonicos stipendiarii</del> qui sunt in<del>com</del>munes, habent<del>em</del>
                 et coloni<supplied>co</supplied>s stipendiarios. habent autem prouinciae et
                 municipales agros aut ciuitatium peregrinarum. Et stipendiarios, qui nexum non
@@ -190,17 +191,17 @@
                 inmunibus et priuatis <milestone unit="page" n="p. 24 Thulin"/> solent euenire.
                 uidebimus tamen an interdicere quis possit, hoc est ad interdictum prouocare, de
                 eius modi possessione<del>m</del>.</p>
-            <p>Multa enim et uaria incidunt, quae ad ius ordinarium pertinent, per prouinciarum
+            <p n="9">Multa enim et uaria incidunt, quae ad ius ordinarium pertinent, per prouinciarum
                 diuersitatem. nam cum in Italia ad aquam pluuiam arcendam controuersia<del>m</del>
                 non minima concitetur, diuerse in Africa ex eadem re tractatur. quom sit enim regio
                 aridissima, nihil magis in querella habe<supplied>n</supplied>t quam siquis
                 inhibuerit aquam pluuiam in suum influere: nam et ag<supplied>g</supplied>eres
                 faciunt <supplied>et</supplied> excipiunt et continent eam, ut ibi potius consumatur
                 quam abfluat.</p>
-            <p>In omnibus his tamen agris superius nominatis quot genera controuersiarum
+            <p n="10">In omnibus his tamen agris superius nominatis quot genera controuersiarum
                 exerceantur, tractare incipiamus. nam et qualia sint et quot status habeant
                 generales, diligenter intueri debemus.</p>
-            <p>Etenim ad artificium defendendi plurimum prode erit, si persecuti <del>hu</del>ius
+            <p n="11">Etenim ad artificium defendendi plurimum prode erit, si persecuti <del>hu</del>ius
                     omni<del>s</del> diligentia fuerimus. non enim a qualibet parte<del>m</del>
                 adgrediendum est in controuersia<del>m</del> sed dispiciendum, cui postulationi
                 absolutio proxima sit, ne inplicatione<del>m</del> aliqua et iudicem inpediamus et
@@ -212,7 +213,7 @@
                 ab exiguo quid<supplied>em</supplied> exemplo secund<supplied>um loc</supplied>orum
                     natura<supplied>m</supplied> colligere possint, quid potissimum sequi
                     debea<supplied>n</supplied>t. </p>
-            <p>
+            <p n="12">
                 <milestone unit="page" n="p. 25 Thulin"/>Quamquam non ignorem,
                     in<supplied>ter</supplied> professores inmodice coutrouersiarum
                     quaestione<supplied>m</supplied> frequenter agitata<supplied>m</supplied>,
@@ -227,7 +228,7 @@
                 aliis artibus et priuatae disputationis exigit cu<supplied>ra</supplied>m.
                     qua<supplied>m</supplied> ita capere ac persequi poterimus, si anticipalia
                 quoque, quibus init<supplied>i</supplied>a substituuntur, non praetermiserimus.</p>
-            <p>Omnium igitur honestarum artium, quae siue naturaliter aguntur siue
+            <p n="13">Omnium igitur honestarum artium, quae siue naturaliter aguntur siue
                     a<supplied>d</supplied> naturae imitationem proferuntur, materiam optinet
                 rationis artificium geometria, principio ardua ac difficilis incessu, delectabilis
                 ordine, plena praestantiae, effectu insuperabilis. manifestis enim
@@ -245,11 +246,11 @@
                     opinione<del>m</del> et ad intellectum sui nisi quos ad naturalem philosophiam
                     proue<supplied>h</supplied>at admitti<supplied>t</supplied>. <gap/>
             </p>
-            <p>Prius quam de transcendentia controuersiarum tractare incipiam, status earum
+            <p n="14">Prius quam de transcendentia controuersiarum tractare incipiam, status earum
                 exponendos existimo, quoniam in priore<del>m</del> parte<del>m</del> libri
                 sequentium rerum ordo absolute de his disputari inhibuit. reddendum itaque hic locum
                 tam necessariis partibus existimo.</p>
-            <p>Omne genus controuersiarum ex quadam materiali bipertitione generatur. constat autem
+            <p n="15">Omne genus controuersiarum ex quadam materiali bipertitione generatur. constat autem
                 haec bipertitio aut in fine aut in loco, non sine illa controuersia quae de
                 positione terminorum praescribitur. Quem admodum unum extra positum est, quo
                 separato a cetero numero duo primum numera<supplied>n</supplied>tur, in hoc quoque
@@ -263,7 +264,7 @@
                 ex hac materia oriuntur et aut ordine<del>m</del> mensurarum aut partibus iuris ad
                 status generales priuatos reuoca<supplied>n</supplied>tur. namque in ordine
                 coutrouersiarum haec quoque materia li<supplied>ti</supplied>s locum suum optinet. </p>
-            <p>
+            <p n="16">
                 <milestone unit="page" n="p. 27 Thulin"/>De fine subtilior exigitur disputatio, quae
                 a rigore nullo modo distat nisi specie. De quibus est diligentius disputandum:
                 quotiens enim de fine aut de rigore dicimus, non p<del>l</del>usilla quaestio
@@ -273,7 +274,7 @@
                 latitudinis dati sint, an in tantum quinque. uide<del>n</del>tur tamen his, quinque
                 pedum esse latitudinem, ita ut dupondium et semisse<supplied>m</supplied> una
                 quaeque pars agri finem pertinere patiatur.</p>
-            <p>Ergo si corpus habet finis, aliter sentire debemus ac <supplied>si</supplied>
+            <p n="17">Ergo si corpus habet finis, aliter sentire debemus ac <supplied>si</supplied>
                 singularem tantum linea<supplied>m</supplied> intueamur. in omni enim genere
                 disterminationis, cui uel singularis linea interueniat et ex uno duas diuidat
                 partes, ipsius mediae lineae sec<del>u</del>tura singularem habet contemplationem,
@@ -288,7 +289,7 @@
                     distinguit<supplied>ur</supplied> corporale esse decernitur. nunc quem admodum
                 <gap/>
             </p>
-            <p>
+            <p n="18">
                 <supplied>Falsa pro</supplied>positio est, cum controuersia alium habeat statum
                 generalem et alio ad litem deducatur. uera propositio est <milestone unit="page"
                     n="p. 28 Thulin"/> cum per stat<supplied>um</supplied> generalem
@@ -297,7 +298,7 @@
                 reuocatur. ex uero in falsum transcendent<supplied>ia</supplied> fit, cum relicto
                     generali<del>s</del> statu<del>s</del> quolibet alio statu controuersia
                 instruitur.</p>
-            <p>Ex non stante propositione in <del>te</del>stante<supplied>m</supplied> transcendunt
+            <p n="19">Ex non stante propositione in <del>te</del>stante<supplied>m</supplied> transcendunt
                 controuersiae, quotiens loci de quo agitur specialia argumenta nulla existunt, neque
                 ullum finitimae similitudinis mo<supplied>nu</supplied>mentum, sed tantum aboliti
                 finis querella exponitur, et excipiens extantium argumentorum quadam expositione
@@ -313,7 +314,7 @@
                     <supplied>ni</supplied>si ratione defenda<supplied>n</supplied>tur, interibiles
                 fiant; si contra pro ueris habeantur, ut interibilis inprudentia iudicantium
                     fia<del>n</del>t uidelicet finitio.</p>
-            <p>A quocumque autem controuersia<supplied>e</supplied> de agris mouentur, effectus
+            <p n="20">A quocumque autem controuersia<supplied>e</supplied> de agris mouentur, effectus
                 habent aut coniunctiuos aut disiunctiuos aut spectiuos aut
                     expos<del>c</del>it<supplied>iuos</supplied> aut
                     reciperat<supplied>iuos</supplied>. coniunctiuus est effectus, quotiens
@@ -340,7 +341,7 @@
                 terminum rectura dirigit et per incessum definitionis loca quaedam alteri fundo
                 adquirit; aut quotiens solum aufer<del>e</del>t et eius loco reddit<del>us</del>
                 utrique fundo, effectus quasi reciperatiuus existit.</p>
-            <p>Per hos effectus omnium controuersiarum status inuicem habent
+            <p n="21">Per hos effectus omnium controuersiarum status inuicem habent
                     transcendentia<supplied>s</supplied> aut necessarias aut que<del>e</del>untes
                 aut neque<del>e</del>untes, saepe interibiles. cum enim status generalis adsumptiuus
                 primae controuersiae, quae est de positione terminorum, in rigorem aut in finem
@@ -360,45 +361,45 @@
                 secunda <supplied>tertia quarta quom in</supplied> controuersiam quae est loco
                 quinto de modo, status effectiui, transcendunt <gap/>
             </p>
-            <p>
+            <p n="22">
                 <supplied>DE POSITIONE TERMINORVM</supplied>
             </p>
-            <p>
+            <p n="23">
                 <gap/> secundum locorum natura<supplied>m</supplied> mouet causas. Si uero in alio
                 loco terminus translatus est usurpandi finis causa<del>m</del>, numquam non utique
                 locum desicauit: non enim cito quisquam propter exiguam partem terminum mouet. erit
                     inprouidentia<del>m</del> mensoris secundum angulorum finitimorum positionem
                 arbitrari, in quantum sit terminus translatus et qua ratione sit in locum suum
                 restituendus.</p>
-            <p>Facillimum est inperitia<supplied>m</supplied> artificis aliusue retundere non
+            <p n="24">Facillimum est inperitia<supplied>m</supplied> artificis aliusue retundere non
                     putant<supplied>is</supplied> rationem inesse ordini: nam et frequenter
                     <milestone unit="page" n="p. 31 Thulin"/> euenit, ut inperitia mensorum
                     <del>an</del>audacia<supplied>m</supplied> possessoribus praebeat. numquam non
                 concurrentium inter se finium anguli, non tantum recti uerum etiam hebetes aut
                 acuti, habe<del>a</del>nt aliquam rationem; in qua<supplied>m</supplied>, si non
                 dissimulemus, facile quod inperiti turbauerunt artificio restituemus.</p>
-            <p>Haec controuersia moti termini null<supplied>i</supplied>us in se aliae controuersiae
+            <p n="25">Haec controuersia moti termini null<supplied>i</supplied>us in se aliae controuersiae
                 statum recipit: est enim anticipalis et quasi comminatio quaedam litium, declarans
                 aut loci aut modi futura<supplied>m</supplied>
                 controuersia<supplied>m</supplied>.</p>
-            <p>De rigore controuersia est status initialis pertinentis ad
+            <p n="26">De rigore controuersia est status initialis pertinentis ad
                     materia<supplied>m</supplied> operis; nec sine prioris controuersiae
                 comparatione. nam cum de rigore agatur, potest fieri ut ante motus sit terminus:
                 ideoque haec secunda controuersia<del>m</del> prioris quoque controuersiae capax
                 apparet; quamquam et sine prioris controuersiae interuentu<del>m</del> priuatim de
                 rigore controuersia suscitari possit: nec enim omnibus locis agrorum, aut
                 capientibus aut non capientibus, termini ponuntur.</p>
-            <p>Refer<del>en</del>t in quo agro agatur. si limitatus est, aut ordo limitis ordinati
+            <p n="27">Refer<del>en</del>t in quo agro agatur. si limitatus est, aut ordo limitis ordinati
                 desideratur aut subrunciui aut linearis aut interiectiui rigoris incessus. at si in
                 agro arcifinio si<del>n</del>t, qui nulla mensura continetur sed finitur aut
                 montibus aut uiis aut aquarum diuergiis aut notabilibus locorum naturis aut
                 arboribus, quas finium causa agricolae relinquunt et ante missas appellant, aut
                 fossis aut quodam culturae discrimine <gap/>
             </p>
-            <p>
+            <p n="28">
                 <supplied>DE FINE</supplied>
             </p>
-            <p>
+            <p n="29">
                 <gap/>
                 <milestone unit="page" n="p. 32 Thulin"/> agetur. cum enim loci sit tanta iniquitas,
                 et aut praerupta aut abrupta, quae aut ruere aut minui possent, uetus consuetudo est
@@ -409,17 +410,17 @@
                 <supplied>di</supplied>ligentes agricolae propter inpudentium uicinorum
                 consuetudinem parum se tutos credunt, nisi ita fundauerint agros, ut etiam aliquid
                 extra mensurarum ordinem faciant.</p>
-            <p>In superciliis autem maioribus non defuerunt qui ita finem seruari uellent, ut
+            <p n="30">In superciliis autem maioribus non defuerunt qui ita finem seruari uellent, ut
                 quatenus attingere unus quisque possessor posset, eatenus<del>u</del>
                     possidere<supplied>t</supplied>. uidebimus an aliquam rationem sint secuti, cum
                 sit totum supercilium superioris agri fundamentum nec, si subruatur, possit sine
                 iniuria superioris fieri. ideoque magis certior ratio illa uidetur, ut fundamento
                 tenus in agro arcifinio possessio seruari debeat, si termini desint.</p>
-            <p>Frequenter inter se possessores propter loci difficultatem totum supercilium, quod
+            <p n="31">Frequenter inter se possessores propter loci difficultatem totum supercilium, quod
                     ange<supplied>re</supplied>ntur ipso subiacente, inferioribus cesserunt, et
                 contenti fuerunt terminos per summum iugum disponere, nullam secuti rationem. haec
                 tamen si occurrunt, non quasi noua intueri debebimus.</p>
-            <p>
+            <p n="32">
                 <milestone unit="page" n="p. 33 Thulin"/> Plurimis deinde locis terminos
                 sacrificales non in fine ponunt, sed ubi illud sacrificii potius opportunitas
                 suadet, hoc est loci conmoditas, in quo sacrificium abuti conmode possint. hos
@@ -428,13 +429,13 @@
                 quas defigere terminos sacrificii causa possessores consuerunt. uerum tamen multi
                 non tantum sacrificii sequuntur consuetudinem sed etiam rationem, et ipso fine
                 defigunt: propter quod adimi fides sacrificalibus palis in totum non debet.</p>
-            <p>
+            <p n="33">
                 <gap/>
             </p>
-            <p>
+            <p n="34">
                 <supplied>DE LOCO</supplied>
             </p>
-            <p>
+            <p n="35">
                 <gap/>
                 <unclear/> haberi ordinem legis Mamiliae excessum plurimum, praecipue in
                     ag<supplied>r</supplied>is arcifiniis sed nec minus id adsignatis. cum enim
@@ -447,24 +448,24 @@
                 aut arbiter pronuntiauerint, neque ullum commissum faciat qui
                     sententia<supplied>m</supplied> non sit secutus, quando de alia re iudicem aut
                 arbitrum sumpserint.</p>
-            <p>De <del>hoc</del> loco, si possessio petenti firma est, etiam <milestone unit="page"
+            <p n="36">De <del>hoc</del> loco, si possessio petenti firma est, etiam <milestone unit="page"
                     n="p. 34 Thulin"/> interdicere licet, dum cetera ex interdicto diligenter
                 peraguntur: magna enim alea est litem ad interdictum deducere, cuius est executio
                 perplexissima. si uero possessio minus firma est, mutata formula iure Quiritium peti
                 debet proprietas loci; iudicari praeterea, si locus de quo agitur aut terminis aut
                 arboribus aut aliquo argumento finem aliquem agri declaret et a continuatione soli
                 quasi quibusdam argumentis eximatur.</p>
-            <p>Ne praeterea<supplied>t</supplied> nos, illud etiam tractare debemus, si arbores
+            <p n="37">Ne praeterea<supplied>t</supplied> nos, illud etiam tractare debemus, si arbores
                 finitimas habet et locus est fere siluester, quo in genere est possessio minus
                 firma, ne certetur i<supplied>nter</supplied>dicto. quod si silua caedua sit, post
                 quintum annum parcissume repetatur. qui autem appellent arbores notatas, scire
                 debemus idioma regionis. qui<supplied>dam</supplied> plagatas uocant quas finis
                 declarandi causa denotant, ut in Brittiis, alii in Piceno stigmatas, in aliis
                 regionibus insignes aut notas.</p>
-            <p>Si uero pascua sit et dumi ac loca paene solitudine derelicta, multo minorem
+            <p n="38">Si uero pascua sit et dumi ac loca paene solitudine derelicta, multo minorem
                 possessionis habent fidem. propter quod <supplied>m</supplied>inime de his locis ad
                 interdictum iri debet.</p>
-            <p> De quibus autem locis ad interdictum ire possunt, <supplied>sunt</supplied> fere
+            <p n="39"> De quibus autem locis ad interdictum ire possunt, <supplied>sunt</supplied> fere
                 culta, quae possessionem breuioris temporis testimonio adipiscuntur, ut arua aut
                 uineae aut prata aut aliud aliquod genus culturae. haec tamen cum in demonstratione
                 allegabuntur, etiam si partes qua<supplied>e</supplied>dam proximae et
@@ -473,13 +474,13 @@
                     illa<supplied>s</supplied> sui generis agro adsignare, sed <milestone
                     unit="page" n="p. 35 Thulin"/> circuire oportebit totum fundum et ita fidem
                 obligare, ne demonstratione neglegenter soluta appareat.</p>
-            <p>De modo controuersia <supplied>est</supplied> status effectiui: ante enim locus est
+            <p n="40">De modo controuersia <supplied>est</supplied> status effectiui: ante enim locus est
                 ibi quam modus nominetur: aeque recipiens ante dictarum controuersiarum omnes
                 status, sed ut superius significaui irritos et non necessarios. Haec controuersia
                 frequenter in agris adsignatis exercetur: agitur enim, ut secundum acceptam eius
                     ueter<supplied>an</supplied>i, qui in illud solum deductus est, modus
                 restituatur; aut si quando praescribtus est lege aliqua agri modus.</p>
-            <p>Quom autem in adsignato agro secundum formam modus spectetur, solet tempus inspici et
+            <p n="41">Quom autem in adsignato agro secundum formam modus spectetur, solet tempus inspici et
                 agri cultura<del>e</del>. si iam excessit memoria<del>m</del> abalienationis, solet
                 iuris formula <del>non silenter</del> interuenire et inhibere mensores,
                     <supplied>n</supplied>e tales controuersias concipia<supplied>n</supplied>t,
@@ -492,9 +493,9 @@
                 exceptus sit modus neque adhuc in mensuram redactus, non ideo fide carere debebit,
                 si nostra demonstratio eius in agro non ante finiri potuerit quam de sententia
                     loc<del>ut</del>us sit designatus.</p>
-            <p>
+            <p n="42">
                 <gap/> in hac controuersia, quod i<supplied>n</supplied>ter priuatos tractatur.</p>
-            <p>
+            <p n="43">
                 <milestone unit="page" n="p. 36 Thulin"/> Nam inter res publicas non mediocriter
                 eius modi controuersia solet exerceri, quam frequenter coloniae habent cum
                     coloni<supplied>i</supplied>s aut municipiis aut saltibus Caesaris aut priuatis.
@@ -502,7 +503,7 @@
                 referf, cuius si<del>n</del>t solum aut cuius iuris, ad mouendam controuersiam: tunc
                 autem habe<del>n</del>t differentia<supplied>m</supplied>, prout ab iudice
                 tractatur.</p>
-            <p>Obseruari in hac controuersia <supplied>a</supplied> mensore debebit
+            <p n="44">Obseruari in hac controuersia <supplied>a</supplied> mensore debebit
                     <supplied>l</supplied>ineis, dum in similitudinem dissimile interrueniat;
                 quoniam nulla potest ueritas adprobari, si illi qui<supplied>d</supplied> uel
                 exiguum falsi interueniat. ueritas enim habere debet suam similitudinem per omnia
@@ -523,7 +524,7 @@
                     <supplied>in</supplied> statua <supplied>diu</supplied> multumque mens
                     infri<supplied>n</supplied>genda est, ut similitudo ueritatis animam habere
                     uideat<supplied>ur</supplied>, de cuius simulatione est profecta.</p>
-            <p>
+            <p n="45">
                 <gap/>
                 <supplied>ad lu</supplied>cum Feroniae Augustinorum iugera M. haec in discrimen si
                 uenerunt, omnia supra dicta conuenienter habere debent, ut illa
@@ -545,7 +546,7 @@
                 mille iugera aliis lineamentis describere, conuenient quidem mille iugera, et ad
                 lucum Feroniae esse conueniet, sed specie disconueniente inter peritos manifeste
                 falsum apparebit.</p>
-            <p>Memineram et superius, ut aliquid uerum adprobari possit, minime ei quicquam falsi
+            <p n="46">Memineram et superius, ut aliquid uerum adprobari possit, minime ei quicquam falsi
                 posse interuenire. nam et haec expositio declarat, <supplied>ut</supplied>, quamuis
                 duae consentiant partes, ab una dissentiente uincantur, neque uerum esse possit,
                 nisi illis quoque tertia pars illa consenserit. conuenire autem omnino in
@@ -554,28 +555,28 @@
                     eri<supplied>n</supplied>t, ut frequenter euenit, turbata.
                     <supplied>ea</supplied> docere nos angulorum positiones poterint. sic erit, ut
                 et artis sinceritas seruetur et ordo ueteris adsignationis non praetermittatur.</p>
-            <p>
+            <p n="47">
                 <milestone unit="page" n="p. 39 Thulin"/>De proprietate <del>mundi</del>
                 controuersia est status effectiui: efficitur enim ex omnibus ante dictis
                 controuersiis. sed quarum status in hac propositione inriti habentur, dixi et
                 supra.</p>
-            <p>De proprietate agitur plurimum iure ordinario, neque est hic mensurarum interuentus,
+            <p n="48">De proprietate agitur plurimum iure ordinario, neque est hic mensurarum interuentus,
                 nisi cum quaeritur, quatenus agatur.</p>
-            <p>Proprietas <supplied>non</supplied> uno genere uindicatur.</p>
-            <p>Et sunt plerumque agri, ut in Campania in Suessano, culti, qui habent in monte
+            <p n="49">Proprietas <supplied>non</supplied> uno genere uindicatur.</p>
+            <p n="50">Et sunt plerumque agri, ut in Campania in Suessano, culti, qui habent in monte
                 Massico plagas siluarum determinatas; quarum siluarum proprietas ad quos pertinere
                 debeat uindicatur. nam et formae antiquae declarant ita esse adsignatum, quoniam
                 solo culto nihil fuit siluestre iunctum quod adsignaretur.</p>
-            <p>Relicta sunt et multa loca, quae ueteranis data non sunt. haec uariis appellationibus
+            <p n="51">Relicta sunt et multa loca, quae ueteranis data non sunt. haec uariis appellationibus
                 per regiones nominantur: in Etruria communalia uocantur, quibusdam prouinciis pro
                 iudiuiso. haec fere pascua certis personis data sunt depascenda tunc, cum agri
                 adsignati sunt. haec pascua multi per <supplied>in</supplied>potentiam inuaserunt et
                 colunt: et de eorum proprietate solet ius ordinarium moueri non sine interuentu
                 mensurarum, quoniam demonstrandum est, quatenus sit adsignatus ager.</p>
-            <p>Nam per emptiones quasdam solet proprietas quarundam possessionum ad
+            <p n="52">Nam per emptiones quasdam solet proprietas quarundam possessionum ad
                     <supplied>priuatas</supplied> personas pertinere. quae iure magis ordinario quam
                 mensuris explicantur. </p>
-            <p>
+            <p n="53">
                 <milestone unit="page" n="p. 40 Thulin"/> Nunc ut ad publicas personas respiciamus,
                 coloniae quoque loca quaedam habent adsignata in alienis finibus, quae loca solemus
                 praefecturas appellare. harum praefecturarum proprietas manifeste ad colonos
@@ -584,22 +585,22 @@
                 acceperint. quorum proprietas indubitate ad eos pertinet, quibus est adsignata. alia
                 beneficia etiam quaedam municipia acceperunt et priuatae personae quae de
                 principibus illis temporibus bene meruerunt.</p>
-            <p>In hac controuersia plus potestatis habet ius ordinarium quam ars mensoria. ab eo
+            <p n="54">In hac controuersia plus potestatis habet ius ordinarium quam ars mensoria. ab eo
                 enim statu lis incipit, <supplied>ut</supplied> de proprietate agatur, non de loco:
                 mensura autem nihil amplius quam secundum formam locum declarat. in hac autem
                 controuersia ars mensurarum locum secundum habet, quoniam prius alii uacandum est,
                 an agenda sit mensura.</p>
-            <p>De possessione controuersia est <supplied>status</supplied>
+            <p n="55">De possessione controuersia est <supplied>status</supplied>
                     effect<supplied>i</supplied>ui, quoniam primum possessio tempore efficitur,
                 deinde, ut ad solum respiciamus, omnes ante dictas controuersias capit: si enim
                 solum cogitemus, ut legitima possessio inpleri possit,
                 indubi<supplied>ta</supplied>te locus definiatur necesse est. et de hac controuersia
                 plurimum interdicti formula litigatur. de qua et in superiore parte meminimus:
                 ideoque non puto eam iterum retractandam.</p>
-            <p>De subsiciuis controuersia est status effectiui, quoniam subsiciua nominari aut
+            <p n="56">De subsiciuis controuersia est status effectiui, quoniam subsiciua nominari aut
                 sentiri sine quadam loci latitudine<del>m</del> aut modo non possunt. ideoque
                 manifeste apparet supra dictarum controuersiarum status in <gap/> locum.</p>
-            <p>
+            <p n="57">
                 <milestone unit="page" n="p. 41 Thulin"/> Subsiciuorum autem genera sunt duo; unum
                 quod extremis adsignatorum agrorum finibus centuria<del>ru</del>m non explet. aliud
                 etiam integris centuriis interuenit. de quo maximae controuersiae agitantur. cum
@@ -620,10 +621,10 @@
                 intermisit, non concessit. aeque et Titus imp. aliqua subsiciua in Italia
                 recollegit. praestantissimus postea Domitianus ad hoc beneficium procurrit et uno
                 edicto totius Italiae metum liberauit. </p>
-            <p>
+            <p n="58">
                 <milestone unit="page" n="p. 42 Thulin"/>Haec controuersia numquam a priuatis
                 exercetur.</p>
-            <p>De alluuione controuersia est status effectiui: efficitur enim subinde et per tempora
+            <p n="59">De alluuione controuersia est status effectiui: efficitur enim subinde et per tempora
                 mutatur. in hac controuersia plurimum sibi uindicat ius ordinarium. agitur enim de
                 eo solo quod alluat flumen, et subtiles intro ducuntur quaestiones, an ad eum
                 pertinere debeat, cui in altera ripa recedente aqua solum creuit; hic qui aliquid
@@ -634,7 +635,7 @@
                 habere, quod hic forte cultum et pingue solum amiserit, apud illum autem harenae,
                 lapides et limum abluuio inuectum remanserit. illud praeterea, quod finem illis
                 semper aqua fecerit et nunc quoque facere debeat.</p>
-            <p>Sunt et multa, de quibus subtiliter tractatur: sed nec uno tantum genere per
+            <p n="60">Sunt et multa, de quibus subtiliter tractatur: sed nec uno tantum genere per
                 alluuionem flumina possessoribus iniurias faciunt. sicut Padus relicto alueo suo per
                 cuiuslibet fundum medium inrumpit et facit insulam inter nouum et ueterem alueum.
                 ideo de hac re tractatur, ad quem pertinere debeat illud quod reliquerit, cum
@@ -646,10 +647,10 @@
                 quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis
                 contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum
                 regelationum repentina<del>s</del> inundatione<del>s</del> patitur iniurias. </p>
-            <p>Quaeritur tamen, qualia quanta sint flumina, in quibus alluuio obseruari debeat. nam
+            <p n="61">Quaeritur tamen, qualia quanta sint flumina, in quibus alluuio obseruari debeat. nam
                 et iure continetur, nequis ripam suam in iniuria<supplied>m</supplied> uicini munire
                 uelit.</p>
-            <p>Multa flumina et non mediocria in adsignationem mensurae antiquae ceciderunt: nam et
+            <p n="62">Multa flumina et non mediocria in adsignationem mensurae antiquae ceciderunt: nam et
                 deductarum coloniarum formae indicant, ut multis fluminibus nulla latitudo sit
                 relicta. sequitur in his fluminibus artem mensoriam aliquem locum sibi uindicare,
                 quando exacto limite accepta finiatur, qua<del>e</del> uel
@@ -661,7 +662,7 @@
                 in his agris exigitur fere mensura secundum <milestone unit="page" n="p. 44 Thulin"
                 /> postulationem aeris formarumque. quo pertica cecidit, eatenus acceptae
                 designantur.</p>
-            <p>Videbimus an inter mensores et iuris peritos esse de hoc quaestio debeat,
+            <p n="63">Videbimus an inter mensores et iuris peritos esse de hoc quaestio debeat,
                     cursu<del>m</del> an pertica metiam<supplied>ur</supplied>, si qua usque potuit
                 ueteranis est adsignatum. scio in Lusitania, finibus Emeritensium, non exiguum per
                 mediam coloniae perticam ire flumen Anam, circa quod agri sunt adsignati qua usque
@@ -676,7 +677,7 @@
                 emeret aut sterilia quae alluebat: modus itaque flumi<supplied>ni</supplied> est
                 constitutus. hoc exempli causa re<del>i</del>gerendum existimaui. nam et in Italia
                 Pisauro flumiui latitudo est adsignata eatenus, qua usque adlauabat.</p>
-            <p>De iure territorii controuersia est status iniectiui. inicitur enim solo quaedam
+            <p n="64">De iure territorii controuersia est status iniectiui. inicitur enim solo quaedam
                 controuersia e persona: tum praecipue qui<supplied>d</supplied>quid est illud de quo
                 agitur, aut locus aut modus, <milestone unit="page" n="p. 45 Thulin"/> generalem
                 statum <supplied>a</supplied> iure ordinario trahit, etiam si multis locis
@@ -690,7 +691,7 @@
                 essent alienigenae, qui intra territorium colerent, <del>alii h</del>omnibus
                     <del>h</del>oneribus fungi in colonia<del>m</del> deberent. hoc Fanestres nuper
                 inpetrauerunt, Tudertini autem beneficio habent conditoris.</p>
-            <p>Inter res p. et priuatos non facile tales in Italia controuersiae mouentur, sed
+            <p n="65">Inter res p. et priuatos non facile tales in Italia controuersiae mouentur, sed
                 frequenter in prouinciis, praecipue in Africa, ubi saltus non minores habent priuati
                 quam res p. territoria: quin immo multi saltus longe maiores sunt territoriis:
                 habent autem in saltibus priuati<del>s</del> non exiguum populum plebeium et uicos
@@ -704,29 +705,29 @@
                 locis quae loca res p. adserere conantur. eius modi lites non tantum cum priuatis
                 hominibus habent, sed et plerumque cum Caesare, <supplied>qui</supplied> in
                 prouincia non exiguum possidet.</p>
-            <p>Non est dubium necessarias esse mensuras in eius modi controuersia,
+            <p n="66">Non est dubium necessarias esse mensuras in eius modi controuersia,
                     <supplied>quae</supplied> quamuis alio nomine appellatur, locorum tamen facit
                 quaestionem.</p>
-            <p>De locis publicis controuersia est aeque status iniectiui. sunt autem loca publica
+            <p n="67">De locis publicis controuersia est aeque status iniectiui. sunt autem loca publica
                 complura, sed ex his quaedam loca priuata<supplied>m</supplied> exigunt defensionem:
                 et quamuis haec loca diuersis appellationibus contineantur, unam tamen habent
                 controuersiae condicionem.</p>
-            <p>Sunt autem loca publica haec, quae inscribuntur ut SILVAE ET PASCVA PVBLICA
+            <p n="68">Sunt autem loca publica haec, quae inscribuntur ut SILVAE ET PASCVA PVBLICA
                 AVGVSTINORVM. haec uidentur nominibus data; quae etiam uendere possunt.</p>
-            <p>Est alia inscriptio, qua<supplied>e</supplied> diuersa
+            <p n="69">Est alia inscriptio, qua<supplied>e</supplied> diuersa
                     significatio<supplied>ne</supplied> uidetur esse, in quo loco inscribitur SILVA
                 ET PASCVA; aut FVNDVS SEPTICIANVS COLONIAE AVGVSTAE CONCORDIAE. haec inscriptio
                 uidetur ad personam coloniae ipsius pertinere <supplied>ne</supplied>que ullo modo
                     ab<supplied>a</supplied>lienari posse a re<del>i</del> publica<del>e</del>. item
                 siquid in tutelam aut templorum publicorum aut balneorum adiungitur.</p>
-            <p>
+            <p n="70">
                 <milestone unit="page" n="p. 47 Thulin"/> Habent et res p. loca suburbana inopum
                 funeribus destinata, quae loca culinas appellant. habent et loca noxiorum poenis
                 destinata. ex his locis, cum sint suburbana, sine ulla religionis reuerentia solent
                 priuati aliquid usurpare et hortis suis adplicare. de his locis, si r. p. formas
                 habet, cum coutrouersia mota est, ad modum <supplied>mensor</supplied> locum
                 restituit: sin autem, utitur testimoniis et quibuscumque potest argumentis.</p>
-            <p>De locis relictis et extra clusis controuersia est status iniectiui: manifestum est
+            <p n="71">De locis relictis et extra clusis controuersia est status iniectiui: manifestum est
                 enim de loco agi, sed per aliam personam. loca autem relicta et extra clusa non sunt
                 nisi in finibus coloniarum, ubi adsignatio peruenit usque qua cultum fuit, quatenus
                     ordinatio<supplied>ne</supplied> centuriarum intermissa finitur. ultra autem
@@ -736,27 +737,27 @@
                 extra limitum ordinationem sint et tamen fine cludantur. haec plerumque proximi
                 possessores inuadunt et opportunitate loci inuitati agrum optinent. cum his
                 controuersiae a rebus publicis solent moueri.</p>
-            <p>De locis sacris et religiosis controuersia est aeque status iniectiui: agitur enim de
+            <p n="72">De locis sacris et religiosis controuersia est aeque status iniectiui: agitur enim de
                 locis, sed cum aut sacra aut religiosa nominentur, statum generalem a iure ordinario
                 accipiunt. <milestone unit="page" n="p. 48 Thulin"/> primum enim quaeritur, an ea
                 loca ullo modo usu capi possint: deinde, quatenus possint, secundum locum habent
                 mensurae.</p>
-            <p>Locorum autem sacrorum secundum legem populi Rom. magna religio et custodia haberi
+            <p n="73">Locorum autem sacrorum secundum legem populi Rom. magna religio et custodia haberi
                 debet: nihil enim magis in mandatis etiam legati prouinciarum accipere solent, quam
                 ut haec loca quae sacra sunt custodiantur. hoc facilius in prouinciis seruatur: in
                 Italia autem densitas possessorum multum inprobe facit, et lucos sacros occupant,
                 quorum solum indubitate p. R. est, etiam si in finibus coloniarum aut municipiorum.
                 de his solet quaestio non exigua moueri inter r. p. et priuatos.</p>
-            <p>Sed et inter res publicas frequenter eius modi contentio agitatur de his locis, in
+            <p n="74">Sed et inter res publicas frequenter eius modi contentio agitatur de his locis, in
                 quibus conuentus fiunt maiores et aliquod genus uectigalis exigitur.</p>
-            <p>Nam et de aedibus sacris, quae constitutae sunt in agris, mutata tantum persona
+            <p n="75">Nam et de aedibus sacris, quae constitutae sunt in agris, mutata tantum persona
                 similes tamen oriuntur quaestiones; sicut in Africa inter Adrumentinos et
                 Tysdritanos de aede Mineruae, de qua iam multis annis litigant.</p>
-            <p>Sunt et loca sacra, quae re uera priuatis finibus rei p. col<supplied>on</supplied>i
+            <p n="76">Sunt et loca sacra, quae re uera priuatis finibus rei p. col<supplied>on</supplied>i
                 debent. haec plerumque interuentu longae obliuionis casu a priuatis optinentur,
                 quamquam in tabulariis formae eorum plurimae extent. haec maxime aut in loco urbis
                 aut suburbanis locis a priuatis detinentur.</p>
-            <p>De aqua pluuia arcenda controuersia est status iniectiui: per quodcumque enim solum
+            <p n="77">De aqua pluuia arcenda controuersia est status iniectiui: per quodcumque enim solum
                 transit, ad ius ordinarium magis respicit condicio eius quam ad mensuras; nisi si
                     <milestone unit="page" n="p. 49 Thulin"/> per extremitatem finis uadat: propter
                 quod statum generalem etiam alium accersire debet et quasi geminatione quadam
@@ -765,21 +766,21 @@
                 respicit condicione<supplied>m</supplied>. in Italia aut quibusdam prouinciis non
                 exigua est iniuria, si in alienum agrum aquam inmittas; in prouincia autem Africa,
                 si transire non patiaris.</p>
-            <p>Eiusdem condicionis est controuersia de cloacis ducendis et
+            <p n="78">Eiusdem condicionis est controuersia de cloacis ducendis et
                 fos<supplied>s</supplied>is caecis. quod totum, nisi per finem agatur, ad ius
                 ordinarium pertinet.</p>
-            <p>De itineribus controuersia est status iniectiui: inicitur enim loco quaestio, et
+            <p n="79">De itineribus controuersia est status iniectiui: inicitur enim loco quaestio, et
                 defenditur populo quod forte a priuatis possidetur. haec quaestio multipliciter
                 tractatur.</p>
-            <p>Nam in agris ceuturiatis excipitur limitum latitudo causa itineris. sed cum illi
+            <p n="80">Nam in agris ceuturiatis excipitur limitum latitudo causa itineris. sed cum illi
                 recturas suas per qualiacumque loca extendant, hoc est qua ratio dictauit, per
                 cliuia et montuosa, qua iter nullo modo fieri potest, quae loca fortasse possessori
                 siluae causa sint utilia, horum loco non inique, per quae possit loca commode iri,
                 iter commutant.</p>
-            <p>Nam quae sit condicio itinerum, non exigua iuris tractatio est. agitur enim, utrumne
+            <p n="81">Nam quae sit condicio itinerum, non exigua iuris tractatio est. agitur enim, utrumne
                     actu<supplied>s</supplied> sit an i<del>n</del>ter <supplied>an</supplied>
                 ambitus. per quae loca quid liceat populo, iure continetur.</p>
-            <p>Satis, ut puto, dilucide genera contronersiarum exposui: nam et simplicius enarrare
+            <p n="82">Satis, ut puto, dilucide genera contronersiarum exposui: nam et simplicius enarrare
                 condiciones earum existimaui, quo facilius ad intellectum peruenirent. nunc quem
                 admodum singulae <milestone unit="page" n="p. 50 Thulin"/> tractari debeant
                 persequendum est. respicio enim quantum sit quod mensori iniungatur, et puto

--- a/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
@@ -33,9 +33,9 @@
         </fileDesc>
         <encodingDesc>
             <refsDecl n="CTS">
-                <cRefPattern n="unknown" matchPattern="(\w+)"
-                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
-                    <p>This pointer pattern extracts unknown</p>
+                <cRefPattern n="paragraphs" matchPattern="(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:p[@n='$1'])">
+                    <p>This pointer pattern extracts paragraphs</p>
                 </cRefPattern>
             </refsDecl>
             <projectDesc>
@@ -84,6 +84,7 @@
             <change who="Romain Verny" when="2021-04-28">
                 <list>
                     <item>profileDes/langUsage/language : correction de l'indicateur de la langue utilisée ("la" en "lat")</item>
+                    <item>encodingDesc/RefsDecl/cRefPattern : suppression d'une référence dans le xpath à une div inexistante</item>
                 </list>
             </change>
         </revisionDesc>

--- a/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
@@ -77,13 +77,13 @@
         </encodingDesc>
         <profileDesc>
             <langUsage>
-                <language ident="la">Latino</language>
+                <language ident="lat">Latino</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="Romain Verny" when="2021-04-28">
                 <list>
-                    <item></item>
+                    <item>profileDes/langUsage/language : correction de l'indicateur de la langue utilisée ("la" en "lat")</item>
                 </list>
             </change>
         </revisionDesc>

--- a/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml
@@ -1,199 +1,804 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-      <fileDesc>
-         <titleStmt>
-            <title>De controuersiis agrorum</title>
-            <author>Agennius Vrbicus</author>
-            <respStmt>
-               <resp>Correzione linguistica</resp>
-               <name>David Paniagua</name>
-            </respStmt>
-            <respStmt>
-               <resp>Codifica XML</resp>
-               <name>David Paniagua</name>
-            </respStmt>
-         </titleStmt>
-         <publicationStmt>
-            <publisher>digilibLT</publisher>
-            <pubPlace>Vercelli</pubPlace>
-            <date>2011</date>
-            <availability>
-               <p>
-                  <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
-               </p>
-            </availability>
-            <idno>dlt000001</idno>
-         </publicationStmt>
-         <sourceDesc>
-            <p>Corpus agrimensorum Romanorum recensuit Carolus Thulin. vol. I fasc. I Opuscula agrimensorum ueterum, Lipsiae in aedibus B. G. Teubneri, 1913.</p>
-         </sourceDesc>
-      </fileDesc>
-      <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
-         <projectDesc>
-            <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
-         </projectDesc>
-         <editorialDecl>
-                
-            <p>
-               <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
-            </p>
-            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-          l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-          e commenti e ogni altro contenuto redatto da editori moderni. </p>
-            <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-          correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-          distinzione u/v minuscole.</p>
-            <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-          grassetto, corsivo, spaziatura espansa.</p>
-            <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-          &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-               <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-          si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-          [...]<lb/> lacuna integrata dagli editori:
-          &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-        </p>
-            <p>Sono stati marcati i termini in lingua greca
-          &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-        </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-          [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
-            </p>
-         </editorialDecl>
-          </encodingDesc>
-      <profileDesc>
-         <langUsage>
-            <language ident="la">Latino</language>
-         </langUsage>
-      </profileDesc>
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>De controuersiis agrorum</title>
+                <author>Agennius Vrbicus</author>
+                <respStmt>
+                    <resp>Correzione linguistica</resp>
+                    <name>David Paniagua</name>
+                </respStmt>
+                <respStmt>
+                    <resp>Codifica XML</resp>
+                    <name>David Paniagua</name>
+                </respStmt>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>digilibLT</publisher>
+                <pubPlace>Vercelli</pubPlace>
+                <date>2011</date>
+                <availability>
+                    <p>
+                        <ref target="http://creativecommons.org/licenses/by-nc-sa/3.0/it/"/>
+                    </p>
+                </availability>
+                <idno>dlt000001</idno>
+            </publicationStmt>
+            <sourceDesc>
+                <p>Corpus agrimensorum Romanorum recensuit Carolus Thulin. vol. I fasc. I Opuscula
+                    agrimensorum ueterum, Lipsiae in aedibus B. G. Teubneri, 1913.</p>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <refsDecl n="CTS">
+                <cRefPattern n="unknown" matchPattern="(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
+                    <p>This pointer pattern extracts unknown</p>
+                </cRefPattern>
+            </refsDecl>
+            <projectDesc>
+                <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
+                <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+                    Lana</p>
+            </projectDesc>
+            <editorialDecl>
+
+                <p>
+                    <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
+                </p>
+                <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non
+                    seguendone l'impaginazione. Sono stati invece esclusi dalla digitalizzazione
+                    apparati, introduzioni, note e commenti e ogni altro contenuto redatto da
+                    editori moderni. </p>
+                <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la
+                    massima correttezza di trascrizione</p>
+                <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di
+                    riferimento per la distinzione u/v minuscole.</p>
+                <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+                <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic"
+                        >corpus</hi>: grassetto, corsivo, spaziatura espansa.</p>
+                <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/>
+                    espunzioni: &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/>
+                    integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+                    <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+                    &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+                    &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+                    &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+                <p>Sono stati marcati i termini in lingua greca &lt;foreign
+                    xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+                <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                        target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                        >Note di trascrizione e codifica di testi latini tardoantichi
+                        [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+                </p>
+            </editorialDecl>
+        </encodingDesc>
+        <profileDesc>
+            <langUsage>
+                <language ident="la">Latino</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="Romain Verny" when="2021-04-28">
+                <list>
+                    <item></item>
+                </list>
+            </change>
+        </revisionDesc>
+    </teiHeader>
     
-  </teiHeader>
-  <text>
-      <body xml:lang="lat" n="urn:cts:latinLit:stoa0012a.stoa001.digilibLT-lat1">
-         <p>
-            <milestone unit="page" n="p. 20 Thulin"/> 
-            <gap/> aduersantur, ne quid in rerum natura finitum esse uideatur. ac si rationis actum uniuersaliter adprehendere<del>t</del> proponimus, ut ab initio quodam ad certa<supplied>m</supplied> finium dispositionem procedit et exigit ornatum, silentio transire nequeo.
-       </p>
-         <p> Si enim uox, quam uaria uerborum significatione<del>m</del> diuidimus, naturalis est, uerborum significatio naturaliter sui exigit institutionem. ipsa quoque litterarum initia necessariam habent substitutionem. nisi enim constet linearum illam figurationem capere nomen et esse aliquid, itemque similiter certas uocis distinctiones certa significatione seruari, numquam scripturae ullius ordo ad notitiam mentis admittetur. et si ad numeros respiciamus et non putemus esse unum neque duo pluraue, <supplied>et</supplied> a primo ad secundum tertiumque distantias non substituamus, nullius ordinis modo <supplied>numero</supplied>rum rationalium gradus distinguamus. et quid pluribus fatigamur exemplis? si ad rationem <milestone unit="page" n="p. 21 Thulin"/> homo pertinet, et rationis nexus humana tangitur prouidentia, ad quam puta<del>n</del>tur peruenire ne quidem institutus quisquam mortalium potuisse, de contrario falsa persuasione decipimur, et naturaliter inesse nobis etiam sapientiam credimus. custos est disciplina, nisi fallor, infantia<supplied>e</supplied>: quae cum ita naturalia ad notitiam mentis admittit<del>ur</del>, <del>a</del>ut sint, in quae dirigi possi<del>n</del>t animus, alia procul et semotior<supplied>e</supplied> ratione<del>m</del> continet<del>ur</del>; ad quae cognoscenda ne uulgaribus abducamur opinionibus, ratio non deerit.</p>
-        <p>Ac <supplied>si</supplied> instituamus adposita<supplied>s</supplied> disputationes in trac<supplied>ta</supplied>tum aut ordine<del>m</del> persequamur, quam multa praecedunt, quibus ad hanc disputandam materia<supplied>m</supplied> instrui debeamus! tali enim operatione<del>m</del> naturae regimur, ut uniuersa, ad quae pertinemus aut quae ad nos pertinent, sensibus nostris uelut confusa offerantur- ipsa<del>quo</del>que animi<supplied>s</supplied> didicerimus dinoscere. quid quod id ipsum, quod quid est a<supplied>ut</supplied> quale, prius qua<supplied>da</supplied>m in parte uidemus, nec statim totam partis proprietatem cernimus, nisi in singulas portiones auocatum undique uisum direximus, ut relicta magnitudinis occupatione paulatim ad notitiam rei animus inducatur. eadem ratione etiam ceterae intellectus qualitates tenentur. per quas <supplied>ad</supplied> aliud opus festinantibus satis dilucida existit probatio, capacitatem rerum generi humano esse concessam, quarum multitudine<del>m</del> oneramur. at in uniuersa distringimur, ut ad certa et electa nisi elaborato studiorum iudicio peruenire nequeamus. ut enim nec ferrum <supplied>in</supplied> genere secare potest, nisi ad secandum habilem acceperit figuram, sic animus naturalium capax rerum, nisi certo disciplinae ordine<del>m</del> a<supplied>di</supplied>utus, subtilioribus indiget argumentis. quam ob rem interpraecipua honestarum amore artium conpun<supplied>g</supplied>ere animum et bonae mentis instrumentis fundare debemus. si quidem secundum cognitas mihi artes huius partis si<del>n</del>t aut experimenti copia, perferendi quoque suffeceri<del>n</del>t facultas, poterit labor<del>ar</del>i <milestone unit="page" n="p. 22 Thulin"/> nostro non inter minim<supplied>ar</supplied>um utilitatium profectus locus uindicari.</p>
-        <p>Quoniam itaque de controuersiis meminimus agrorum, hae quot partibus dividantur et in quot genera possessionum aut quas habea<supplied>n</supplied>t qualitates, tractemus.</p>
-        <p>Quom autem quaerendum uideatur, quid sit ager et ubi sit, ad ordinem mundi partesque reuocamur. mundus autem, uti<del>n</del> stoici decer<supplied>n</supplied>unt, unus esse intelligitur: sed qualis quantus, geometricis spectaminibus aperitur. eo enim elementorum natura terrae aequilibratur. huius terrae pars die<del>i</del> fulget, pars nocte fuscatur. diuiditur, ut supra diximus, in quattuor partes. quarum una inter Atlanticum et e<supplied>o</supplied>um mare meridiano ac septentrionali clauditur Oceano, habitabilis atque cognita: appellatur a Graecis oecumene. reliqu<supplied>ae ig</supplied>itur habitabilis ratione colliguntur. contraria autem pars parti <supplied>isti</supplied> finitur Oceano Atlantico atque eoo et inter meridianum et australem cohibetur Oceanum: appellatur ant<supplied>o</supplied>ecumene. post Oceanum septentrionalem atque australem duae terreni partes meridiano diffinduntur Oceano: quarum Graeci austro prop<del>r</del>iorem antictonon appellauerunt; alteram prop<del>r</del>iorem septentrioni antipodon, quoniam emisperiou aliud latus optinet et ad rationem habitabilis <supplied>t</supplied>etartemorii contrariis ambulantium gressibus premit<del>tit</del>ur. <supplied>o</supplied>ecumene autem, hoc est habitabilis et cognita terreni portio, ad notitiam spatiorum incrementis redigitur umbrarum. huius latitudinem definit orientis occidentisque dimensio, altitudine<supplied>m</supplied> septentrionalis facit kardo: intra haec spatia termina<del>n</del>tur utroque Oceano. tripertita regionum diuisione<del>m</del> distinguitur, Europa Libya atque Asia. Europam a Libya Gallicum Tyr<supplied>r</supplied>enum Egeum, hoc est intestinum, mare diuidit, Asia<supplied>m</supplied> ab Europa <supplied>Ta</supplied>nais, a Lib<supplied>ya Nilus. ex his argument</supplied>aliter inclinamentorum condicio cognoscet<supplied>ur</supplied>, intra quae ager imperii Romani spatioso fine diffunditur, cuius controuersias generaliter exsequi proposuimus.</p>
-        <p>
-            <milestone unit="page" n="p. 23 Thulin"/> Ager est <unclear/>finiruris <gap/> non praetermittimus nomina consent<supplied>i</supplied>entia condicionibus possessionum.</p>
-          <p>Prima enim condicio possidendi haec extat per Italiam; ubi nullus a<del>iu</del>ger est tributarius, sed aut colonicus aut municipalis, aut alicuius castelli aut conciliabuli, aut saltus priuati.</p>
-        <p>At si ad prouincias respiciamus, habent agros colonici quidem iuris, <del>habent et colonicos stipendiarii</del> qui sunt in<del>com</del>munes, habent<del>em</del> et coloni<supplied>co</supplied>s stipendiarios. habent autem prouinciae et municipales agros aut ciuitatium peregrinarum. Et stipendiarios, qui nexum non habent neque possidendo ab alio quaeri possunt. possidentur tamen a priuatis, sed alia condicione<del>m</del>: et ueneunt, sed nec mancipatio eorum legitima potest esse. possidere enim illis quasi fructus tollendi causa et praestandi tributi condicio<supplied>ne</supplied> concessum est. uindicant tamen inter se non minus fines ex aequo ac si priuatorum agrorum. etenim ciuile est debere eos discretum finem habere, quo unus quisque aut colere se sciat oportere aut ille qui iure possidet possidere. nam et controuersias inter se tales mouent, quales in agris inmunibus et priuatis <milestone unit="page" n="p. 24 Thulin"/> solent euenire. uidebimus tamen an interdicere quis possit, hoc est ad interdictum prouocare, de eius modi possessione<del>m</del>.</p>    
-        <p>Multa enim et uaria incidunt, quae ad ius ordinarium pertinent, per prouinciarum diuersitatem. nam cum in Italia ad aquam pluuiam arcendam controuersia<del>m</del> non minima concitetur, diuerse in Africa ex eadem re tractatur. quom sit enim regio aridissima, nihil magis in querella habe<supplied>n</supplied>t quam siquis inhibuerit aquam pluuiam in suum influere: nam et ag<supplied>g</supplied>eres faciunt <supplied>et</supplied> excipiunt et continent eam, ut ibi potius consumatur quam abfluat.</p>
-        <p>In omnibus his tamen agris superius nominatis quot genera controuersiarum exerceantur, tractare incipiamus. nam et qualia sint et quot status habeant generales, diligenter intueri debemus.</p>
-        <p>Etenim ad artificium defendendi plurimum prode erit, si persecuti <del>hu</del>ius omni<del>s</del> diligentia fuerimus. non enim a qualibet parte<del>m</del> adgrediendum est in controuersia<del>m</del> sed dispiciendum, cui postulationi absolutio proxima sit, ne inplicatione<del>m</del> aliqua et iudicem inpediamus et controuersiam faciamus obscuriorem. nihil puto deformius esse quam <supplied>cum</supplied> de eius modi causis inperiti idoneas uolunt exhibere aduocationes. quaecumque autem in artificio generaliter <supplied>e</supplied>ueniunt, colligi utcumque possunt: reliqua omnia sunt infinita. in quantum potero tamen a generalibus specialia argumentis tractabo, cum ab exiguo quid<supplied>em</supplied> exemplo secund<supplied>um loc</supplied>orum natura<supplied>m</supplied> colligere possint, quid potissimum sequi debea<supplied>n</supplied>t. </p>
-        <p>
-            <milestone unit="page" n="p. 25 Thulin"/>Quamquam non ignorem, in<supplied>ter</supplied> professores inmodice coutrouersiarum quaestione<supplied>m</supplied> frequenter agitata<supplied>m</supplied>, necessariam studii exercitationem huius quoque partis existimaui. uno enim libro instituimus artificem, alio de arte disputauimus, cuius tripertitionem <supplied>s</supplied>ex libris, ut puto, satis conmode sumus executi. exigit enim <del>p</del>ars scientiam metiundi, cui datur libri tertia pars, quam quinto et sexto libro continuabimus. et de adsignationibus et partitionibus agrorum et de finitionibus terminorum <supplied>h</supplied>actenus deputato artis mensoriae ordine meminimus: superest nunc ut de controuersiis disputem. quae pars, quamuis quarta sit uniuersitati<supplied>s</supplied>, seiungitur, quoniam communis est cum aliis artibus et priuatae disputationis exigit cu<supplied>ra</supplied>m. qua<supplied>m</supplied> ita capere ac persequi poterimus, si anticipalia quoque, quibus init<supplied>i</supplied>a substituuntur, non praetermiserimus.</p>
-        <p>Omnium igitur honestarum artium, quae siue naturaliter aguntur siue a<supplied>d</supplied> naturae imitationem proferuntur, materiam optinet rationis artificium geometria, principio ardua ac difficilis incessu, delectabilis ordine, plena praestantiae, effectu insuperabilis. manifestis enim rationi<del>bu</del>s executionibus declarat <supplied>rat</supplied>ionalium materiam, ita ut geometria<supplied>m</supplied> ine<del>o</del>sse artibus aut arte<supplied>s</supplied> ex geometria esse intelligat<supplied>ur</supplied>. si enim rationis incrementa tractamus arte, simplicibus ac planis solidisque adhibita<supplied>m</supplied> etiam <supplied>ante</supplied> nomen potestate<supplied>m</supplied> cognoscimus: quin et geometrica analogia aut <supplied>h</supplied>armonica aut arithmetica, <del>a</del>ut contraria aut quinta aut sexta et ceteros ordines, exercemus; ut non tantum artificiorum, uerum etiam omnium rerum qualitates probabiliter ostendat. sed quoniam tant<del>um</del>a naturalium rerum magnitudo exercitatioris acuminis exigit curam, non <milestone unit="page" n="p. 26 Thulin"/> facile geometria uulgari tangitur opinione<del>m</del> et ad intellectum sui nisi quos ad naturalem philosophiam proue<supplied>h</supplied>at admitti<supplied>t</supplied>. <gap/>
-         </p>
-        <p>Prius quam de transcendentia controuersiarum tractare incipiam, status earum exponendos existimo, quoniam in priore<del>m</del> parte<del>m</del> libri sequentium rerum ordo absolute de his disputari inhibuit. reddendum itaque hic locum tam necessariis partibus existimo.</p>
-        <p>Omne genus controuersiarum ex quadam materiali bipertitione generatur. constat autem haec bipertitio aut in fine aut in loco, non sine illa controuersia quae de positione terminorum praescribitur. Quem admodum unum extra positum est, quo separato a cetero numero duo primum numera<supplied>n</supplied>tur, in hoc quoque numero controuersiarum de positione terminorum ad unius omnino condicionem respicit, et quamuis sit origo quaedam litium, minime tamen adiungi materialibus controuersiis uidetur posse, quoniam singulariter omnium litium anticipalis existit, et si querella eius ad solum descendit, desin<supplied>i</supplied>t controuersia e<supplied>sse</supplied> de positione terminorum: finis enim incipit esse aut loci. ergo legitimi materiales status controuersiarum hi duo uidentur ex<del>i</del>stare, de fine aut de loco: reliquae controuersiae, quaecumque sunt, ex hac materia oriuntur et aut ordine<del>m</del> mensurarum aut partibus iuris ad status generales priuatos reuoca<supplied>n</supplied>tur. namque in ordine coutrouersiarum haec quoque materia li<supplied>ti</supplied>s locum suum optinet. </p>
-        <p>
-            <milestone unit="page" n="p. 27 Thulin"/>De fine subtilior exigitur disputatio, quae a rigore nullo modo distat nisi specie. De quibus est diligentius disputandum: quotiens enim de fine aut de rigore dicimus, non p<del>l</del>usilla quaestio oritur, una<supplied>m</supplied> pluresue lineas sentiamus; ne praeterea lex Mamilia fini latitudinem praescribat. de qua lege iuris periti adhuc habent quaestionem, neque antiqui sermonis sensus proprie explicare possunt, quini pedes latitudinis dati sint, an in tantum quinque. uide<del>n</del>tur tamen his, quinque pedum esse latitudinem, ita ut dupondium et semisse<supplied>m</supplied> una quaeque pars agri finem pertinere patiatur.</p>
-        <p>Ergo si corpus habet finis, aliter sentire debemus ac <supplied>si</supplied> singularem tantum linea<supplied>m</supplied> intueamur. in omni enim genere disterminationis, cui uel singularis linea interueniat et ex uno duas diuidat partes, ipsius mediae lineae sec<del>u</del>tura singularem habet contemplationem, sed efficit duas partes horum locorum diuisorum, et si proprius sentire uelimus, triplex incipit esse contemplatio vel diuisae, <supplied>non duplex</supplied>. uidebimus tamen an tota si<del>n</del>t corporalis. nam quidquid terreni est diuisum, sequitur ut et omnino corporale esse constet. inter uersuras autem duas illud genus lineamenti quod mensura distrinxit, quom ex inferiore parte terreno finiatur, etiam si graciliter, in modum tamen sulci, per supplementum aeris conspicitur. secundum rationem quorundam philosophorum aut geometrarum <del>non duplex</del> illud quoque quod aere<del>s</del> distinguit<supplied>ur</supplied> corporale esse decernitur. nunc quem admodum <gap/> 
-         </p>
-        <p>
-            <supplied>Falsa pro</supplied>positio est, cum controuersia alium habeat statum generalem et alio ad litem deducatur. uera propositio est <milestone unit="page" n="p. 28 Thulin"/> cum per stat<supplied>um</supplied> generalem controuersia<del>m</del> ad litem deducitur. ex falso ergo in uerum transcendentia est, cum a quolibet alio statu ad generalem statum controuersia reuocatur. ex uero in falsum transcendent<supplied>ia</supplied> fit, cum relicto generali<del>s</del> statu<del>s</del> quolibet alio statu controuersia instruitur.</p>
-        <p>Ex non stante propositione in <del>te</del>stante<supplied>m</supplied> transcendunt controuersiae, quotiens loci de quo agitur specialia argumenta nulla existunt, neque ullum finitimae similitudinis mo<supplied>nu</supplied>mentum, sed tantum aboliti finis querella exponitur, et excipiens extantium argumentorum quadam expositione defenditur. nam nec uno genere, sed et si proximi<del>ae</del>tas aliqua naturalis fuit, quae similitudine<supplied>m</supplied> finis adferre possi<del>n</del>t, in illam quoque uelut extantium argumentorum opportunitas aptatur. ex re stant<supplied>e</supplied> i<supplied>n</supplied> non stante<supplied>m</supplied> fit transcendentia, cum certus agro<supplied>rum</supplied> finis, qui aut loci natura aut terminorum distinctione firmatus est, relinquitur et per uanas demonstrationes controuersiae includitur. hoc modo controuersiae plerumque ab ambitio<supplied>sis</supplied> possessoribus proximis mouentur. euenit autem, ut eius modi demonstrationes, <supplied>ni</supplied>si ratione defenda<supplied>n</supplied>tur, interibiles fiant; si contra pro ueris habeantur, ut interibilis inprudentia iudicantium fia<del>n</del>t uidelicet finitio.</p>
-        <p>A quocumque autem controuersia<supplied>e</supplied> de agris mouentur, effectus habent aut coniunctiuos aut disiunctiuos aut spectiuos aut expos<del>c</del>it<supplied>iuos</supplied> aut reciperat<supplied>iuos</supplied>. coniunctiuus est effectus, quotiens consentientibus angulis exploratus agrorum finis ad modum rationis accipit determinationem inlaeso utriusque agri<del>s</del> solo: <supplied>hoc</supplied> genus finitionis plerique inter <supplied>se</supplied> conuenientes potius quam iudices sortient<supplied>es</supplied> factum consignare malunt; disiunctiuus est effectus, cum determinatio alterius partis solum desecat et ita <del>ae</del>qualitate<supplied>m</supplied> agri diuersam <supplied>dis</supplied>simili <milestone unit="page" n="p. 29 Thulin"/> solo applicat, ut plerumque euenit <supplied>ut</supplied> ex prato siluae aliquid adiungatur aut ex silua fine distincto adplicetur ad pratum, et similiter per alias agrorum qualitates. spectiuus est effectus, cum est demonstratio finitimis argumentis ex maxima parte fundata, ita ut et dubi<supplied>i</supplied>s quoque locis aspectum praebeat finitionis. namque animum non tantum ratione orationis intrauit, sed etiam contemplandi potestate confirmat. expositiuus est effectus controuersiae, quotiens finitimorum argumentorum caret demonstratione et partium magis exigit narrationes, per quas exponendum sit quo<del>d in</del> rigore termini desi<supplied>n</supplied>t, aut persuadendum iudici, etiam si loci natura finitimam exhibeat similitudinem, quomodo sint reponendi. subiectiuus est effectus controuersiae, cum relinquitur status generalis et alio quolibet statu controuersia defenditur. reciperatiuus est effectus controuersiae, quotiens a trifinia aut quadrifinia <supplied>aut</supplied> ex quolibet alio finis loco in excipientem terminum rectura dirigit et per incessum definitionis loca quaedam alteri fundo adquirit; aut quotiens solum aufer<del>e</del>t et eius loco reddit<del>us</del> utrique fundo,  effectus quasi reciperatiuus existit.</p>
-        <p>Per hos effectus omnium controuersiarum status inuicem habent transcendentia<supplied>s</supplied> aut necessarias aut que<del>e</del>untes aut neque<del>e</del>untes, saepe interibiles. cum enim status generalis adsumptiuus primae controuersiae, quae est de positione terminorum, in rigorem aut in finem transcendit, e<supplied>s</supplied>t quidem necessarius causa argumentorum, sed in illo genere controuersiae nequiens habetur: at si uere de fine agatur et omnino termin<supplied>at</supplied>us distinctio ei desit, manifeste transcendentia eius non tantum nequiens sed interibilis apparet. eadem ratione in ceteris <milestone unit="page" n="p. 30 Thulin"/> controuersiis haec transcendentia adficitur, ut aut non necessaria aut nequiens <supplied>aut</supplied> interibilis appareat. secunda controuersia de rigore, initialis status pertinentis ad materiam, <supplied>cum</supplied> transcendit in controuersiam quae est loco tertio de fine, status materialis, speciem, non condicionem, mutat neque materia<supplied>lis</supplied> efficit<supplied>ur</supplied>. secunda controuersia de rigore, status initialis, quom transcendit in controuersia<supplied>m</supplied> quae est loco <supplied>quarto de loco</supplied> materialis, transcendentia eius non necessaria efficitur. secunda <supplied>tertia quarta quom in</supplied> controuersiam quae est loco quinto de modo, status effectiui, transcendunt <gap/>
-         </p>
-        <p>
-            <supplied>DE POSITIONE TERMINORVM</supplied>
-         </p>
-        <p>
-            <gap/> secundum locorum natura<supplied>m</supplied> mouet causas. Si uero in alio loco terminus translatus est usurpandi  finis causa<del>m</del>, numquam non utique locum desicauit: non enim cito quisquam propter exiguam partem terminum mouet. erit inprouidentia<del>m</del> mensoris secundum angulorum finitimorum positionem arbitrari, in quantum sit terminus translatus et qua ratione sit in locum suum restituendus.</p>
-        <p>Facillimum est inperitia<supplied>m</supplied> artificis aliusue retundere non putant<supplied>is</supplied> rationem inesse ordini: nam et frequenter <milestone unit="page" n="p. 31 Thulin"/> euenit, ut inperitia mensorum <del>an</del>audacia<supplied>m</supplied> possessoribus praebeat. numquam non concurrentium inter se finium anguli, non tantum recti uerum etiam hebetes aut acuti, habe<del>a</del>nt aliquam rationem; in qua<supplied>m</supplied>, si non dissimulemus, facile quod inperiti turbauerunt artificio restituemus.</p>
-        <p>Haec controuersia moti termini null<supplied>i</supplied>us in se aliae controuersiae statum recipit: est enim anticipalis et quasi comminatio quaedam litium, declarans aut loci aut modi futura<supplied>m</supplied> controuersia<supplied>m</supplied>.</p>
-        <p>De rigore controuersia est status initialis pertinentis ad materia<supplied>m</supplied> operis; nec sine prioris controuersiae comparatione. nam cum de rigore agatur, potest fieri ut ante motus sit terminus: ideoque haec secunda controuersia<del>m</del> prioris quoque controuersiae capax apparet; quamquam et sine prioris controuersiae interuentu<del>m</del> priuatim de rigore controuersia suscitari possit: nec enim omnibus locis agrorum, aut capientibus aut non capientibus, termini ponuntur.</p>
-        <p>Refer<del>en</del>t in quo agro agatur. si limitatus est, aut ordo limitis ordinati desideratur aut subrunciui aut linearis aut interiectiui rigoris incessus. at si in agro arcifinio si<del>n</del>t, qui nulla mensura continetur sed finitur aut montibus aut uiis aut aquarum diuergiis aut notabilibus locorum naturis aut arboribus, quas finium causa agricolae relinquunt et ante missas appellant, aut fossis aut quodam culturae discrimine <gap/>
-         </p>
-        <p>
-            <supplied>DE FINE</supplied>
-         </p>
-        <p>
-            <gap/>
-            <milestone unit="page" n="p. 32 Thulin"/> agetur. cum enim loci sit tanta iniquitas, et aut praerupta aut abrupta, quae aut ruere aut minui possent, uetus consuetudo est terminos relatis pedibus in solido agro ponere. quamquam non era<del>n</del>t necessarium, cum ipsa loci natura talis esset, ut neque inferiorem uicinum admittere<supplied>t</supplied> in partem superiorem neque superiori descensu<supplied>m</supplied> ullo modo praeberet. sed <supplied>di</supplied>ligentes agricolae propter inpudentium uicinorum consuetudinem parum se tutos credunt, nisi ita fundauerint agros, ut etiam aliquid extra mensurarum ordinem faciant.</p>
-        <p>In superciliis autem maioribus non defuerunt qui ita finem seruari uellent, ut quatenus attingere unus quisque possessor posset, eatenus<del>u</del> possidere<supplied>t</supplied>. uidebimus an aliquam rationem sint secuti, cum sit totum supercilium superioris agri fundamentum nec, si subruatur, possit sine iniuria superioris fieri. ideoque magis certior ratio illa uidetur, ut fundamento tenus in agro arcifinio possessio seruari debeat, si termini desint.</p>
-        <p>Frequenter inter se possessores propter loci difficultatem totum supercilium, quod ange<supplied>re</supplied>ntur ipso subiacente, inferioribus cesserunt, et contenti fuerunt terminos per summum iugum disponere, nullam secuti rationem. haec tamen si occurrunt, non quasi noua intueri debebimus.</p>
-        <p>
-            <milestone unit="page" n="p. 33 Thulin"/> Plurimis deinde locis terminos sacrificales non in fine ponunt, sed ubi illud sacrificii potius opportunitas suadet, hoc est loci conmoditas, in quo sacrificium abuti conmode possint. hos terminos non statim finitimos obseruare debebimus, etiam si non longe a fine positi fuerint: frequenter enim uiae finiunt, iuxta quas arbores solent esse laetiores, sub quas defigere terminos sacrificii causa possessores consuerunt. uerum tamen multi non tantum sacrificii sequuntur consuetudinem sed etiam rationem, et ipso fine defigunt: propter quod adimi fides sacrificalibus palis in totum non debet.</p>
-        <p>
-            <gap/>
-         </p>
-         <p>
-            <supplied>DE LOCO</supplied>
-         </p>
-        <p>
-            <gap/> 
-            <unclear/> haberi ordinem legis Mamiliae excessum plurimum, praecipue in ag<supplied>r</supplied>is arcifiniis sed nec minus id adsignatis. cum enim modum loci nulla forma praescribit et controuersia oritur, nullo alio statu<del>m</del> ad litem deduci debet, quam ut de loco agatur; solent quidam per inprudentiam mensores arbitros conscribere aut sortiri iudices finium regundorum causa, quando in re praesenti plus quidem quam de fini<del>um</del> regundo agatur. si<supplied>c</supplied> fit ut pos<supplied>t</supplied> sent<supplied>ent</supplied>iam inritum sit et rescindi possit, quod aut iudex aut arbiter pronuntiauerint, neque ullum commissum faciat qui sententia<supplied>m</supplied> non sit secutus, quando de alia re iudicem aut arbitrum sumpserint.</p>
-        <p>De <del>hoc</del> loco, si possessio petenti firma est, etiam <milestone unit="page" n="p. 34 Thulin"/> interdicere licet, dum cetera ex interdicto diligenter peraguntur: magna enim alea est litem ad interdictum deducere, cuius est executio perplexissima. si uero possessio minus firma est, mutata formula iure Quiritium peti debet proprietas loci; iudicari praeterea, si locus de quo agitur aut terminis aut arboribus aut aliquo argumento finem aliquem agri declaret et a continuatione soli quasi quibusdam argumentis eximatur.</p>
-        <p>Ne praeterea<supplied>t</supplied> nos, illud etiam tractare debemus, si arbores finitimas habet et locus est fere siluester, quo in genere est possessio minus firma, ne certetur i<supplied>nter</supplied>dicto. quod si silua caedua sit, post quintum annum parcissume repetatur. qui autem appellent arbores notatas, scire debemus idioma regionis. qui<supplied>dam</supplied> plagatas uocant quas finis declarandi causa denotant, ut in Brittiis, alii in Piceno stigmatas, in aliis regionibus insignes aut notas.</p>
-        <p>Si uero pascua sit et dumi ac loca paene solitudine derelicta, multo minorem possessionis habent fidem. propter quod <supplied>m</supplied>inime de his locis ad interdictum iri debet.</p>
-        <p> De quibus autem locis ad interdictum ire possunt, <supplied>sunt</supplied> fere culta, quae possessionem breuioris temporis testimonio adipiscuntur, ut arua aut uineae aut prata aut aliud aliquod genus culturae. haec tamen cum in demonstratione allegabuntur, etiam si partes qua<supplied>e</supplied>dam proximae et in<supplied>ter</supplied>iacentes culturae fuerint propria<supplied>e</supplied>, non eri<del>n</del>t satis illa<supplied>s</supplied> sui generis agro adsignare, sed <milestone unit="page" n="p. 35 Thulin"/> circuire oportebit totum fundum et ita fidem obligare, ne demonstratione neglegenter soluta appareat.</p>
-        <p>De modo controuersia <supplied>est</supplied> status effectiui: ante enim locus est ibi quam modus nominetur: aeque recipiens ante dictarum controuersiarum omnes status, sed ut superius significaui irritos et non necessarios. Haec controuersia frequenter in agris adsignatis exercetur: agitur enim, ut secundum acceptam eius ueter<supplied>an</supplied>i, qui in illud solum deductus est, modus restituatur; aut si quando praescribtus est lege aliqua agri modus.</p>
-        <p>Quom autem in adsignato agro secundum formam modus spectetur, solet tempus inspici et agri cultura<del>e</del>. si iam excessit memoria<del>m</del> abalienationis, solet iuris 
-          formula <del>non silenter</del> interuenire et inhibere mensores, <supplied>n</supplied>e tales controuersias concipia<supplied>n</supplied>t, neque quietem tam longae 
-          possessionis inrepere <supplied>si</supplied>ni<supplied>t</supplied>. si et memoria sit recens et iam modus secundum centuriam conueniat et loci natura indicetur et cultura, nihil inpediet secundum formas aestimatum petere: lex enim modum petiti<del>s</del> definite praescribit, cum ante quam mensura agri agatur  modus ex forma pronuntiatus cum loco conueniat. Hoc in agris adsignatis euenit. nam si aliqua lege uenditionis exceptus sit modus neque adhuc in mensuram redactus, non ideo fide carere debebit, si nostra demonstratio eius in agro non ante finiri potuerit quam de sententia loc<del>ut</del>us sit designatus.</p>
-        <p>
-            <gap/> in hac controuersia, quod i<supplied>n</supplied>ter priuatos tractatur.</p>
-        <p>
-            <milestone unit="page" n="p. 36 Thulin"/> Nam inter res publicas non mediocriter eius modi controuersia solet exerceri, quam frequenter coloniae habent cum coloni<supplied>i</supplied>s aut municipiis aut saltibus Caesaris aut priuatis. nam et supra dictae controuersiae omnes euenire et rebus publicis possunt. nec enim referf, cuius si<del>n</del>t solum aut cuius iuris, ad mouendam controuersiam: tunc autem habe<del>n</del>t differentia<supplied>m</supplied>, prout ab iudice tractatur.</p>
-        <p>Obseruari in hac controuersia <supplied>a</supplied> mensore debebit <supplied>l</supplied>ineis, dum in similitudinem dissimile interrueniat; quoniam nulla potest ueritas adprobari, si illi qui<supplied>d</supplied> uel exiguum falsi interueniat. ueritas enim habere debet suam similitudinem per omnia momenta: falsum siquid est, multa uarietate confunditur. et habe<del>n</del>t aes, cuius formam respicit, cum modus in <supplied>dis</supplied>crimine est. <del>p</del>ars triplici adtestatione firmatur:  habere enim debet aes primu<supplied>m</supplied> locum, deinde modum, deinde speciem. at si inter <supplied>res publicas</supplied> agatur au<supplied>t</supplied> rem publicam et Caesarem, instrumentis forte ueteribus continebitur, ut solet, adaeratio; ne falsa ueris dissimilia sint, sed persuasione similia fiant, hoc est falsa pro ueris <milestone unit="page" n="p. 37 Thulin"/> adprobentur. in conparatione tamen hoc interest, quod falsa persuadendo adprobentur ueris, qua<supplied>e</supplied> adprobatio in promptu<del>m</del> est et quodam modo in prima acie fertur, falsis latentius hoc uera adprobentur. ita ut si conparare quis uelit hominis probationem et statuae; cum autem hominem omnibus bibere et ambulare constet, siquis inquirere uelit ann<supplied>e</supplied> uiuat, non potest illi non ab ipsis probationibus persuaderi, ideo quo<supplied>d</supplied> bibat, quod ambulet, quod loquatur; at <supplied>in</supplied> statua <supplied>diu</supplied> multumque mens infri<supplied>n</supplied>genda est, ut similitudo ueritatis animam habere uideat<supplied>ur</supplied>, de cuius simulatione est profecta.</p>
-        <p>
-            <gap/> 
-            <supplied>ad lu</supplied>cum Feroniae Augustinorum iugera M. haec in discrimen si uenerunt, omnia supra dicta conuenienter habere debent, ut illa si<supplied>n</supplied>t, quae secundum forma<supplied>m</supplied> proponuntur. geminus in prouinciis modus ab alio possidetur, ab alio ne quidem simplex. quem admodum autem fieri soleat, tractare non alienum iudic<del>i</del>o. potest enim fieri, ut illa mille iugera secundum ordinationem mensoris a luco quidem incipiant, at in diuersa<del>m</del> regione<del>m</del>. quod falsum manifesto apparet: sed in demonstratione inperitis obscurissimum est dinoscere, an secundum formam regio <milestone unit="page" n="p. 38 Thulin"/> conueniat praesens, si <supplied>u</supplied>t aquae diffusae regiones pareant et argumentis aut arborum aut aliarum rerum careant; sicut in Africa, ubi spatiositas et inundatio camporum eius modi controuersias facillime in errorem deducit. quod si eadem mille iugera, in eodem sane loco <supplied>quo</supplied>  forma indic<del>t</del>at, cohibitis angulis <del>nihil deest</del> in re praesenti minoribus lineamentis deformentur, ut modum non expleant, sequitur falsum futurum, quando nihil amplius demonstrationi quam locus conueniat, et specie disconueniente, uelut AD pro CA <del>ad</del>scripta, modus item disconueniat. at si in eodem loco uelim eadem mille iugera aliis lineamentis describere, conuenient quidem mille iugera, et ad lucum Feroniae esse conueniet, sed specie disconueniente inter peritos manifeste falsum apparebit.</p>
-        <p>Memineram et superius, ut aliquid uerum adprobari possit, minime ei quicquam falsi posse interuenire. nam et haec expositio declarat, <supplied>ut</supplied>, quamuis duae consentiant partes, ab una dissentiente uincantur, neque uerum esse possit, nisi illis quoque tertia pars illa consenserit. conuenire autem omnino in restitutione formarum omnia debent, ut secundum signa in formis nominata locus quicumque erat restituatur, aut artificio signorum loca requirantur, si eri<supplied>n</supplied>t, ut frequenter euenit, turbata. <supplied>ea</supplied> docere nos angulorum positiones poterint. sic erit, ut et artis sinceritas seruetur et ordo ueteris adsignationis non praetermittatur.</p>
-        <p>
-            <milestone unit="page" n="p. 39 Thulin"/>De proprietate <del>mundi</del> controuersia est status effectiui: efficitur enim ex omnibus ante dictis controuersiis. sed quarum status in hac propositione inriti habentur, dixi et supra.</p>
-        <p>De proprietate agitur plurimum iure ordinario, neque est hic mensurarum interuentus, nisi cum quaeritur, quatenus agatur.</p>
-        <p>Proprietas <supplied>non</supplied> uno genere uindicatur.</p>
-        <p>Et sunt plerumque agri, ut in Campania in Suessano, culti, qui habent in monte Massico plagas siluarum determinatas; quarum siluarum proprietas ad quos pertinere debeat uindicatur. nam et formae antiquae declarant ita esse adsignatum, quoniam solo culto nihil fuit siluestre iunctum quod adsignaretur.</p>
-        <p>Relicta sunt et multa loca, quae ueteranis data non sunt. haec uariis appellationibus per regiones nominantur: in Etruria communalia uocantur, quibusdam prouinciis pro iudiuiso. haec fere pascua certis personis data sunt depascenda tunc, cum agri adsignati sunt. haec pascua multi per <supplied>in</supplied>potentiam inuaserunt et colunt: et de eorum proprietate solet ius ordinarium moueri non sine interuentu mensurarum, quoniam demonstrandum est, quatenus sit adsignatus ager.</p>
-        <p>Nam per emptiones quasdam solet proprietas quarundam possessionum ad <supplied>priuatas</supplied> personas pertinere. quae iure magis ordinario quam mensuris explicantur. </p>
-        <p>
-            <milestone unit="page" n="p. 40 Thulin"/> Nunc ut ad publicas personas respiciamus, coloniae quoque loca quaedam habent adsignata in alienis finibus, quae loca solemus praefecturas appellare. harum praefecturarum proprietas manifeste ad colonos pertinet, non ad eos quorum fines sunt deminuti. solent et priuilegia quaedam habere beneficio principum, ut longe et semotis locis saltus quosdam reditus causa acceperint. quorum proprietas indubitate ad eos pertinet, quibus est adsignata. alia beneficia etiam quaedam municipia acceperunt et priuatae personae quae de principibus illis temporibus bene meruerunt.</p>
-        <p>In hac controuersia plus potestatis habet ius ordinarium quam ars mensoria. ab eo enim statu lis incipit, <supplied>ut</supplied> de proprietate agatur, non de loco: mensura autem nihil amplius quam secundum formam locum declarat. in hac autem controuersia ars mensurarum locum secundum habet, quoniam prius alii uacandum est, an agenda sit mensura.</p>
-        <p>De possessione controuersia est <supplied>status</supplied> effect<supplied>i</supplied>ui, quoniam primum possessio tempore efficitur, deinde, ut ad solum respiciamus, omnes ante dictas controuersias capit: si enim solum cogitemus, ut legitima possessio inpleri possit, indubi<supplied>ta</supplied>te locus definiatur necesse est. et de hac controuersia plurimum interdicti formula litigatur. de qua et in superiore parte meminimus: ideoque non puto eam iterum retractandam.</p>
-        <p>De subsiciuis controuersia est status effectiui, quoniam subsiciua nominari aut sentiri sine quadam loci latitudine<del>m</del> aut modo non possunt. ideoque manifeste apparet supra dictarum controuersiarum status in <gap/> locum.</p>
-        <p>
-            <milestone unit="page" n="p. 41 Thulin"/> Subsiciuorum autem genera sunt duo; unum quod extremis adsignatorum agrorum finibus centuria<del>ru</del>m non explet. aliud etiam integris centuriis interuenit. de quo maximae controuersiae agitantur. cum autem adsignatio in agro adsignato fieret, non potuit omnis modus intra IIII limites ueteranis adsignari. in ea remansit aliquid, quod a subsecante linea nomen accepit subsiciuum. in his subsiciuis quidam iterum miserunt quibus agri adsignarentur, quidam et subsiciua coloni<supplied>i</supplied>s concesserunt. ideoque semper hoc genus controuersiae a rebus publicis exercentur. per longum enim tempus atti<del>n</del>gui possessores uacantia loca quasi inuitante otiosi <supplied>soli</supplied> opportunitate<del>m</del> inuaserunt et per longum tempus inpune commal<supplied>lea</supplied>uerunt. horum subsiciuorum multae res p. etiam si sero mensuram repetierunt, non minimum aerario publico contulerunt. pecuniam etiam quarundam coloniarum imp. Vespasianus exegit, quae non haberent subsiciua concessa: non enim fieri poterat, ut solum illud, quod nemini erat adsignatum, alterius esse posset quam qui poterat adsignare. non enim exiguum pecuniae fisco contulit uenditis subsiciuis. sed pos<supplied>t</supplied>quam legationum miseratione commotus est, quia quassabatur uniuersus Italiae possessor, intermisit, non concessit. aeque et Titus imp. aliqua subsiciua in Italia recollegit. praestantissimus postea Domitianus ad hoc beneficium procurrit et uno edicto totius Italiae metum liberauit. </p>
-        <p>
-            <milestone unit="page" n="p. 42 Thulin"/>Haec controuersia numquam a priuatis exercetur.</p>
-        <p>De alluuione controuersia est status effectiui: efficitur enim subinde et per tempora mutatur. in hac controuersia plurimum sibi uindicat ius ordinarium. agitur enim de eo solo quod alluat flumen, et subtiles intro ducuntur quaestiones, an ad eum pertinere debeat, cui in altera ripa recedente aqua solum creuit; hic qui aliquid agri sui desiderat transire et possidere illud debeat, quo<supplied>d</supplied> flumen reliquit. nisi quod illud subtilissime profertur, quod is solum <supplied>a</supplied>misit, non statim transire in alteram ripam, sed abductum esse <supplied>e</supplied>t elotum. et illud, contra uicinum longe dissimilem agrum habere, quod hic forte cultum et pingue solum amiserit, apud illum autem harenae, lapides et limum abluuio inuectum remanserit. illud praeterea, quod finem illis semper aqua fecerit et nunc quoque facere debeat.</p>
-        <p>Sunt et multa, de quibus subtiliter tractatur: sed nec uno tantum genere per alluuionem flumina possessoribus iniurias faciunt. sicut Padus relicto alueo suo per cuiuslibet fundum medium inrumpit et facit insulam inter nouum et ueterem alueum. ideo de hac re tractatur, ad quem pertinere debeat illud quod reliquerit, cum iniuriam proximus possessor non mediocrem patiatur, per cuius solum amnis publicus perfluat. nisi quod iuris periti aliter interpretantur, et negant illud solum, quod <milestone unit="page" n="p. 43 Thulin"/> solum p(opuli) R(omani) coepit esse, ullo modo usu capi a<del>t</del> quoquam mortalium posse. et est uerisimile ita neuter possessor excedere finem illum ueteris aquae ullo iure potest aut debet. hae quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum regelationum repentina<del>s</del> inundatione<del>s</del> patitur iniurias. </p>
-        <p>Quaeritur tamen, qualia quanta sint flumina, in quibus alluuio obseruari debeat. nam et iure continetur, nequis ripam suam in iniuria<supplied>m</supplied> uicini munire uelit.</p>
-        <p>Multa flumina et non mediocria in adsignationem mensurae antiquae ceciderunt: nam et deductarum coloniarum formae indicant, ut multis fluminibus nulla latitudo sit relicta. sequitur in his fluminibus artem mensoriam aliquem locum sibi uindicare, quando exacto limite accepta finiatur, qua<del>e</del> uel aqua<supplied>m</supplied> uel agrum uel utrumque habere debeat unus. fuit enim fortasse tunc ratio non simplex, qua deberet quis quid deductorum etiam <supplied>a</supplied>quae accipere. primum quod exiguitas agrorum conditorem ita suadebat. deinde <supplied>quod</supplied> non erat ingratum possessori proximum esse aquae commodo. tertio quod, si sors ita tulerat, aequo animo ferendum  habebat. in his agris exigitur fere mensura secundum <milestone unit="page" n="p. 44 Thulin"/> postulationem aeris formarumque. quo pertica cecidit, eatenus acceptae designantur.</p>
-        <p>Videbimus an inter mensores et iuris peritos esse de hoc quaestio debeat, cursu<del>m</del> an pertica metiam<supplied>ur</supplied>, si qua usque potuit ueteranis est adsignatum. scio in Lusitania, finibus Emeritensium, non exiguum per mediam coloniae perticam ire flumen Anam, circa quod agri sunt adsignati qua usque tunc solum utile uisum est. propter magnitudinem enim agrorum ueteranos circa extremum fere finem uelut terminos disposuit, paucissimos circa coloniam et circa flumen A<supplied>nam</supplied>: reliquum ita remanserat, ut postea repleretur. nihilo minus et secunda et tertia postea facta est adsignatio: nec tamen agrorum modus diuisione uinci potuit, sed superfuit inadsignatus. in his agris cum subsiciua requirerentur, inpetrauerunt possessores a praeside prouinciae eius, ut aliquam latitudinem An<supplied>ae</supplied> flumini daret. quoniam subsiciua quae quis occupauerat redimere cogebatur, iniquum iudicatum est, ut quisquam amnem publicum emeret aut sterilia quae alluebat: modus itaque flumi<supplied>ni</supplied> est constitutus. hoc exempli causa re<del>i</del>gerendum existimaui. nam et in Italia Pisauro flumiui latitudo est adsignata eatenus, qua usque adlauabat.</p>
-        <p>De iure territorii controuersia est status iniectiui. inicitur enim solo quaedam controuersia e persona: tum praecipue qui<supplied>d</supplied>quid est illud de quo agitur, aut locus aut modus, <milestone unit="page" n="p. 45 Thulin"/> generalem statum <supplied>a</supplied> iure ordinario trahit, etiam si multis locis mensurarum exigat interuentum. haec enim controuersia non tantum inter res publicas sed et inter rem p. et priuatos exercetur, nec tantum iure ordinario sed et arte mensoria conponitur. Inter res p. autem controuersiae eius generis mouentur, ut quaedam sui territorii iuris esse dicant, quamuis sint intra alienos fines, munificentiam quoque coloniae aut municipio ex his locis deberi defendant. sed <supplied>h</supplied>aec quaedam coloniae aut beneficio conditorum perceperunt, ut Tudertini, aut postea apud principes egerunt, ut Fanestres, ut incolae, etiam si essent alienigenae, qui intra territorium colerent, <del>alii h</del>omnibus <del>h</del>oneribus fungi in colonia<del>m</del> deberent. hoc Fanestres nuper inpetrauerunt, Tudertini autem beneficio habent conditoris.</p>
-        <p>Inter res p. et priuatos non facile tales in Italia controuersiae mouentur, sed frequenter in prouinciis, praecipue in Africa, ubi saltus non minores habent priuati quam res p. territoria: quin immo multi saltus longe maiores sunt territoriis: habent autem in saltibus priuati<del>s</del> non exiguum populum plebeium et uicos circa uillam in modum municipiorum. r(es) p(ublicae) controuersias de iure territorii sole<supplied>n</supplied>t mouere, quod aut indicere munera dicant oportere in ea parte soli, aut<del>em</del> legere tironem ex uico, aut uecturas aut copias deuehendas indicere, aliquando et ex quadam parte soli; quamuis alium statum <milestone unit="page" n="p. 46 Thulin"/> generalem controuersiae accipere debeant, quae de loco non exiguo mouentur. res tamen publicae cum priuatis si agunt, quasi iure territorii solent uindicare, et hunc statum generalem constituunt eis locis quae loca res p. adserere conantur. eius modi lites non tantum cum priuatis hominibus habent, sed et plerumque cum Caesare, <supplied>qui</supplied> in prouincia non exiguum possidet.</p>
-        <p>Non est dubium necessarias esse mensuras in eius modi controuersia, <supplied>quae</supplied> quamuis alio nomine appellatur, locorum tamen facit quaestionem.</p>
-        <p>De locis publicis controuersia est aeque status iniectiui. sunt autem loca publica complura, sed ex his quaedam loca priuata<supplied>m</supplied> exigunt defensionem: et quamuis haec loca diuersis appellationibus contineantur, unam tamen habent controuersiae condicionem.</p>
-        <p>Sunt autem loca publica haec, quae inscribuntur ut SILVAE ET PASCVA PVBLICA AVGVSTINORVM. haec uidentur nominibus data; quae etiam uendere possunt.</p>
-        <p>Est alia inscriptio, qua<supplied>e</supplied> diuersa significatio<supplied>ne</supplied> uidetur esse, in quo loco inscribitur SILVA ET PASCVA; aut FVNDVS SEPTICIANVS COLONIAE AVGVSTAE CONCORDIAE. haec inscriptio uidetur ad personam coloniae ipsius pertinere <supplied>ne</supplied>que ullo modo ab<supplied>a</supplied>lienari posse a re<del>i</del> publica<del>e</del>. item siquid in tutelam aut templorum publicorum aut balneorum adiungitur.</p>
-        <p>
-            <milestone unit="page" n="p. 47 Thulin"/> Habent et res p. loca suburbana inopum funeribus destinata, quae loca culinas appellant. habent et loca noxiorum poenis destinata. ex his locis, cum sint suburbana, sine ulla religionis reuerentia solent priuati aliquid usurpare et hortis suis adplicare. de his locis, si r. p. formas habet, cum coutrouersia mota est, ad modum <supplied>mensor</supplied> locum restituit: sin autem, utitur testimoniis et quibuscumque potest argumentis.</p>
-        <p>De locis relictis et extra clusis controuersia est status iniectiui: manifestum est enim de loco agi, sed per aliam personam. loca autem relicta et extra clusa non sunt nisi in finibus coloniarum, ubi adsignatio peruenit usque qua cultum fuit, quatenus ordinatio<supplied>ne</supplied> centuriarum intermissa finitur. ultra autem siluestria fere fuerunt et iuga quaedam montium, quae uisa sunt finem coloniae non sine magno argumento facere posse ergo fines coloniae inclusi sunt montibus. propter quod haec loca, quod adsignata non sint, relicta appellantur; extra clusa, quod extra limitum ordinationem sint et tamen fine cludantur. haec plerumque proximi possessores inuadunt et opportunitate loci inuitati agrum optinent. cum his controuersiae a rebus publicis solent moueri.</p>
-        <p>De locis sacris et religiosis controuersia est aeque status iniectiui: agitur enim de locis, sed cum aut sacra aut religiosa nominentur, statum generalem a iure ordinario accipiunt. <milestone unit="page" n="p. 48 Thulin"/> primum enim quaeritur, an ea loca ullo modo usu capi possint: deinde, quatenus possint, secundum locum habent mensurae.</p>
-        <p>Locorum autem sacrorum secundum legem populi Rom. magna religio et custodia haberi debet: nihil enim magis in mandatis etiam legati prouinciarum accipere solent, quam ut haec loca quae sacra sunt custodiantur. hoc facilius in prouinciis seruatur: in Italia autem densitas possessorum multum inprobe facit, et lucos sacros occupant, quorum solum indubitate p. R. est, etiam si in finibus coloniarum aut municipiorum. de his solet quaestio non exigua moueri inter r. p. et priuatos.</p>
-        <p>Sed et inter res publicas frequenter eius modi contentio agitatur de his locis, in quibus conuentus fiunt maiores et aliquod genus uectigalis exigitur.</p>
-        <p>Nam et de aedibus sacris, quae constitutae sunt in agris, mutata tantum persona similes tamen oriuntur quaestiones; sicut in Africa inter Adrumentinos et Tysdritanos de aede Mineruae, de qua iam multis annis litigant.</p>
-        <p>Sunt et loca sacra, quae re uera priuatis finibus rei p. col<supplied>on</supplied>i debent. haec plerumque interuentu longae obliuionis casu a priuatis optinentur, quamquam in tabulariis formae eorum plurimae extent. haec maxime aut in loco urbis aut suburbanis locis a priuatis detinentur.</p>     
-        <p>De aqua pluuia arcenda controuersia est status iniectiui: per quodcumque enim solum transit, ad ius ordinarium magis respicit condicio eius quam ad mensuras; nisi si <milestone unit="page" n="p. 49 Thulin"/> per extremitatem finis uadat: propter quod statum generalem etiam alium accersire debet et quasi geminatione quadam defendi, quod et per finem eat et sit lis de pluuia arcenda. haec controuersia per regiones uari<supplied>i</supplied>s generibus exercetur, sed quasi ad eandem respicit condicione<supplied>m</supplied>. in Italia aut quibusdam prouinciis non exigua est iniuria, si in alienum agrum aquam inmittas; in prouincia autem Africa, si transire non patiaris.</p>
-        <p>Eiusdem condicionis est controuersia de cloacis ducendis et fos<supplied>s</supplied>is caecis. quod totum, nisi per finem agatur, ad ius ordinarium pertinet.</p>
-        <p>De itineribus controuersia est status iniectiui: inicitur enim loco quaestio, et defenditur populo quod forte a priuatis possidetur. haec quaestio multipliciter tractatur.</p>
-        <p>Nam in agris ceuturiatis excipitur limitum latitudo causa itineris. sed cum illi recturas suas per qualiacumque loca extendant, hoc est qua ratio dictauit, per cliuia et montuosa, qua iter nullo modo fieri potest, quae loca fortasse possessori siluae causa sint utilia, horum loco non inique, per quae possit loca commode iri, iter commutant.</p>
-        <p>Nam quae sit condicio itinerum, non exigua iuris tractatio est. agitur enim, utrumne actu<supplied>s</supplied> sit an i<del>n</del>ter <supplied>an</supplied> ambitus. per quae loca quid liceat populo, iure continetur.</p>
-        <p>Satis, ut puto, dilucide genera contronersiarum exposui: nam et simplicius enarrare condiciones earum existimaui, quo facilius ad intellectum peruenirent. nunc quem admodum singulae <milestone unit="page" n="p. 50 Thulin"/> tractari debeant persequendum est. respicio enim quantum sit quod mensori iniungatur, et puto diligentius exequenda quae ad prouidentiam pertinenti<supplied>a</supplied> sunt artificis. difficillimus autem locus hic est, quod mensori iudicandum est; sed nec minus ille exactus, quod est aduocatio praestanda. quamquam diuersa sint et longe inter se discernere debeant, prudentiam tamen eandem artifices habere debent et qui iudicaturi sunt et qui aduocationes sunt praestituri. in iudicando autem mensor<del>em</del> bonum uirum et iustum agere debet neque ulla ambitione aut sordibus moueri,  seruare opinionem et arti et moribus. Omnis illi artifici ueritas custodienda est, exclusis illis similitudinibus, quae falsae pro ueris subiciuntur. quidam enim per imperitiam quidam per inpudentiam peccant: totum autem hoc iudicandi officium et hominem et artificem exigit egregium. erat aequissimum et in aduocatione<del>m</del> eandem fidem exhiberi in controuersiam a mensoribus. sed hoc possessores aequo animo ferre non possunt: nam cum his ueritas exposita est, aduersus sinceritatem artis facere cogunt. <milestone unit="page" n="p. 51 Thulin"/> multa sunt in professione quae generaliter pro ueris offerantur, multa quae specialiter, quaedam quae argumentaliter. coniecturaliter etiam mentiri artifices coguntur. <gap/>
-         </p>
-      </body>
-  </text>
+    <text>
+        <body xml:lang="lat" n="urn:cts:latinLit:stoa0012a.stoa001.digilibLT-lat1">
+            <p>
+                <milestone unit="page" n="p. 20 Thulin"/>
+                <gap/> aduersantur, ne quid in rerum natura finitum esse uideatur. ac si rationis
+                actum uniuersaliter adprehendere<del>t</del> proponimus, ut ab initio quodam ad
+                    certa<supplied>m</supplied> finium dispositionem procedit et exigit ornatum,
+                silentio transire nequeo. </p>
+            <p> Si enim uox, quam uaria uerborum significatione<del>m</del> diuidimus, naturalis
+                est, uerborum significatio naturaliter sui exigit institutionem. ipsa quoque
+                litterarum initia necessariam habent substitutionem. nisi enim constet linearum
+                illam figurationem capere nomen et esse aliquid, itemque similiter certas uocis
+                distinctiones certa significatione seruari, numquam scripturae ullius ordo ad
+                notitiam mentis admittetur. et si ad numeros respiciamus et non putemus esse unum
+                neque duo pluraue, <supplied>et</supplied> a primo ad secundum tertiumque distantias
+                non substituamus, nullius ordinis modo <supplied>numero</supplied>rum rationalium
+                gradus distinguamus. et quid pluribus fatigamur exemplis? si ad rationem <milestone
+                    unit="page" n="p. 21 Thulin"/> homo pertinet, et rationis nexus humana tangitur
+                prouidentia, ad quam puta<del>n</del>tur peruenire ne quidem institutus quisquam
+                mortalium potuisse, de contrario falsa persuasione decipimur, et naturaliter inesse
+                nobis etiam sapientiam credimus. custos est disciplina, nisi fallor,
+                    infantia<supplied>e</supplied>: quae cum ita naturalia ad notitiam mentis
+                    admittit<del>ur</del>, <del>a</del>ut sint, in quae dirigi possi<del>n</del>t
+                animus, alia procul et semotior<supplied>e</supplied> ratione<del>m</del>
+                    continet<del>ur</del>; ad quae cognoscenda ne uulgaribus abducamur opinionibus,
+                ratio non deerit.</p>
+            <p>Ac <supplied>si</supplied> instituamus adposita<supplied>s</supplied> disputationes
+                in trac<supplied>ta</supplied>tum aut ordine<del>m</del> persequamur, quam multa
+                praecedunt, quibus ad hanc disputandam materia<supplied>m</supplied> instrui
+                debeamus! tali enim operatione<del>m</del> naturae regimur, ut uniuersa, ad quae
+                pertinemus aut quae ad nos pertinent, sensibus nostris uelut confusa offerantur-
+                    ipsa<del>quo</del>que animi<supplied>s</supplied> didicerimus dinoscere. quid
+                quod id ipsum, quod quid est a<supplied>ut</supplied> quale, prius
+                    qua<supplied>da</supplied>m in parte uidemus, nec statim totam partis
+                proprietatem cernimus, nisi in singulas portiones auocatum undique uisum direximus,
+                ut relicta magnitudinis occupatione paulatim ad notitiam rei animus inducatur. eadem
+                ratione etiam ceterae intellectus qualitates tenentur. per quas
+                    <supplied>ad</supplied> aliud opus festinantibus satis dilucida existit
+                probatio, capacitatem rerum generi humano esse concessam, quarum
+                    multitudine<del>m</del> oneramur. at in uniuersa distringimur, ut ad certa et
+                electa nisi elaborato studiorum iudicio peruenire nequeamus. ut enim nec ferrum
+                    <supplied>in</supplied> genere secare potest, nisi ad secandum habilem acceperit
+                figuram, sic animus naturalium capax rerum, nisi certo disciplinae
+                    ordine<del>m</del> a<supplied>di</supplied>utus, subtilioribus indiget
+                argumentis. quam ob rem interpraecipua honestarum amore artium
+                    conpun<supplied>g</supplied>ere animum et bonae mentis instrumentis fundare
+                debemus. si quidem secundum cognitas mihi artes huius partis si<del>n</del>t aut
+                experimenti copia, perferendi quoque suffeceri<del>n</del>t facultas, poterit
+                    labor<del>ar</del>i <milestone unit="page" n="p. 22 Thulin"/> nostro non inter
+                    minim<supplied>ar</supplied>um utilitatium profectus locus uindicari.</p>
+            <p>Quoniam itaque de controuersiis meminimus agrorum, hae quot partibus dividantur et in
+                quot genera possessionum aut quas habea<supplied>n</supplied>t qualitates,
+                tractemus.</p>
+            <p>Quom autem quaerendum uideatur, quid sit ager et ubi sit, ad ordinem mundi partesque
+                reuocamur. mundus autem, uti<del>n</del> stoici decer<supplied>n</supplied>unt, unus
+                esse intelligitur: sed qualis quantus, geometricis spectaminibus aperitur. eo enim
+                elementorum natura terrae aequilibratur. huius terrae pars die<del>i</del> fulget,
+                pars nocte fuscatur. diuiditur, ut supra diximus, in quattuor partes. quarum una
+                inter Atlanticum et e<supplied>o</supplied>um mare meridiano ac septentrionali
+                clauditur Oceano, habitabilis atque cognita: appellatur a Graecis oecumene.
+                    reliqu<supplied>ae ig</supplied>itur habitabilis ratione colliguntur. contraria
+                autem pars parti <supplied>isti</supplied> finitur Oceano Atlantico atque eoo et
+                inter meridianum et australem cohibetur Oceanum: appellatur
+                    ant<supplied>o</supplied>ecumene. post Oceanum septentrionalem atque australem
+                duae terreni partes meridiano diffinduntur Oceano: quarum Graeci austro
+                    prop<del>r</del>iorem antictonon appellauerunt; alteram prop<del>r</del>iorem
+                septentrioni antipodon, quoniam emisperiou aliud latus optinet et ad rationem
+                habitabilis <supplied>t</supplied>etartemorii contrariis ambulantium gressibus
+                    premit<del>tit</del>ur. <supplied>o</supplied>ecumene autem, hoc est habitabilis
+                et cognita terreni portio, ad notitiam spatiorum incrementis redigitur umbrarum.
+                huius latitudinem definit orientis occidentisque dimensio,
+                    altitudine<supplied>m</supplied> septentrionalis facit kardo: intra haec spatia
+                    termina<del>n</del>tur utroque Oceano. tripertita regionum diuisione<del>m</del>
+                distinguitur, Europa Libya atque Asia. Europam a Libya Gallicum
+                    Tyr<supplied>r</supplied>enum Egeum, hoc est intestinum, mare diuidit,
+                    Asia<supplied>m</supplied> ab Europa <supplied>Ta</supplied>nais, a
+                    Lib<supplied>ya Nilus. ex his argument</supplied>aliter inclinamentorum condicio
+                    cognoscet<supplied>ur</supplied>, intra quae ager imperii Romani spatioso fine
+                diffunditur, cuius controuersias generaliter exsequi proposuimus.</p>
+            <p>
+                <milestone unit="page" n="p. 23 Thulin"/> Ager est <unclear/>finiruris <gap/> non
+                praetermittimus nomina consent<supplied>i</supplied>entia condicionibus
+                possessionum.</p>
+            <p>Prima enim condicio possidendi haec extat per Italiam; ubi nullus a<del>iu</del>ger
+                est tributarius, sed aut colonicus aut municipalis, aut alicuius castelli aut
+                conciliabuli, aut saltus priuati.</p>
+            <p>At si ad prouincias respiciamus, habent agros colonici quidem iuris, <del>habent et
+                    colonicos stipendiarii</del> qui sunt in<del>com</del>munes, habent<del>em</del>
+                et coloni<supplied>co</supplied>s stipendiarios. habent autem prouinciae et
+                municipales agros aut ciuitatium peregrinarum. Et stipendiarios, qui nexum non
+                habent neque possidendo ab alio quaeri possunt. possidentur tamen a priuatis, sed
+                alia condicione<del>m</del>: et ueneunt, sed nec mancipatio eorum legitima potest
+                esse. possidere enim illis quasi fructus tollendi causa et praestandi tributi
+                    condicio<supplied>ne</supplied> concessum est. uindicant tamen inter se non
+                minus fines ex aequo ac si priuatorum agrorum. etenim ciuile est debere eos
+                discretum finem habere, quo unus quisque aut colere se sciat oportere aut ille qui
+                iure possidet possidere. nam et controuersias inter se tales mouent, quales in agris
+                inmunibus et priuatis <milestone unit="page" n="p. 24 Thulin"/> solent euenire.
+                uidebimus tamen an interdicere quis possit, hoc est ad interdictum prouocare, de
+                eius modi possessione<del>m</del>.</p>
+            <p>Multa enim et uaria incidunt, quae ad ius ordinarium pertinent, per prouinciarum
+                diuersitatem. nam cum in Italia ad aquam pluuiam arcendam controuersia<del>m</del>
+                non minima concitetur, diuerse in Africa ex eadem re tractatur. quom sit enim regio
+                aridissima, nihil magis in querella habe<supplied>n</supplied>t quam siquis
+                inhibuerit aquam pluuiam in suum influere: nam et ag<supplied>g</supplied>eres
+                faciunt <supplied>et</supplied> excipiunt et continent eam, ut ibi potius consumatur
+                quam abfluat.</p>
+            <p>In omnibus his tamen agris superius nominatis quot genera controuersiarum
+                exerceantur, tractare incipiamus. nam et qualia sint et quot status habeant
+                generales, diligenter intueri debemus.</p>
+            <p>Etenim ad artificium defendendi plurimum prode erit, si persecuti <del>hu</del>ius
+                    omni<del>s</del> diligentia fuerimus. non enim a qualibet parte<del>m</del>
+                adgrediendum est in controuersia<del>m</del> sed dispiciendum, cui postulationi
+                absolutio proxima sit, ne inplicatione<del>m</del> aliqua et iudicem inpediamus et
+                controuersiam faciamus obscuriorem. nihil puto deformius esse quam
+                    <supplied>cum</supplied> de eius modi causis inperiti idoneas uolunt exhibere
+                aduocationes. quaecumque autem in artificio generaliter
+                <supplied>e</supplied>ueniunt, colligi utcumque possunt: reliqua omnia sunt
+                infinita. in quantum potero tamen a generalibus specialia argumentis tractabo, cum
+                ab exiguo quid<supplied>em</supplied> exemplo secund<supplied>um loc</supplied>orum
+                    natura<supplied>m</supplied> colligere possint, quid potissimum sequi
+                    debea<supplied>n</supplied>t. </p>
+            <p>
+                <milestone unit="page" n="p. 25 Thulin"/>Quamquam non ignorem,
+                    in<supplied>ter</supplied> professores inmodice coutrouersiarum
+                    quaestione<supplied>m</supplied> frequenter agitata<supplied>m</supplied>,
+                necessariam studii exercitationem huius quoque partis existimaui. uno enim libro
+                instituimus artificem, alio de arte disputauimus, cuius tripertitionem
+                    <supplied>s</supplied>ex libris, ut puto, satis conmode sumus executi. exigit
+                enim <del>p</del>ars scientiam metiundi, cui datur libri tertia pars, quam quinto et
+                sexto libro continuabimus. et de adsignationibus et partitionibus agrorum et de
+                finitionibus terminorum <supplied>h</supplied>actenus deputato artis mensoriae
+                ordine meminimus: superest nunc ut de controuersiis disputem. quae pars, quamuis
+                quarta sit uniuersitati<supplied>s</supplied>, seiungitur, quoniam communis est cum
+                aliis artibus et priuatae disputationis exigit cu<supplied>ra</supplied>m.
+                    qua<supplied>m</supplied> ita capere ac persequi poterimus, si anticipalia
+                quoque, quibus init<supplied>i</supplied>a substituuntur, non praetermiserimus.</p>
+            <p>Omnium igitur honestarum artium, quae siue naturaliter aguntur siue
+                    a<supplied>d</supplied> naturae imitationem proferuntur, materiam optinet
+                rationis artificium geometria, principio ardua ac difficilis incessu, delectabilis
+                ordine, plena praestantiae, effectu insuperabilis. manifestis enim
+                    rationi<del>bu</del>s executionibus declarat <supplied>rat</supplied>ionalium
+                materiam, ita ut geometria<supplied>m</supplied> ine<del>o</del>sse artibus aut
+                    arte<supplied>s</supplied> ex geometria esse intelligat<supplied>ur</supplied>.
+                si enim rationis incrementa tractamus arte, simplicibus ac planis solidisque
+                    adhibita<supplied>m</supplied> etiam <supplied>ante</supplied> nomen
+                    potestate<supplied>m</supplied> cognoscimus: quin et geometrica analogia aut
+                    <supplied>h</supplied>armonica aut arithmetica, <del>a</del>ut contraria aut
+                quinta aut sexta et ceteros ordines, exercemus; ut non tantum artificiorum, uerum
+                etiam omnium rerum qualitates probabiliter ostendat. sed quoniam tant<del>um</del>a
+                naturalium rerum magnitudo exercitatioris acuminis exigit curam, non <milestone
+                    unit="page" n="p. 26 Thulin"/> facile geometria uulgari tangitur
+                    opinione<del>m</del> et ad intellectum sui nisi quos ad naturalem philosophiam
+                    proue<supplied>h</supplied>at admitti<supplied>t</supplied>. <gap/>
+            </p>
+            <p>Prius quam de transcendentia controuersiarum tractare incipiam, status earum
+                exponendos existimo, quoniam in priore<del>m</del> parte<del>m</del> libri
+                sequentium rerum ordo absolute de his disputari inhibuit. reddendum itaque hic locum
+                tam necessariis partibus existimo.</p>
+            <p>Omne genus controuersiarum ex quadam materiali bipertitione generatur. constat autem
+                haec bipertitio aut in fine aut in loco, non sine illa controuersia quae de
+                positione terminorum praescribitur. Quem admodum unum extra positum est, quo
+                separato a cetero numero duo primum numera<supplied>n</supplied>tur, in hoc quoque
+                numero controuersiarum de positione terminorum ad unius omnino condicionem respicit,
+                et quamuis sit origo quaedam litium, minime tamen adiungi materialibus controuersiis
+                uidetur posse, quoniam singulariter omnium litium anticipalis existit, et si
+                querella eius ad solum descendit, desin<supplied>i</supplied>t controuersia
+                    e<supplied>sse</supplied> de positione terminorum: finis enim incipit esse aut
+                loci. ergo legitimi materiales status controuersiarum hi duo uidentur
+                ex<del>i</del>stare, de fine aut de loco: reliquae controuersiae, quaecumque sunt,
+                ex hac materia oriuntur et aut ordine<del>m</del> mensurarum aut partibus iuris ad
+                status generales priuatos reuoca<supplied>n</supplied>tur. namque in ordine
+                coutrouersiarum haec quoque materia li<supplied>ti</supplied>s locum suum optinet. </p>
+            <p>
+                <milestone unit="page" n="p. 27 Thulin"/>De fine subtilior exigitur disputatio, quae
+                a rigore nullo modo distat nisi specie. De quibus est diligentius disputandum:
+                quotiens enim de fine aut de rigore dicimus, non p<del>l</del>usilla quaestio
+                oritur, una<supplied>m</supplied> pluresue lineas sentiamus; ne praeterea lex
+                Mamilia fini latitudinem praescribat. de qua lege iuris periti adhuc habent
+                quaestionem, neque antiqui sermonis sensus proprie explicare possunt, quini pedes
+                latitudinis dati sint, an in tantum quinque. uide<del>n</del>tur tamen his, quinque
+                pedum esse latitudinem, ita ut dupondium et semisse<supplied>m</supplied> una
+                quaeque pars agri finem pertinere patiatur.</p>
+            <p>Ergo si corpus habet finis, aliter sentire debemus ac <supplied>si</supplied>
+                singularem tantum linea<supplied>m</supplied> intueamur. in omni enim genere
+                disterminationis, cui uel singularis linea interueniat et ex uno duas diuidat
+                partes, ipsius mediae lineae sec<del>u</del>tura singularem habet contemplationem,
+                sed efficit duas partes horum locorum diuisorum, et si proprius sentire uelimus,
+                triplex incipit esse contemplatio vel diuisae, <supplied>non duplex</supplied>.
+                uidebimus tamen an tota si<del>n</del>t corporalis. nam quidquid terreni est
+                diuisum, sequitur ut et omnino corporale esse constet. inter uersuras autem duas
+                illud genus lineamenti quod mensura distrinxit, quom ex inferiore parte terreno
+                finiatur, etiam si graciliter, in modum tamen sulci, per supplementum aeris
+                conspicitur. secundum rationem quorundam philosophorum aut geometrarum <del>non
+                    duplex</del> illud quoque quod aere<del>s</del>
+                    distinguit<supplied>ur</supplied> corporale esse decernitur. nunc quem admodum
+                <gap/>
+            </p>
+            <p>
+                <supplied>Falsa pro</supplied>positio est, cum controuersia alium habeat statum
+                generalem et alio ad litem deducatur. uera propositio est <milestone unit="page"
+                    n="p. 28 Thulin"/> cum per stat<supplied>um</supplied> generalem
+                    controuersia<del>m</del> ad litem deducitur. ex falso ergo in uerum
+                transcendentia est, cum a quolibet alio statu ad generalem statum controuersia
+                reuocatur. ex uero in falsum transcendent<supplied>ia</supplied> fit, cum relicto
+                    generali<del>s</del> statu<del>s</del> quolibet alio statu controuersia
+                instruitur.</p>
+            <p>Ex non stante propositione in <del>te</del>stante<supplied>m</supplied> transcendunt
+                controuersiae, quotiens loci de quo agitur specialia argumenta nulla existunt, neque
+                ullum finitimae similitudinis mo<supplied>nu</supplied>mentum, sed tantum aboliti
+                finis querella exponitur, et excipiens extantium argumentorum quadam expositione
+                defenditur. nam nec uno genere, sed et si proximi<del>ae</del>tas aliqua naturalis
+                fuit, quae similitudine<supplied>m</supplied> finis adferre possi<del>n</del>t, in
+                illam quoque uelut extantium argumentorum opportunitas aptatur. ex re
+                    stant<supplied>e</supplied> i<supplied>n</supplied> non
+                    stante<supplied>m</supplied> fit transcendentia, cum certus
+                    agro<supplied>rum</supplied> finis, qui aut loci natura aut terminorum
+                distinctione firmatus est, relinquitur et per uanas demonstrationes controuersiae
+                includitur. hoc modo controuersiae plerumque ab ambitio<supplied>sis</supplied>
+                possessoribus proximis mouentur. euenit autem, ut eius modi demonstrationes,
+                    <supplied>ni</supplied>si ratione defenda<supplied>n</supplied>tur, interibiles
+                fiant; si contra pro ueris habeantur, ut interibilis inprudentia iudicantium
+                    fia<del>n</del>t uidelicet finitio.</p>
+            <p>A quocumque autem controuersia<supplied>e</supplied> de agris mouentur, effectus
+                habent aut coniunctiuos aut disiunctiuos aut spectiuos aut
+                    expos<del>c</del>it<supplied>iuos</supplied> aut
+                    reciperat<supplied>iuos</supplied>. coniunctiuus est effectus, quotiens
+                consentientibus angulis exploratus agrorum finis ad modum rationis accipit
+                determinationem inlaeso utriusque agri<del>s</del> solo: <supplied>hoc</supplied>
+                genus finitionis plerique inter <supplied>se</supplied> conuenientes potius quam
+                iudices sortient<supplied>es</supplied> factum consignare malunt; disiunctiuus est
+                effectus, cum determinatio alterius partis solum desecat et ita
+                    <del>ae</del>qualitate<supplied>m</supplied> agri diuersam
+                    <supplied>dis</supplied>simili <milestone unit="page" n="p. 29 Thulin"/> solo
+                applicat, ut plerumque euenit <supplied>ut</supplied> ex prato siluae aliquid
+                adiungatur aut ex silua fine distincto adplicetur ad pratum, et similiter per alias
+                agrorum qualitates. spectiuus est effectus, cum est demonstratio finitimis
+                argumentis ex maxima parte fundata, ita ut et dubi<supplied>i</supplied>s quoque
+                locis aspectum praebeat finitionis. namque animum non tantum ratione orationis
+                intrauit, sed etiam contemplandi potestate confirmat. expositiuus est effectus
+                controuersiae, quotiens finitimorum argumentorum caret demonstratione et partium
+                magis exigit narrationes, per quas exponendum sit quo<del>d in</del> rigore termini
+                    desi<supplied>n</supplied>t, aut persuadendum iudici, etiam si loci natura
+                finitimam exhibeat similitudinem, quomodo sint reponendi. subiectiuus est effectus
+                controuersiae, cum relinquitur status generalis et alio quolibet statu controuersia
+                defenditur. reciperatiuus est effectus controuersiae, quotiens a trifinia aut
+                quadrifinia <supplied>aut</supplied> ex quolibet alio finis loco in excipientem
+                terminum rectura dirigit et per incessum definitionis loca quaedam alteri fundo
+                adquirit; aut quotiens solum aufer<del>e</del>t et eius loco reddit<del>us</del>
+                utrique fundo, effectus quasi reciperatiuus existit.</p>
+            <p>Per hos effectus omnium controuersiarum status inuicem habent
+                    transcendentia<supplied>s</supplied> aut necessarias aut que<del>e</del>untes
+                aut neque<del>e</del>untes, saepe interibiles. cum enim status generalis adsumptiuus
+                primae controuersiae, quae est de positione terminorum, in rigorem aut in finem
+                transcendit, e<supplied>s</supplied>t quidem necessarius causa argumentorum, sed in
+                illo genere controuersiae nequiens habetur: at si uere de fine agatur et omnino
+                    termin<supplied>at</supplied>us distinctio ei desit, manifeste transcendentia
+                eius non tantum nequiens sed interibilis apparet. eadem ratione in ceteris
+                    <milestone unit="page" n="p. 30 Thulin"/> controuersiis haec transcendentia
+                adficitur, ut aut non necessaria aut nequiens <supplied>aut</supplied> interibilis
+                appareat. secunda controuersia de rigore, initialis status pertinentis ad materiam,
+                    <supplied>cum</supplied> transcendit in controuersiam quae est loco tertio de
+                fine, status materialis, speciem, non condicionem, mutat neque
+                    materia<supplied>lis</supplied> efficit<supplied>ur</supplied>. secunda
+                controuersia de rigore, status initialis, quom transcendit in
+                    controuersia<supplied>m</supplied> quae est loco <supplied>quarto de
+                    loco</supplied> materialis, transcendentia eius non necessaria efficitur.
+                secunda <supplied>tertia quarta quom in</supplied> controuersiam quae est loco
+                quinto de modo, status effectiui, transcendunt <gap/>
+            </p>
+            <p>
+                <supplied>DE POSITIONE TERMINORVM</supplied>
+            </p>
+            <p>
+                <gap/> secundum locorum natura<supplied>m</supplied> mouet causas. Si uero in alio
+                loco terminus translatus est usurpandi finis causa<del>m</del>, numquam non utique
+                locum desicauit: non enim cito quisquam propter exiguam partem terminum mouet. erit
+                    inprouidentia<del>m</del> mensoris secundum angulorum finitimorum positionem
+                arbitrari, in quantum sit terminus translatus et qua ratione sit in locum suum
+                restituendus.</p>
+            <p>Facillimum est inperitia<supplied>m</supplied> artificis aliusue retundere non
+                    putant<supplied>is</supplied> rationem inesse ordini: nam et frequenter
+                    <milestone unit="page" n="p. 31 Thulin"/> euenit, ut inperitia mensorum
+                    <del>an</del>audacia<supplied>m</supplied> possessoribus praebeat. numquam non
+                concurrentium inter se finium anguli, non tantum recti uerum etiam hebetes aut
+                acuti, habe<del>a</del>nt aliquam rationem; in qua<supplied>m</supplied>, si non
+                dissimulemus, facile quod inperiti turbauerunt artificio restituemus.</p>
+            <p>Haec controuersia moti termini null<supplied>i</supplied>us in se aliae controuersiae
+                statum recipit: est enim anticipalis et quasi comminatio quaedam litium, declarans
+                aut loci aut modi futura<supplied>m</supplied>
+                controuersia<supplied>m</supplied>.</p>
+            <p>De rigore controuersia est status initialis pertinentis ad
+                    materia<supplied>m</supplied> operis; nec sine prioris controuersiae
+                comparatione. nam cum de rigore agatur, potest fieri ut ante motus sit terminus:
+                ideoque haec secunda controuersia<del>m</del> prioris quoque controuersiae capax
+                apparet; quamquam et sine prioris controuersiae interuentu<del>m</del> priuatim de
+                rigore controuersia suscitari possit: nec enim omnibus locis agrorum, aut
+                capientibus aut non capientibus, termini ponuntur.</p>
+            <p>Refer<del>en</del>t in quo agro agatur. si limitatus est, aut ordo limitis ordinati
+                desideratur aut subrunciui aut linearis aut interiectiui rigoris incessus. at si in
+                agro arcifinio si<del>n</del>t, qui nulla mensura continetur sed finitur aut
+                montibus aut uiis aut aquarum diuergiis aut notabilibus locorum naturis aut
+                arboribus, quas finium causa agricolae relinquunt et ante missas appellant, aut
+                fossis aut quodam culturae discrimine <gap/>
+            </p>
+            <p>
+                <supplied>DE FINE</supplied>
+            </p>
+            <p>
+                <gap/>
+                <milestone unit="page" n="p. 32 Thulin"/> agetur. cum enim loci sit tanta iniquitas,
+                et aut praerupta aut abrupta, quae aut ruere aut minui possent, uetus consuetudo est
+                terminos relatis pedibus in solido agro ponere. quamquam non era<del>n</del>t
+                necessarium, cum ipsa loci natura talis esset, ut neque inferiorem uicinum
+                    admittere<supplied>t</supplied> in partem superiorem neque superiori
+                    descensu<supplied>m</supplied> ullo modo praeberet. sed
+                <supplied>di</supplied>ligentes agricolae propter inpudentium uicinorum
+                consuetudinem parum se tutos credunt, nisi ita fundauerint agros, ut etiam aliquid
+                extra mensurarum ordinem faciant.</p>
+            <p>In superciliis autem maioribus non defuerunt qui ita finem seruari uellent, ut
+                quatenus attingere unus quisque possessor posset, eatenus<del>u</del>
+                    possidere<supplied>t</supplied>. uidebimus an aliquam rationem sint secuti, cum
+                sit totum supercilium superioris agri fundamentum nec, si subruatur, possit sine
+                iniuria superioris fieri. ideoque magis certior ratio illa uidetur, ut fundamento
+                tenus in agro arcifinio possessio seruari debeat, si termini desint.</p>
+            <p>Frequenter inter se possessores propter loci difficultatem totum supercilium, quod
+                    ange<supplied>re</supplied>ntur ipso subiacente, inferioribus cesserunt, et
+                contenti fuerunt terminos per summum iugum disponere, nullam secuti rationem. haec
+                tamen si occurrunt, non quasi noua intueri debebimus.</p>
+            <p>
+                <milestone unit="page" n="p. 33 Thulin"/> Plurimis deinde locis terminos
+                sacrificales non in fine ponunt, sed ubi illud sacrificii potius opportunitas
+                suadet, hoc est loci conmoditas, in quo sacrificium abuti conmode possint. hos
+                terminos non statim finitimos obseruare debebimus, etiam si non longe a fine positi
+                fuerint: frequenter enim uiae finiunt, iuxta quas arbores solent esse laetiores, sub
+                quas defigere terminos sacrificii causa possessores consuerunt. uerum tamen multi
+                non tantum sacrificii sequuntur consuetudinem sed etiam rationem, et ipso fine
+                defigunt: propter quod adimi fides sacrificalibus palis in totum non debet.</p>
+            <p>
+                <gap/>
+            </p>
+            <p>
+                <supplied>DE LOCO</supplied>
+            </p>
+            <p>
+                <gap/>
+                <unclear/> haberi ordinem legis Mamiliae excessum plurimum, praecipue in
+                    ag<supplied>r</supplied>is arcifiniis sed nec minus id adsignatis. cum enim
+                modum loci nulla forma praescribit et controuersia oritur, nullo alio
+                    statu<del>m</del> ad litem deduci debet, quam ut de loco agatur; solent quidam
+                per inprudentiam mensores arbitros conscribere aut sortiri iudices finium regundorum
+                causa, quando in re praesenti plus quidem quam de fini<del>um</del> regundo agatur.
+                    si<supplied>c</supplied> fit ut pos<supplied>t</supplied>
+                    sent<supplied>ent</supplied>iam inritum sit et rescindi possit, quod aut iudex
+                aut arbiter pronuntiauerint, neque ullum commissum faciat qui
+                    sententia<supplied>m</supplied> non sit secutus, quando de alia re iudicem aut
+                arbitrum sumpserint.</p>
+            <p>De <del>hoc</del> loco, si possessio petenti firma est, etiam <milestone unit="page"
+                    n="p. 34 Thulin"/> interdicere licet, dum cetera ex interdicto diligenter
+                peraguntur: magna enim alea est litem ad interdictum deducere, cuius est executio
+                perplexissima. si uero possessio minus firma est, mutata formula iure Quiritium peti
+                debet proprietas loci; iudicari praeterea, si locus de quo agitur aut terminis aut
+                arboribus aut aliquo argumento finem aliquem agri declaret et a continuatione soli
+                quasi quibusdam argumentis eximatur.</p>
+            <p>Ne praeterea<supplied>t</supplied> nos, illud etiam tractare debemus, si arbores
+                finitimas habet et locus est fere siluester, quo in genere est possessio minus
+                firma, ne certetur i<supplied>nter</supplied>dicto. quod si silua caedua sit, post
+                quintum annum parcissume repetatur. qui autem appellent arbores notatas, scire
+                debemus idioma regionis. qui<supplied>dam</supplied> plagatas uocant quas finis
+                declarandi causa denotant, ut in Brittiis, alii in Piceno stigmatas, in aliis
+                regionibus insignes aut notas.</p>
+            <p>Si uero pascua sit et dumi ac loca paene solitudine derelicta, multo minorem
+                possessionis habent fidem. propter quod <supplied>m</supplied>inime de his locis ad
+                interdictum iri debet.</p>
+            <p> De quibus autem locis ad interdictum ire possunt, <supplied>sunt</supplied> fere
+                culta, quae possessionem breuioris temporis testimonio adipiscuntur, ut arua aut
+                uineae aut prata aut aliud aliquod genus culturae. haec tamen cum in demonstratione
+                allegabuntur, etiam si partes qua<supplied>e</supplied>dam proximae et
+                    in<supplied>ter</supplied>iacentes culturae fuerint
+                    propria<supplied>e</supplied>, non eri<del>n</del>t satis
+                    illa<supplied>s</supplied> sui generis agro adsignare, sed <milestone
+                    unit="page" n="p. 35 Thulin"/> circuire oportebit totum fundum et ita fidem
+                obligare, ne demonstratione neglegenter soluta appareat.</p>
+            <p>De modo controuersia <supplied>est</supplied> status effectiui: ante enim locus est
+                ibi quam modus nominetur: aeque recipiens ante dictarum controuersiarum omnes
+                status, sed ut superius significaui irritos et non necessarios. Haec controuersia
+                frequenter in agris adsignatis exercetur: agitur enim, ut secundum acceptam eius
+                    ueter<supplied>an</supplied>i, qui in illud solum deductus est, modus
+                restituatur; aut si quando praescribtus est lege aliqua agri modus.</p>
+            <p>Quom autem in adsignato agro secundum formam modus spectetur, solet tempus inspici et
+                agri cultura<del>e</del>. si iam excessit memoria<del>m</del> abalienationis, solet
+                iuris formula <del>non silenter</del> interuenire et inhibere mensores,
+                    <supplied>n</supplied>e tales controuersias concipia<supplied>n</supplied>t,
+                neque quietem tam longae possessionis inrepere
+                    <supplied>si</supplied>ni<supplied>t</supplied>. si et memoria sit recens et iam
+                modus secundum centuriam conueniat et loci natura indicetur et cultura, nihil
+                inpediet secundum formas aestimatum petere: lex enim modum petiti<del>s</del>
+                definite praescribit, cum ante quam mensura agri agatur modus ex forma pronuntiatus
+                cum loco conueniat. Hoc in agris adsignatis euenit. nam si aliqua lege uenditionis
+                exceptus sit modus neque adhuc in mensuram redactus, non ideo fide carere debebit,
+                si nostra demonstratio eius in agro non ante finiri potuerit quam de sententia
+                    loc<del>ut</del>us sit designatus.</p>
+            <p>
+                <gap/> in hac controuersia, quod i<supplied>n</supplied>ter priuatos tractatur.</p>
+            <p>
+                <milestone unit="page" n="p. 36 Thulin"/> Nam inter res publicas non mediocriter
+                eius modi controuersia solet exerceri, quam frequenter coloniae habent cum
+                    coloni<supplied>i</supplied>s aut municipiis aut saltibus Caesaris aut priuatis.
+                nam et supra dictae controuersiae omnes euenire et rebus publicis possunt. nec enim
+                referf, cuius si<del>n</del>t solum aut cuius iuris, ad mouendam controuersiam: tunc
+                autem habe<del>n</del>t differentia<supplied>m</supplied>, prout ab iudice
+                tractatur.</p>
+            <p>Obseruari in hac controuersia <supplied>a</supplied> mensore debebit
+                    <supplied>l</supplied>ineis, dum in similitudinem dissimile interrueniat;
+                quoniam nulla potest ueritas adprobari, si illi qui<supplied>d</supplied> uel
+                exiguum falsi interueniat. ueritas enim habere debet suam similitudinem per omnia
+                momenta: falsum siquid est, multa uarietate confunditur. et habe<del>n</del>t aes,
+                cuius formam respicit, cum modus in <supplied>dis</supplied>crimine est.
+                    <del>p</del>ars triplici adtestatione firmatur: habere enim debet aes
+                    primu<supplied>m</supplied> locum, deinde modum, deinde speciem. at si inter
+                    <supplied>res publicas</supplied> agatur au<supplied>t</supplied> rem publicam
+                et Caesarem, instrumentis forte ueteribus continebitur, ut solet, adaeratio; ne
+                falsa ueris dissimilia sint, sed persuasione similia fiant, hoc est falsa pro ueris
+                    <milestone unit="page" n="p. 37 Thulin"/> adprobentur. in conparatione tamen hoc
+                interest, quod falsa persuadendo adprobentur ueris, qua<supplied>e</supplied>
+                adprobatio in promptu<del>m</del> est et quodam modo in prima acie fertur, falsis
+                latentius hoc uera adprobentur. ita ut si conparare quis uelit hominis probationem
+                et statuae; cum autem hominem omnibus bibere et ambulare constet, siquis inquirere
+                uelit ann<supplied>e</supplied> uiuat, non potest illi non ab ipsis probationibus
+                persuaderi, ideo quo<supplied>d</supplied> bibat, quod ambulet, quod loquatur; at
+                    <supplied>in</supplied> statua <supplied>diu</supplied> multumque mens
+                    infri<supplied>n</supplied>genda est, ut similitudo ueritatis animam habere
+                    uideat<supplied>ur</supplied>, de cuius simulatione est profecta.</p>
+            <p>
+                <gap/>
+                <supplied>ad lu</supplied>cum Feroniae Augustinorum iugera M. haec in discrimen si
+                uenerunt, omnia supra dicta conuenienter habere debent, ut illa
+                    si<supplied>n</supplied>t, quae secundum forma<supplied>m</supplied>
+                proponuntur. geminus in prouinciis modus ab alio possidetur, ab alio ne quidem
+                simplex. quem admodum autem fieri soleat, tractare non alienum iudic<del>i</del>o.
+                potest enim fieri, ut illa mille iugera secundum ordinationem mensoris a luco quidem
+                incipiant, at in diuersa<del>m</del> regione<del>m</del>. quod falsum manifesto
+                apparet: sed in demonstratione inperitis obscurissimum est dinoscere, an secundum
+                formam regio <milestone unit="page" n="p. 38 Thulin"/> conueniat praesens, si
+                    <supplied>u</supplied>t aquae diffusae regiones pareant et argumentis aut
+                arborum aut aliarum rerum careant; sicut in Africa, ubi spatiositas et inundatio
+                camporum eius modi controuersias facillime in errorem deducit. quod si eadem mille
+                iugera, in eodem sane loco <supplied>quo</supplied> forma indic<del>t</del>at,
+                cohibitis angulis <del>nihil deest</del> in re praesenti minoribus lineamentis
+                deformentur, ut modum non expleant, sequitur falsum futurum, quando nihil amplius
+                demonstrationi quam locus conueniat, et specie disconueniente, uelut AD pro CA
+                    <del>ad</del>scripta, modus item disconueniat. at si in eodem loco uelim eadem
+                mille iugera aliis lineamentis describere, conuenient quidem mille iugera, et ad
+                lucum Feroniae esse conueniet, sed specie disconueniente inter peritos manifeste
+                falsum apparebit.</p>
+            <p>Memineram et superius, ut aliquid uerum adprobari possit, minime ei quicquam falsi
+                posse interuenire. nam et haec expositio declarat, <supplied>ut</supplied>, quamuis
+                duae consentiant partes, ab una dissentiente uincantur, neque uerum esse possit,
+                nisi illis quoque tertia pars illa consenserit. conuenire autem omnino in
+                restitutione formarum omnia debent, ut secundum signa in formis nominata locus
+                quicumque erat restituatur, aut artificio signorum loca requirantur, si
+                    eri<supplied>n</supplied>t, ut frequenter euenit, turbata.
+                    <supplied>ea</supplied> docere nos angulorum positiones poterint. sic erit, ut
+                et artis sinceritas seruetur et ordo ueteris adsignationis non praetermittatur.</p>
+            <p>
+                <milestone unit="page" n="p. 39 Thulin"/>De proprietate <del>mundi</del>
+                controuersia est status effectiui: efficitur enim ex omnibus ante dictis
+                controuersiis. sed quarum status in hac propositione inriti habentur, dixi et
+                supra.</p>
+            <p>De proprietate agitur plurimum iure ordinario, neque est hic mensurarum interuentus,
+                nisi cum quaeritur, quatenus agatur.</p>
+            <p>Proprietas <supplied>non</supplied> uno genere uindicatur.</p>
+            <p>Et sunt plerumque agri, ut in Campania in Suessano, culti, qui habent in monte
+                Massico plagas siluarum determinatas; quarum siluarum proprietas ad quos pertinere
+                debeat uindicatur. nam et formae antiquae declarant ita esse adsignatum, quoniam
+                solo culto nihil fuit siluestre iunctum quod adsignaretur.</p>
+            <p>Relicta sunt et multa loca, quae ueteranis data non sunt. haec uariis appellationibus
+                per regiones nominantur: in Etruria communalia uocantur, quibusdam prouinciis pro
+                iudiuiso. haec fere pascua certis personis data sunt depascenda tunc, cum agri
+                adsignati sunt. haec pascua multi per <supplied>in</supplied>potentiam inuaserunt et
+                colunt: et de eorum proprietate solet ius ordinarium moueri non sine interuentu
+                mensurarum, quoniam demonstrandum est, quatenus sit adsignatus ager.</p>
+            <p>Nam per emptiones quasdam solet proprietas quarundam possessionum ad
+                    <supplied>priuatas</supplied> personas pertinere. quae iure magis ordinario quam
+                mensuris explicantur. </p>
+            <p>
+                <milestone unit="page" n="p. 40 Thulin"/> Nunc ut ad publicas personas respiciamus,
+                coloniae quoque loca quaedam habent adsignata in alienis finibus, quae loca solemus
+                praefecturas appellare. harum praefecturarum proprietas manifeste ad colonos
+                pertinet, non ad eos quorum fines sunt deminuti. solent et priuilegia quaedam habere
+                beneficio principum, ut longe et semotis locis saltus quosdam reditus causa
+                acceperint. quorum proprietas indubitate ad eos pertinet, quibus est adsignata. alia
+                beneficia etiam quaedam municipia acceperunt et priuatae personae quae de
+                principibus illis temporibus bene meruerunt.</p>
+            <p>In hac controuersia plus potestatis habet ius ordinarium quam ars mensoria. ab eo
+                enim statu lis incipit, <supplied>ut</supplied> de proprietate agatur, non de loco:
+                mensura autem nihil amplius quam secundum formam locum declarat. in hac autem
+                controuersia ars mensurarum locum secundum habet, quoniam prius alii uacandum est,
+                an agenda sit mensura.</p>
+            <p>De possessione controuersia est <supplied>status</supplied>
+                    effect<supplied>i</supplied>ui, quoniam primum possessio tempore efficitur,
+                deinde, ut ad solum respiciamus, omnes ante dictas controuersias capit: si enim
+                solum cogitemus, ut legitima possessio inpleri possit,
+                indubi<supplied>ta</supplied>te locus definiatur necesse est. et de hac controuersia
+                plurimum interdicti formula litigatur. de qua et in superiore parte meminimus:
+                ideoque non puto eam iterum retractandam.</p>
+            <p>De subsiciuis controuersia est status effectiui, quoniam subsiciua nominari aut
+                sentiri sine quadam loci latitudine<del>m</del> aut modo non possunt. ideoque
+                manifeste apparet supra dictarum controuersiarum status in <gap/> locum.</p>
+            <p>
+                <milestone unit="page" n="p. 41 Thulin"/> Subsiciuorum autem genera sunt duo; unum
+                quod extremis adsignatorum agrorum finibus centuria<del>ru</del>m non explet. aliud
+                etiam integris centuriis interuenit. de quo maximae controuersiae agitantur. cum
+                autem adsignatio in agro adsignato fieret, non potuit omnis modus intra IIII limites
+                ueteranis adsignari. in ea remansit aliquid, quod a subsecante linea nomen accepit
+                subsiciuum. in his subsiciuis quidam iterum miserunt quibus agri adsignarentur,
+                quidam et subsiciua coloni<supplied>i</supplied>s concesserunt. ideoque semper hoc
+                genus controuersiae a rebus publicis exercentur. per longum enim tempus
+                    atti<del>n</del>gui possessores uacantia loca quasi inuitante otiosi
+                    <supplied>soli</supplied> opportunitate<del>m</del> inuaserunt et per longum
+                tempus inpune commal<supplied>lea</supplied>uerunt. horum subsiciuorum multae res p.
+                etiam si sero mensuram repetierunt, non minimum aerario publico contulerunt.
+                pecuniam etiam quarundam coloniarum imp. Vespasianus exegit, quae non haberent
+                subsiciua concessa: non enim fieri poterat, ut solum illud, quod nemini erat
+                adsignatum, alterius esse posset quam qui poterat adsignare. non enim exiguum
+                pecuniae fisco contulit uenditis subsiciuis. sed pos<supplied>t</supplied>quam
+                legationum miseratione commotus est, quia quassabatur uniuersus Italiae possessor,
+                intermisit, non concessit. aeque et Titus imp. aliqua subsiciua in Italia
+                recollegit. praestantissimus postea Domitianus ad hoc beneficium procurrit et uno
+                edicto totius Italiae metum liberauit. </p>
+            <p>
+                <milestone unit="page" n="p. 42 Thulin"/>Haec controuersia numquam a priuatis
+                exercetur.</p>
+            <p>De alluuione controuersia est status effectiui: efficitur enim subinde et per tempora
+                mutatur. in hac controuersia plurimum sibi uindicat ius ordinarium. agitur enim de
+                eo solo quod alluat flumen, et subtiles intro ducuntur quaestiones, an ad eum
+                pertinere debeat, cui in altera ripa recedente aqua solum creuit; hic qui aliquid
+                agri sui desiderat transire et possidere illud debeat, quo<supplied>d</supplied>
+                flumen reliquit. nisi quod illud subtilissime profertur, quod is solum
+                    <supplied>a</supplied>misit, non statim transire in alteram ripam, sed abductum
+                esse <supplied>e</supplied>t elotum. et illud, contra uicinum longe dissimilem agrum
+                habere, quod hic forte cultum et pingue solum amiserit, apud illum autem harenae,
+                lapides et limum abluuio inuectum remanserit. illud praeterea, quod finem illis
+                semper aqua fecerit et nunc quoque facere debeat.</p>
+            <p>Sunt et multa, de quibus subtiliter tractatur: sed nec uno tantum genere per
+                alluuionem flumina possessoribus iniurias faciunt. sicut Padus relicto alueo suo per
+                cuiuslibet fundum medium inrumpit et facit insulam inter nouum et ueterem alueum.
+                ideo de hac re tractatur, ad quem pertinere debeat illud quod reliquerit, cum
+                iniuriam proximus possessor non mediocrem patiatur, per cuius solum amnis publicus
+                perfluat. nisi quod iuris periti aliter interpretantur, et negant illud solum, quod
+                    <milestone unit="page" n="p. 43 Thulin"/> solum p(opuli) R(omani) coepit esse,
+                ullo modo usu capi a<del>t</del> quoquam mortalium posse. et est uerisimile ita
+                neuter possessor excedere finem illum ueteris aquae ullo iure potest aut debet. hae
+                quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis
+                contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum
+                regelationum repentina<del>s</del> inundatione<del>s</del> patitur iniurias. </p>
+            <p>Quaeritur tamen, qualia quanta sint flumina, in quibus alluuio obseruari debeat. nam
+                et iure continetur, nequis ripam suam in iniuria<supplied>m</supplied> uicini munire
+                uelit.</p>
+            <p>Multa flumina et non mediocria in adsignationem mensurae antiquae ceciderunt: nam et
+                deductarum coloniarum formae indicant, ut multis fluminibus nulla latitudo sit
+                relicta. sequitur in his fluminibus artem mensoriam aliquem locum sibi uindicare,
+                quando exacto limite accepta finiatur, qua<del>e</del> uel
+                    aqua<supplied>m</supplied> uel agrum uel utrumque habere debeat unus. fuit enim
+                fortasse tunc ratio non simplex, qua deberet quis quid deductorum etiam
+                    <supplied>a</supplied>quae accipere. primum quod exiguitas agrorum conditorem
+                ita suadebat. deinde <supplied>quod</supplied> non erat ingratum possessori proximum
+                esse aquae commodo. tertio quod, si sors ita tulerat, aequo animo ferendum habebat.
+                in his agris exigitur fere mensura secundum <milestone unit="page" n="p. 44 Thulin"
+                /> postulationem aeris formarumque. quo pertica cecidit, eatenus acceptae
+                designantur.</p>
+            <p>Videbimus an inter mensores et iuris peritos esse de hoc quaestio debeat,
+                    cursu<del>m</del> an pertica metiam<supplied>ur</supplied>, si qua usque potuit
+                ueteranis est adsignatum. scio in Lusitania, finibus Emeritensium, non exiguum per
+                mediam coloniae perticam ire flumen Anam, circa quod agri sunt adsignati qua usque
+                tunc solum utile uisum est. propter magnitudinem enim agrorum ueteranos circa
+                extremum fere finem uelut terminos disposuit, paucissimos circa coloniam et circa
+                flumen A<supplied>nam</supplied>: reliquum ita remanserat, ut postea repleretur.
+                nihilo minus et secunda et tertia postea facta est adsignatio: nec tamen agrorum
+                modus diuisione uinci potuit, sed superfuit inadsignatus. in his agris cum subsiciua
+                requirerentur, inpetrauerunt possessores a praeside prouinciae eius, ut aliquam
+                latitudinem An<supplied>ae</supplied> flumini daret. quoniam subsiciua quae quis
+                occupauerat redimere cogebatur, iniquum iudicatum est, ut quisquam amnem publicum
+                emeret aut sterilia quae alluebat: modus itaque flumi<supplied>ni</supplied> est
+                constitutus. hoc exempli causa re<del>i</del>gerendum existimaui. nam et in Italia
+                Pisauro flumiui latitudo est adsignata eatenus, qua usque adlauabat.</p>
+            <p>De iure territorii controuersia est status iniectiui. inicitur enim solo quaedam
+                controuersia e persona: tum praecipue qui<supplied>d</supplied>quid est illud de quo
+                agitur, aut locus aut modus, <milestone unit="page" n="p. 45 Thulin"/> generalem
+                statum <supplied>a</supplied> iure ordinario trahit, etiam si multis locis
+                mensurarum exigat interuentum. haec enim controuersia non tantum inter res publicas
+                sed et inter rem p. et priuatos exercetur, nec tantum iure ordinario sed et arte
+                mensoria conponitur. Inter res p. autem controuersiae eius generis mouentur, ut
+                quaedam sui territorii iuris esse dicant, quamuis sint intra alienos fines,
+                munificentiam quoque coloniae aut municipio ex his locis deberi defendant. sed
+                    <supplied>h</supplied>aec quaedam coloniae aut beneficio conditorum perceperunt,
+                ut Tudertini, aut postea apud principes egerunt, ut Fanestres, ut incolae, etiam si
+                essent alienigenae, qui intra territorium colerent, <del>alii h</del>omnibus
+                    <del>h</del>oneribus fungi in colonia<del>m</del> deberent. hoc Fanestres nuper
+                inpetrauerunt, Tudertini autem beneficio habent conditoris.</p>
+            <p>Inter res p. et priuatos non facile tales in Italia controuersiae mouentur, sed
+                frequenter in prouinciis, praecipue in Africa, ubi saltus non minores habent priuati
+                quam res p. territoria: quin immo multi saltus longe maiores sunt territoriis:
+                habent autem in saltibus priuati<del>s</del> non exiguum populum plebeium et uicos
+                circa uillam in modum municipiorum. r(es) p(ublicae) controuersias de iure
+                territorii sole<supplied>n</supplied>t mouere, quod aut indicere munera dicant
+                oportere in ea parte soli, aut<del>em</del> legere tironem ex uico, aut uecturas aut
+                copias deuehendas indicere, aliquando et ex quadam parte soli; quamuis alium statum
+                    <milestone unit="page" n="p. 46 Thulin"/> generalem controuersiae accipere
+                debeant, quae de loco non exiguo mouentur. res tamen publicae cum priuatis si agunt,
+                quasi iure territorii solent uindicare, et hunc statum generalem constituunt eis
+                locis quae loca res p. adserere conantur. eius modi lites non tantum cum priuatis
+                hominibus habent, sed et plerumque cum Caesare, <supplied>qui</supplied> in
+                prouincia non exiguum possidet.</p>
+            <p>Non est dubium necessarias esse mensuras in eius modi controuersia,
+                    <supplied>quae</supplied> quamuis alio nomine appellatur, locorum tamen facit
+                quaestionem.</p>
+            <p>De locis publicis controuersia est aeque status iniectiui. sunt autem loca publica
+                complura, sed ex his quaedam loca priuata<supplied>m</supplied> exigunt defensionem:
+                et quamuis haec loca diuersis appellationibus contineantur, unam tamen habent
+                controuersiae condicionem.</p>
+            <p>Sunt autem loca publica haec, quae inscribuntur ut SILVAE ET PASCVA PVBLICA
+                AVGVSTINORVM. haec uidentur nominibus data; quae etiam uendere possunt.</p>
+            <p>Est alia inscriptio, qua<supplied>e</supplied> diuersa
+                    significatio<supplied>ne</supplied> uidetur esse, in quo loco inscribitur SILVA
+                ET PASCVA; aut FVNDVS SEPTICIANVS COLONIAE AVGVSTAE CONCORDIAE. haec inscriptio
+                uidetur ad personam coloniae ipsius pertinere <supplied>ne</supplied>que ullo modo
+                    ab<supplied>a</supplied>lienari posse a re<del>i</del> publica<del>e</del>. item
+                siquid in tutelam aut templorum publicorum aut balneorum adiungitur.</p>
+            <p>
+                <milestone unit="page" n="p. 47 Thulin"/> Habent et res p. loca suburbana inopum
+                funeribus destinata, quae loca culinas appellant. habent et loca noxiorum poenis
+                destinata. ex his locis, cum sint suburbana, sine ulla religionis reuerentia solent
+                priuati aliquid usurpare et hortis suis adplicare. de his locis, si r. p. formas
+                habet, cum coutrouersia mota est, ad modum <supplied>mensor</supplied> locum
+                restituit: sin autem, utitur testimoniis et quibuscumque potest argumentis.</p>
+            <p>De locis relictis et extra clusis controuersia est status iniectiui: manifestum est
+                enim de loco agi, sed per aliam personam. loca autem relicta et extra clusa non sunt
+                nisi in finibus coloniarum, ubi adsignatio peruenit usque qua cultum fuit, quatenus
+                    ordinatio<supplied>ne</supplied> centuriarum intermissa finitur. ultra autem
+                siluestria fere fuerunt et iuga quaedam montium, quae uisa sunt finem coloniae non
+                sine magno argumento facere posse ergo fines coloniae inclusi sunt montibus. propter
+                quod haec loca, quod adsignata non sint, relicta appellantur; extra clusa, quod
+                extra limitum ordinationem sint et tamen fine cludantur. haec plerumque proximi
+                possessores inuadunt et opportunitate loci inuitati agrum optinent. cum his
+                controuersiae a rebus publicis solent moueri.</p>
+            <p>De locis sacris et religiosis controuersia est aeque status iniectiui: agitur enim de
+                locis, sed cum aut sacra aut religiosa nominentur, statum generalem a iure ordinario
+                accipiunt. <milestone unit="page" n="p. 48 Thulin"/> primum enim quaeritur, an ea
+                loca ullo modo usu capi possint: deinde, quatenus possint, secundum locum habent
+                mensurae.</p>
+            <p>Locorum autem sacrorum secundum legem populi Rom. magna religio et custodia haberi
+                debet: nihil enim magis in mandatis etiam legati prouinciarum accipere solent, quam
+                ut haec loca quae sacra sunt custodiantur. hoc facilius in prouinciis seruatur: in
+                Italia autem densitas possessorum multum inprobe facit, et lucos sacros occupant,
+                quorum solum indubitate p. R. est, etiam si in finibus coloniarum aut municipiorum.
+                de his solet quaestio non exigua moueri inter r. p. et priuatos.</p>
+            <p>Sed et inter res publicas frequenter eius modi contentio agitatur de his locis, in
+                quibus conuentus fiunt maiores et aliquod genus uectigalis exigitur.</p>
+            <p>Nam et de aedibus sacris, quae constitutae sunt in agris, mutata tantum persona
+                similes tamen oriuntur quaestiones; sicut in Africa inter Adrumentinos et
+                Tysdritanos de aede Mineruae, de qua iam multis annis litigant.</p>
+            <p>Sunt et loca sacra, quae re uera priuatis finibus rei p. col<supplied>on</supplied>i
+                debent. haec plerumque interuentu longae obliuionis casu a priuatis optinentur,
+                quamquam in tabulariis formae eorum plurimae extent. haec maxime aut in loco urbis
+                aut suburbanis locis a priuatis detinentur.</p>
+            <p>De aqua pluuia arcenda controuersia est status iniectiui: per quodcumque enim solum
+                transit, ad ius ordinarium magis respicit condicio eius quam ad mensuras; nisi si
+                    <milestone unit="page" n="p. 49 Thulin"/> per extremitatem finis uadat: propter
+                quod statum generalem etiam alium accersire debet et quasi geminatione quadam
+                defendi, quod et per finem eat et sit lis de pluuia arcenda. haec controuersia per
+                regiones uari<supplied>i</supplied>s generibus exercetur, sed quasi ad eandem
+                respicit condicione<supplied>m</supplied>. in Italia aut quibusdam prouinciis non
+                exigua est iniuria, si in alienum agrum aquam inmittas; in prouincia autem Africa,
+                si transire non patiaris.</p>
+            <p>Eiusdem condicionis est controuersia de cloacis ducendis et
+                fos<supplied>s</supplied>is caecis. quod totum, nisi per finem agatur, ad ius
+                ordinarium pertinet.</p>
+            <p>De itineribus controuersia est status iniectiui: inicitur enim loco quaestio, et
+                defenditur populo quod forte a priuatis possidetur. haec quaestio multipliciter
+                tractatur.</p>
+            <p>Nam in agris ceuturiatis excipitur limitum latitudo causa itineris. sed cum illi
+                recturas suas per qualiacumque loca extendant, hoc est qua ratio dictauit, per
+                cliuia et montuosa, qua iter nullo modo fieri potest, quae loca fortasse possessori
+                siluae causa sint utilia, horum loco non inique, per quae possit loca commode iri,
+                iter commutant.</p>
+            <p>Nam quae sit condicio itinerum, non exigua iuris tractatio est. agitur enim, utrumne
+                    actu<supplied>s</supplied> sit an i<del>n</del>ter <supplied>an</supplied>
+                ambitus. per quae loca quid liceat populo, iure continetur.</p>
+            <p>Satis, ut puto, dilucide genera contronersiarum exposui: nam et simplicius enarrare
+                condiciones earum existimaui, quo facilius ad intellectum peruenirent. nunc quem
+                admodum singulae <milestone unit="page" n="p. 50 Thulin"/> tractari debeant
+                persequendum est. respicio enim quantum sit quod mensori iniungatur, et puto
+                diligentius exequenda quae ad prouidentiam pertinenti<supplied>a</supplied> sunt
+                artificis. difficillimus autem locus hic est, quod mensori iudicandum est; sed nec
+                minus ille exactus, quod est aduocatio praestanda. quamquam diuersa sint et longe
+                inter se discernere debeant, prudentiam tamen eandem artifices habere debent et qui
+                iudicaturi sunt et qui aduocationes sunt praestituri. in iudicando autem
+                    mensor<del>em</del> bonum uirum et iustum agere debet neque ulla ambitione aut
+                sordibus moueri, seruare opinionem et arti et moribus. Omnis illi artifici ueritas
+                custodienda est, exclusis illis similitudinibus, quae falsae pro ueris subiciuntur.
+                quidam enim per imperitiam quidam per inpudentiam peccant: totum autem hoc iudicandi
+                officium et hominem et artificem exigit egregium. erat aequissimum et in
+                    aduocatione<del>m</del> eandem fidem exhiberi in controuersiam a mensoribus. sed
+                hoc possessores aequo animo ferre non possunt: nam cum his ueritas exposita est,
+                aduersus sinceritatem artis facere cogunt. <milestone unit="page" n="p. 51 Thulin"/>
+                multa sunt in professione quae generaliter pro ueris offerantur, multa quae
+                specialiter, quaedam quae argumentaliter. coniecturaliter etiam mentiri artifices
+                coguntur. <gap/>
+            </p>
+        </body>
+    </text>
 </TEI>


### PR DESCRIPTION
### **Correction du fichier stoa0012a.stoa001 correspondant à l'issue #88** 

Pour rappel, le chemin vers le fichier est le suivant :
`data/stoa0012a/stoa001/stoa0012a.stoa001.digilibLT-lat1.xml`

Corrections effectuées pour rendre le fichier compatible avec CapiTainS :

- [ ] `TEI/teiHeader/profileDesc/langUsage/language` : correction du "la" en "lat" pour indiquer la langue utilisée
- [ ] `TEI/text/body/p` : numérotation des paragraphes
- [ ] `TEI/teiHeader/encodingDesc/refsDecl/cRefPattern` : suppression d'une div inexistante et précision que le pointer extrait des paragraphes
- [ ] Suppression de la déclaration RNGSchema en début de document