### PR TITLE
(3/5) Correction du fichier 'stoa0012a.stoa003'

### DIFF
--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -32,9 +32,9 @@
       </fileDesc>
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="unknown" matchPattern="(\w+)"
+            <cRefPattern n="paragraph" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
-               <p>This pointer pattern extracts unknown</p>
+               <p>This pointer pattern extracts paragraph</p>
             </cRefPattern>
          </refsDecl>
          <projectDesc>
@@ -44,29 +44,29 @@
          </projectDesc>
          <editorialDecl>
 
-            <p>
+            <p n="">
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
-            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
+            <p n="">Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
                l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
                introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
-            <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
+            <p n=""> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
                correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+            <p n="">Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
                per la distinzione u/v minuscole.</p>
-            <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
+            <p n=""> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+            <p n=""> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
                grassetto, corsivo, spaziatura espansa.</p>
-            <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
+            <p n="">Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
                &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
                &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
                <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
                &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
                &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
                &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
-            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+            <p n="">Sono stati marcati i termini in lingua greca &lt;foreign
                xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+            <p n="">Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
                   target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
                   >Note di trascrizione e codifica di testi latini tardoantichi
                   [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
@@ -84,7 +84,8 @@
             <list>
                <item>Suppression de la déclaration RNGSchema en début de document</item>
                <item>profileDesc/langUsage/language : correction de l'indicateur de langue utilisé ("la" en "lat")</item>
-               <item></item>
+               <item>encondingDesc/RefsDcl/cRefPattern : indication que le pointer extrait des paragraphes"</item>
+               <item>text/body/div : numérotation des paragraphes</item>
             </list>            
          </change>
       </revisionDesc>
@@ -95,8 +96,8 @@
          <div type="opus">
             <head>Commentum de controuersiis</head>
             <milestone unit="page" n="p. 58 Thulin"/>
-            <p>Suscepimus quoque tractandos controuersiarum status cum diuino praesidio.</p>
-            <p>
+            <p n="1">Suscepimus quoque tractandos controuersiarum status cum diuino praesidio.</p>
+            <p n="2">
                <q>"<hi rend="italic">Materiae</hi>"</q>, inquit,<q>"<hi rend="italic"
                      >controuersiarum sunt duae, finis et locus. harum condicio alterutra
                      continetur. sed quoniam singulae controuersiae diuersis condicionibus
@@ -107,7 +108,7 @@
                neque genus sine specie neque sine genere species potest dici, omnino dixit
                inproprie: nos tamen suum illi idioma relinquentes ad intellegendas eas atque
                exponendas, sicut promisimus, transeamus.</p>
-            <p>
+            <p n="3">
                <q>"<hi rend="italic">De positione terminorum controuersia est inter duos pluresue
                      uicinos; inter duos, an in rigore sit positus terminus citerorum, siue
                      rationis; inter plures, trifinium facit an quadrifinium</hi>
@@ -133,7 +134,7 @@
                rationem, tum de conportionalium terminorum positionem, quos uice tabellarum antiqui
                intercidendis portiunculis inter filios suos defigebant, integra ab artifice ratio
                proferatur.</p>
-            <p>
+            <p n="4">
                <milestone unit="page" n="p. 60 Thulin"/>De rigore atque de fine licet similem
                posuerit controuersiam unamque eis condicionem esse firmauerit, tamen credo inter eas
                aliquid posse differri. rigor enim naturalis est. qualiscumque enim rigor interuenit
@@ -143,7 +144,7 @@
                superior possessor in planum usque descendat et sibi defendat omnem deuexum locum.
                hoc enim lex propter malignitatem inferioris possessoris instituit, ne aut arando aut
                fodiendo superioris possessoris terras inuaderet.</p>
-            <p>Termini quoque quibusdam locis positi sunt, ab uno ad unum dirigantur, per pedes ad
+            <p n="5">Termini quoque quibusdam locis positi sunt, ab uno ad unum dirigantur, per pedes ad
                CCCXX et supra usque ad CCCCLXXX et infra hoc si licet. nam Tiburtini distant a se in
                pedibus a CCXL et supra usque ad DCLX et infra. quod si spissiores non sunt, riparum
                et rigorum cursus seruabunt; harum tamen quae per multa milia pedum recturas
@@ -153,7 +154,7 @@
                potestas limitum recturarumue eursus non confirmat. sed si conuentionis causa ea
                partes <milestone unit="page" n="p. 61 Thulin"/>inter se conseruanda censuerunt, non
                recturae imputandum, sed concurrenti definitioni fides est adhibenda.</p>
-            <p>De fine enim lex Manilia quinque aut sex pedum latitudinem praescribit, quoniam hanc
+            <p n="6">De fine enim lex Manilia quinque aut sex pedum latitudinem praescribit, quoniam hanc
                latitudinem uel iter ad culturas accidens occupat uel circumactus aratri. quod usu
                capi non potest: iter enim non, qua ad culturas peruenitur, capitur usu<del>s</del>
                sed id quod in usu biennio fuit. finis enim multis documentis seruabitur, terminibus,
@@ -167,7 +168,7 @@
                et si in extremo fine facta; itemque utrum publica an uicinalis. Si iugis montium,
                quae ex eo nomine accipiuntur, quod continuatione ipsa iugantur. Haec autem omnia
                genera finitionum putato in uno agro posse sine dubio repperiri.</p>
-            <p>De loco si agitur, quae res hanc habet quaestionem, ut nec ad formam nec ad ullum
+            <p n="7">De loco si agitur, quae res hanc habet quaestionem, ut nec ad formam nec ad ullum
                scripturae reuertatur exemplum, nisi tantum hunc locum hinc dico esse, et alter e
                contrario similiter quaeret, ex fere culturae comparationem accipit. id est si silua,
                cuius sit aetatis par caesurae et aetas arborum, ut solent relinqui quas ante missas
@@ -184,7 +185,7 @@
                qui finiebant singulos agros relinquere praeterea cui contributi sunt. uicini non
                contenti suis finibus tollunt terminos, quibus possessio eorum finitur, et eo, qui
                inter fundos unius domini sunt sibi defendunt. ita et haec despicienda erunt.</p>
-            <p>De modo quaestiones fere in agris diuisis et assignatis nascuntur, item quaestoriis
+            <p n="8">De modo quaestiones fere in agris diuisis et assignatis nascuntur, item quaestoriis
                et uectigalibus subiectis, quoniam seilicet in aere scripturae modus conprehensus
                est. quod semper erit ad formam respiciendum. et hoc si duobus possessoribus
                conueniat. alioquin ex modo illo, qui aere scriptura continetur, forma liquebit,
@@ -203,7 +204,7 @@
                utriusque mensura: si nihil ad cautionem conueniat, ne utrius possessio modum
                cautione conprehensum impleat, magna erit rei confusio, quaerendumque tunc quomodo in
                uniuersa regione magis opinione quam mensura modum complecti soliti sint.</p>
-            <p>
+            <p n="9">
                <q>"<hi rend="italic">De proprietate controuersia est plerumque ut in Campania
                      cultorum agrorum siluae absunt in montibus ultra quartum aut quintum forte
                      uicinum</hi>
@@ -232,14 +233,14 @@
                quaedam habere beneficia principum, quod longe et semotis locis saltos quosdam
                reditus causa acciperunt. quae proprietas ad eos quibus data est indubitate pertinet.
                sunt et aliae proprietates quae municipiis a principibus sunt concessae.</p>
-            <p>
+            <p n="10">
                <q>"<hi rend="italic">De possessione fit controuersia quotiens de totius fundi statum
                      per interdictum, hoc est iure ordinario, litigatur</hi>
                </q>". hoc non est disciplinae nostrae iudicium sed apud praesidem prouinciae agitur,
                et ex lege restituitur possessio cui poterit adtineri. in his secundum locum habet
                disciplina nostra, sicut lex <milestone unit="page" n="p. 64 Thulin"/>ait: nisi de
                possessionis statu quaestio fuerit terminata, non licet mensori praeire ad loca.</p>
-            <p>De alluuione obseruatio est, si haec in occupatoriis agitur agris. quidquid uis aquae
+            <p n="11">De alluuione obseruatio est, si haec in occupatoriis agitur agris. quidquid uis aquae
                abstulerit, repetitionem nemo habet, quae res necessitatem ripae muniendae iniungit,
                ita tamen ut sine alterius damno quicquam fiat. si uero in diuisa et assignata
                regione tractabitur, nihil amittet possessor, quoniam formis per centurias certus
@@ -256,12 +257,12 @@
                diuidendorum agrorum, ut quotiens tempestas fluuium concitasset, non per regionem
                excedens alueum uagaretur, sed sine iniuria cuiusquam deflueret. hos tamen agros, id
                est hunc omnem modum, qui flumini adscriptus est, R. P. quibusdam uendidit.</p>
-            <p>Haec quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis
+            <p n="12">Haec quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis
                contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum
                regelationum repentinas inundationes patitur. aliquibus locis impetrauerunt
                possessores a praeside prouinciae ut aliquam latitudinent flumini daret. nam et in
                Italia Pisaurum flumini latitudo est assignata eatenus quo usque alluebat.</p>
-            <p>
+            <p n="13">
                <q>"<hi rend="italic">De iure territorii controuersia est</hi>
                </q>", cum quidam priuatorum aut <q>"<hi rend="italic">pomerium eius urbis</hi>
                </q>" <q>"<hi rend="italic">priuatis operibus</hi>
@@ -304,7 +305,7 @@
                      rend="italic">Si autem rationem appellationis huius tractemus, territorium est
                      quidquid hostis terrendi causa constitutum est.</hi>
                </q>" </p>
-            <p>
+            <p n="14">
                <q>"<hi rend="italic">De locis publicis siue populi Romani sine coloniarum
                      municipiorumue controuersia est, quotiens ea loca, quae neque assignata neque
                      uendita fuerint</hi>
@@ -314,7 +315,7 @@
                      monte Mutela</hi>
                </q>", qui nunc a priuatis operibus obtinetur. nam et regione Reatina itidem sunt
                loca P. R.</p>
-            <p>Loca autem quae sint publica uideamus. sunt siluae de quibus lignorum copia in
+            <p n="15">Loca autem quae sint publica uideamus. sunt siluae de quibus lignorum copia in
                lauacra publica ministranda caeduntur. sunt et loca publica quae in pascuis sunt
                relicta quibuscumque ad urbem uenientibus peregrinis. sunt in suburbanis loca publica
                inopum destinata funeribus, quae loca culinas appellant: sunt et loca noxiorum poenis
@@ -334,7 +335,7 @@
                </q>" fecit, locus est publicus. <q>"<hi rend="italic">siluae</hi>
                </q>" etiam sunt iuxta hoc alueo suis circum datae terminibus, quae casalia non
                utuntur.</p>
-            <p>
+            <p n="16">
                <q>"<hi rend="italic">De locis relictis et extra clusis controuersia est in agris
                      assignatis. relicta autem ea loca sunt quae siue iniquitate locorum assignari
                      nequiuerunt, siue ex uoluntate conditoris, hoc est mensoris, relicta limites
@@ -349,7 +350,7 @@
                non sint, relicta appellantur; et extra clusa, quod extra ordinationes sint et tamen
                fine cludantur. haec plerumque proximi possessores inuadunt et oportunitate loci
                irritati agrum obtinent. cum his controuersiae a rebus solent moueri.</p>
-            <p>
+            <p n="17">
                <q>"<hi rend="italic">De locis sacris et religiosis controuersiae plurimae</hi>
                </q>"<q>"<hi rend="italic">iure ordinario finiuntur</hi>
                </q>". si enim loca sacra aedificabantur, quam maxime apud antiquos in confinio
@@ -371,7 +372,7 @@
                      modum circum iacentem uel praescriptum agri finem</hi>
                </q>". nam lucos frequenter in trifinia et quadrifinia inuenimus, sicut in suburbanis
                et circa publica itinera constitutum esse perspicimus.</p>
-            <p>
+            <p n="18">
                <milestone unit="page" n="p. 69 Thulin"/>
                <q>"<hi rend="italic">De aquae pluuiae transitu controuersia est, in qua si collectus
                      pluuialis <supplied>a</supplied>quae transuersum secans finem alterius fundi
@@ -383,7 +384,7 @@
                uelit fines ad riuum usque defendere, non mediocris exinde controuersiae genus
                exoritur. sed hoc <q>"<hi rend="italic">mensoris</hi>
                </q>" est peritia finiendum.</p>
-            <p>
+            <p n="19">
                <q>"<hi rend="italic">De itineribus controuersia est, quae in arcifiniis agris iure
                      ordinario finitur, in assignatis mensurarum ratione</hi>
                </q>". <q>"<hi rend="italic">sed multi limites exigente ratione per diuia et
@@ -395,7 +396,7 @@
                   utri<supplied>m</supplied>que discesserint, desi<supplied>ni</supplied>t uia finem
                praestare <supplied>et</supplied> erit controuersia: sed inspectio
                   artifici<supplied>s</supplied> eam finiet.</p>
-            <p>Satis, ut puto, dilucide genera controuersiarum uel primum agri qualitatem exposui.
+            <p n="20">Satis, ut puto, dilucide genera controuersiarum uel primum agri qualitatem exposui.
                nam et simplicius enarrare condiciones earum existimaui, quo facilius ad intellectum
                peruenirent. nunc quem ammodum singula pertractari debeant persequendum est, uel quod
                sint status earum, id est iniectiuus expositiuus subiectiuum reciperatiuus
@@ -418,7 +419,7 @@
                transcendentiam non habet de hoc effectiuus, sed dum consummatus fuerit nascitur. nam
                effectiuus est cum de loco litigatur et idoneas partes ad litigium aduocationes
                instituunt.</p>
-            <p>Respicio etenim quantum sit quod mensoris prouidentiae iniungatur; sed nec minus
+            <p n="21">Respicio etenim quantum sit quod mensoris prouidentiae iniungatur; sed nec minus
                aduocatis. quorum ars licet diuersa sit, prudentiam tamen et simplicitatem eandem
                habere debent et qui iudicaturi sunt et qui aduocationes sunt praestaturi. iudicando
                autem mensor bonus uir et iustus agere debet, nulla ambitione aut sordibus moueri,

--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+   <teiHeader>
       <fileDesc>
          <titleStmt>
             <title>Commentum de controuersiis</title>
@@ -27,134 +27,407 @@
             <idno>dlt000543</idno>
          </publicationStmt>
          <sourceDesc>
-            <p>Corpus agrimensorum Romanorum recensuit Carolus Thulin. vol. I fasc. I Opuscula agrimensorum ueterum, Lipsiae in aedibus B. G. Teubneri, 1913 </p>
+            <p>Corpus agrimensorum Romanorum recensuit Carolus Thulin. vol. I fasc. I Opuscula
+               agrimensorum ueterum, Lipsiae in aedibus B. G. Teubneri, 1913 </p>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS">
+            <cRefPattern n="unknown" matchPattern="(\w+)"
+               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:p[@n='$1'])">
+               <p>This pointer pattern extracts unknown</p>
+            </cRefPattern>
+         </refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
-            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
+            <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio
+               Lana</p>
          </projectDesc>
          <editorialDecl>
-               
+
             <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
             <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
-          l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati, introduzioni, note
-          e commenti e ogni altro contenuto redatto da editori moderni. </p>
+               l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
+               introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
             <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
-          correttezza di trascrizione</p>
-            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento per la
-          distinzione u/v minuscole.</p>
+               correttezza di trascrizione</p>
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+               per la distinzione u/v minuscole.</p>
             <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
             <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
-          grassetto, corsivo, spaziatura espansa.</p>
+               grassetto, corsivo, spaziatura espansa.</p>
             <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
-          &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni: &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
-               <hi rend="italic">loci desperati</hi>:  &lt;unclear&gt;testo&lt;/unclear&gt; o &lt;unclear/&gt; testo
-          si visualizzano †testo† e †testo<lb/> lacuna materiale: &lt;gap/&gt; si visualizza
-          [...]<lb/> lacuna integrata dagli editori:
-          &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt;
-        </p>
-            <p>Sono stati marcati i termini in lingua greca
-          &lt;foreign xml:lang="grc"&gt;αγβ&lt;/foreign&gt;
-        </p>
-            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf">Note di trascrizione e codifica di testi latini tardoantichi
-          [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
+               &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
+               &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
+               <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
+               &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
+               &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
+               &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
+               xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+                  target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
+                  >Note di trascrizione e codifica di testi latini tardoantichi
+                  [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>
             </p>
          </editorialDecl>
-      
+
       </encodingDesc>
       <profileDesc>
          <langUsage>
             <language ident="la">Latino</language>
          </langUsage>
       </profileDesc>
-  </teiHeader>
-  <text>
+      <revisionDesc>
+         <change who="Romain Verny" when="2021-04-29">
+            <item></item>
+         </change>
+      </revisionDesc>
+   </teiHeader>
+   
+   <text>
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0012a.stoa003.digilibLT-lat1">
          <div type="opus">
             <head>Commentum de controuersiis</head>
             <milestone unit="page" n="p. 58 Thulin"/>
             <p>Suscepimus quoque tractandos controuersiarum status cum diuino praesidio.</p>
             <p>
-               <q>"<hi rend="italic">Materiae</hi>"</q>, inquit,<q>"<hi rend="italic">controuersiarum sunt duae, finis et locus. harum condicio alterutra continetur. sed quoniam singulae controuersiae diuersis condicionibus obligantur, proprie nominandae sunt. genera</hi>
+               <q>"<hi rend="italic">Materiae</hi>"</q>, inquit,<q>"<hi rend="italic"
+                     >controuersiarum sunt duae, finis et locus. harum condicio alterutra
+                     continetur. sed quoniam singulae controuersiae diuersis condicionibus
+                     obligantur, proprie nominandae sunt. genera</hi>
                </q>" autem <q>"<hi rend="italic">controuersiarum</hi>
                </q>", ut ait Frontinus, <q>"<hi rend="italic">sunt numero XV</hi>
-               </q>". sed quia his generibus species non dedit, et quia secundum regulam dialecticam neque genus sine specie neque sine genere species potest dici, omnino dixit inproprie: nos tamen suum illi idioma relinquentes ad intellegendas eas atque exponendas, sicut promisimus, transeamus.</p>
+               </q>". sed quia his generibus species non dedit, et quia secundum regulam dialecticam
+               neque genus sine specie neque sine genere species potest dici, omnino dixit
+               inproprie: nos tamen suum illi idioma relinquentes ad intellegendas eas atque
+               exponendas, sicut promisimus, transeamus.</p>
             <p>
-               <q>"<hi rend="italic">De positione terminorum controuersia est inter duos pluresue uicinos; inter duos, an in rigore sit positus terminus citerorum, siue rationis; inter plures, trifinium facit an quadrifinium</hi>
-               </q>". cum ergo possessor inuenerit terminum in possessione sua aliter formatum aut aliter positum quam <milestone unit="page" n="p. 59 Thulin"/>ceteri qui in ea possessione sunt, aut <supplied>non</supplied> inscriptum ut adsolet, agit de eo, in qua sit positus ratione, seu ipse trifininium faciat siue ab alio lineam procedentem excipiat: dumque uicinus possessor huic extiterit ambiguitati contrarius, magna inter utrosque controuersia agitatur. Solent enim hae<del>c</del> controuersiae de conportionalibus nasci terminibus, nam si de eorum latere linea quasi ex artificis manu composita uideatur exire atque in unius termini angulum inpingere qui in limite est positus, in istis, ut ait Frontinus, uelud instantium argumentorum oportunitas controuersialis aptatur. hoc enim plerumque potest in limitibus inueniri. nam si ueteranus, filiis suis unam possessionem diuidens in tres aut quattuor portiones, terminos uoluit interesse, potuit quiddam tale contingere, ut ex multis quicumque respiceret angulum illius termini, qui in maximo est limite constitutus. hos siquidem terminos, qui intra possessionum fines inueniuntur, conportionales appellauit antiquitas. <q>"<hi rend="italic">Qui si secundum pristini temporis possessionem non conueniunt, diuersas attiguis possessoribus controuersias generabunt. sed alius forte de loco, alius de fine litigat</hi>
-               </q>". uidendum hoc diligenti cura. et circuiri agrum ante omnia oportet, de quo intentio uertitur. et redintegrato suis fundo limitibus per maximorum limitum rationem, tum de conportionalium terminorum positionem, quos uice tabellarum antiqui intercidendis portiunculis inter filios suos defigebant, integra ab artifice ratio proferatur.</p>
+               <q>"<hi rend="italic">De positione terminorum controuersia est inter duos pluresue
+                     uicinos; inter duos, an in rigore sit positus terminus citerorum, siue
+                     rationis; inter plures, trifinium facit an quadrifinium</hi>
+               </q>". cum ergo possessor inuenerit terminum in possessione sua aliter formatum aut
+               aliter positum quam <milestone unit="page" n="p. 59 Thulin"/>ceteri qui in ea
+               possessione sunt, aut <supplied>non</supplied> inscriptum ut adsolet, agit de eo, in
+               qua sit positus ratione, seu ipse trifininium faciat siue ab alio lineam procedentem
+               excipiat: dumque uicinus possessor huic extiterit ambiguitati contrarius, magna inter
+               utrosque controuersia agitatur. Solent enim hae<del>c</del> controuersiae de
+               conportionalibus nasci terminibus, nam si de eorum latere linea quasi ex artificis
+               manu composita uideatur exire atque in unius termini angulum inpingere qui in limite
+               est positus, in istis, ut ait Frontinus, uelud instantium argumentorum oportunitas
+               controuersialis aptatur. hoc enim plerumque potest in limitibus inueniri. nam si
+               ueteranus, filiis suis unam possessionem diuidens in tres aut quattuor portiones,
+               terminos uoluit interesse, potuit quiddam tale contingere, ut ex multis quicumque
+               respiceret angulum illius termini, qui in maximo est limite constitutus. hos siquidem
+               terminos, qui intra possessionum fines inueniuntur, conportionales appellauit
+               antiquitas. <q>"<hi rend="italic">Qui si secundum pristini temporis possessionem non
+                     conueniunt, diuersas attiguis possessoribus controuersias generabunt. sed alius
+                     forte de loco, alius de fine litigat</hi>
+               </q>". uidendum hoc diligenti cura. et circuiri agrum ante omnia oportet, de quo
+               intentio uertitur. et redintegrato suis fundo limitibus per maximorum limitum
+               rationem, tum de conportionalium terminorum positionem, quos uice tabellarum antiqui
+               intercidendis portiunculis inter filios suos defigebant, integra ab artifice ratio
+               proferatur.</p>
             <p>
-               <milestone unit="page" n="p. 60 Thulin"/>De rigore atque de fine licet similem posuerit controuersiam unamque eis condicionem esse firmauerit, tamen credo inter eas aliquid posse differri. rigor enim naturalis est. qualiscumque enim rigor interuenit constituentibus limites, rarioribus locis terminos posuerunt. et seruari iubetur rigor, si inuentus fuerit de triginta pedum latitudine, ut ne ab utroque possessore tangatur quod si plus de XXX pedibus patuerit, iam collis est. quod exigit ut superior possessor in planum usque descendat et sibi defendat omnem deuexum locum. hoc enim lex propter malignitatem inferioris possessoris instituit, ne aut arando aut fodiendo superioris possessoris terras inuaderet.</p>
-            <p>Termini quoque quibusdam locis positi sunt, ab uno ad unum dirigantur, per pedes ad CCCXX et supra usque ad CCCCLXXX et infra hoc si licet. nam Tiburtini distant a se in pedibus a CCXL et supra usque ad DCLX et infra. quod si spissiores non sunt, riparum et rigorum cursus seruabunt; harum tamen quae per multa milia pedum recturas separationesue agrorum ab initio suo usque ad occasum custodiunt. et ne eas ripas aut rigores sequendos obseruarent quae intra corpus agri nascuntur et in suo latere decidunt, lex limitum eas praedamnauit. ne id aliquando sequamini, quod maior potestas limitum recturarumue eursus non confirmat. sed si conuentionis causa ea partes <milestone unit="page" n="p. 61 Thulin"/>inter se conseruanda censuerunt, non recturae imputandum, sed concurrenti definitioni fides est adhibenda.</p>
-            <p>De fine enim lex Manilia quinque aut sex pedum latitudinem praescribit, quoniam hanc latitudinem uel iter ad culturas accidens occupat uel circumactus aratri. quod usu capi non potest: iter enim non, qua ad culturas peruenitur, capitur usu<del>s</del> sed id quod in usu biennio fuit. finis enim multis documentis seruabitur, terminibus, et arboribus notatis, et fossis, et uiis, et riuis, et uepribus, et saepe normalibus, et ut comperi, aliquibus locis inter arua marginibus quibusdam tamquam puluinis, saepe etiam limitibus, item petris notatis. quae in finibus sunt, pro terminibus habebitis. Si arboribus notatis fines obseruabuntur, uidendum quae partes arborum notatae sint. notae enim in propriis arboribus a foras ponuntur, ut arbores liberas in parte a nota relinquat. si communes sunt arbores mediae notantur et ad utrumque pertinent. Nam si fossa erit finalis, uidendum utrum unius an utriusque sit partis, et si in extremo fine facta; itemque utrum publica an uicinalis. Si iugis montium, quae ex eo nomine accipiuntur, quod continuatione ipsa iugantur. Haec autem omnia genera finitionum putato in uno agro posse sine dubio repperiri.</p>
-            <p>De loco si agitur, quae res hanc habet quaestionem, ut nec ad formam nec ad ullum scripturae reuertatur exemplum, nisi tantum hunc locum hinc dico esse, et alter e contrario similiter quaeret, ex fere culturae comparationem accipit. id est si silua, cuius sit aetatis par caesurae et aetas arborum, ut solent relinqui quas ante missas uocant, et siluarum quoque aetates an sint pares. si uineae, similes erunt in comparatione; an ordines aequidistantes, an pari constitutione, et an simile genus uitium constabit. tamen rem magis esse iuris quam nostri operis, quoniam fere usu capiuntur loca quae biennio possessa fuerint. respiciendum erit ne, quem admodum solemus uidere quibusdam regionibus particulas quasdam in mediis aliorum agris, numquid simile huic interueniat. quod in agro diuiso accidere non potest, quoniam continuae possessiones et assignantur et <milestone unit="page" n="p. 62 Thulin"/>redduntur. et his forte incidit ut tale quid committeretur, ut locus pro loco, ut continua sit possessio. ita, ut dixi, in assignatis fieri non potest. solent quidam complurium fundorum suorum domini duos aut tres agros uni uelle contribuere, terminos qui finiebant singulos agros relinquere praeterea cui contributi sunt. uicini non contenti suis finibus tollunt terminos, quibus possessio eorum finitur, et eo, qui inter fundos unius domini sunt sibi defendunt. ita et haec despicienda erunt.</p>
-            <p>De modo quaestiones fere in agris diuisis et assignatis nascuntur, item quaestoriis et uectigalibus subiectis, quoniam seilicet in aere scripturae modus conprehensus est. quod semper erit ad formam respiciendum. et hoc si duobus possessoribus conueniat. alioquin ex modo illo, qui aere scriptura continetur, forma liquebit, etiam si dominus aliquid uendidisset. namque hoc comperi in Samnio, ut agri quos diuus Vespasianus ueteranis assignauerat, eos ab ipsi, quibus assignati erant iam possideri. quidam enim emerunt aliqua loca adieceruntque suis finibus et ipsud, uel uia finiente uel flumine uel alio quolibet genere: sed nec uendentes ex acceptis suis aut ementes adicientesque ad acceptas suas certum modum taxauerunt, sed ut quisque modus aliqua, ut dixi, aut uia aut flumine aut aliquo genere finiri potuit, ita uendiderunt emeruntque. ergo ad aes commodi reuocari potest, si duobus, inter quos controuersia est, conuenerit. in eis autem, qui uectigalibus subiecti sunt, proximus quisque possessioni suae iunxit. nam soliti erant antiqui in conductiones et in emptiones modum conprehendere atque ita cauere: FVNDVM ILLVM, IVGERA TOT, IN SINGVLIS IVGERIBVS. tantum itaque si in ea regione agitur, ubi haec erit consuetudo, aut cautiones scilicet aut emptiones intuendae erunt. inter quos disputabitur acta utriusque mensura: si nihil ad cautionem conueniat, ne utrius possessio modum cautione conprehensum impleat, magna erit rei confusio, quaerendumque tunc quomodo in uniuersa regione magis opinione quam mensura modum complecti soliti sint.</p>     
+               <milestone unit="page" n="p. 60 Thulin"/>De rigore atque de fine licet similem
+               posuerit controuersiam unamque eis condicionem esse firmauerit, tamen credo inter eas
+               aliquid posse differri. rigor enim naturalis est. qualiscumque enim rigor interuenit
+               constituentibus limites, rarioribus locis terminos posuerunt. et seruari iubetur
+               rigor, si inuentus fuerit de triginta pedum latitudine, ut ne ab utroque possessore
+               tangatur quod si plus de XXX pedibus patuerit, iam collis est. quod exigit ut
+               superior possessor in planum usque descendat et sibi defendat omnem deuexum locum.
+               hoc enim lex propter malignitatem inferioris possessoris instituit, ne aut arando aut
+               fodiendo superioris possessoris terras inuaderet.</p>
+            <p>Termini quoque quibusdam locis positi sunt, ab uno ad unum dirigantur, per pedes ad
+               CCCXX et supra usque ad CCCCLXXX et infra hoc si licet. nam Tiburtini distant a se in
+               pedibus a CCXL et supra usque ad DCLX et infra. quod si spissiores non sunt, riparum
+               et rigorum cursus seruabunt; harum tamen quae per multa milia pedum recturas
+               separationesue agrorum ab initio suo usque ad occasum custodiunt. et ne eas ripas aut
+               rigores sequendos obseruarent quae intra corpus agri nascuntur et in suo latere
+               decidunt, lex limitum eas praedamnauit. ne id aliquando sequamini, quod maior
+               potestas limitum recturarumue eursus non confirmat. sed si conuentionis causa ea
+               partes <milestone unit="page" n="p. 61 Thulin"/>inter se conseruanda censuerunt, non
+               recturae imputandum, sed concurrenti definitioni fides est adhibenda.</p>
+            <p>De fine enim lex Manilia quinque aut sex pedum latitudinem praescribit, quoniam hanc
+               latitudinem uel iter ad culturas accidens occupat uel circumactus aratri. quod usu
+               capi non potest: iter enim non, qua ad culturas peruenitur, capitur usu<del>s</del>
+               sed id quod in usu biennio fuit. finis enim multis documentis seruabitur, terminibus,
+               et arboribus notatis, et fossis, et uiis, et riuis, et uepribus, et saepe normalibus,
+               et ut comperi, aliquibus locis inter arua marginibus quibusdam tamquam puluinis,
+               saepe etiam limitibus, item petris notatis. quae in finibus sunt, pro terminibus
+               habebitis. Si arboribus notatis fines obseruabuntur, uidendum quae partes arborum
+               notatae sint. notae enim in propriis arboribus a foras ponuntur, ut arbores liberas
+               in parte a nota relinquat. si communes sunt arbores mediae notantur et ad utrumque
+               pertinent. Nam si fossa erit finalis, uidendum utrum unius an utriusque sit partis,
+               et si in extremo fine facta; itemque utrum publica an uicinalis. Si iugis montium,
+               quae ex eo nomine accipiuntur, quod continuatione ipsa iugantur. Haec autem omnia
+               genera finitionum putato in uno agro posse sine dubio repperiri.</p>
+            <p>De loco si agitur, quae res hanc habet quaestionem, ut nec ad formam nec ad ullum
+               scripturae reuertatur exemplum, nisi tantum hunc locum hinc dico esse, et alter e
+               contrario similiter quaeret, ex fere culturae comparationem accipit. id est si silua,
+               cuius sit aetatis par caesurae et aetas arborum, ut solent relinqui quas ante missas
+               uocant, et siluarum quoque aetates an sint pares. si uineae, similes erunt in
+               comparatione; an ordines aequidistantes, an pari constitutione, et an simile genus
+               uitium constabit. tamen rem magis esse iuris quam nostri operis, quoniam fere usu
+               capiuntur loca quae biennio possessa fuerint. respiciendum erit ne, quem admodum
+               solemus uidere quibusdam regionibus particulas quasdam in mediis aliorum agris,
+               numquid simile huic interueniat. quod in agro diuiso accidere non potest, quoniam
+               continuae possessiones et assignantur et <milestone unit="page" n="p. 62 Thulin"
+               />redduntur. et his forte incidit ut tale quid committeretur, ut locus pro loco, ut
+               continua sit possessio. ita, ut dixi, in assignatis fieri non potest. solent quidam
+               complurium fundorum suorum domini duos aut tres agros uni uelle contribuere, terminos
+               qui finiebant singulos agros relinquere praeterea cui contributi sunt. uicini non
+               contenti suis finibus tollunt terminos, quibus possessio eorum finitur, et eo, qui
+               inter fundos unius domini sunt sibi defendunt. ita et haec despicienda erunt.</p>
+            <p>De modo quaestiones fere in agris diuisis et assignatis nascuntur, item quaestoriis
+               et uectigalibus subiectis, quoniam seilicet in aere scripturae modus conprehensus
+               est. quod semper erit ad formam respiciendum. et hoc si duobus possessoribus
+               conueniat. alioquin ex modo illo, qui aere scriptura continetur, forma liquebit,
+               etiam si dominus aliquid uendidisset. namque hoc comperi in Samnio, ut agri quos
+               diuus Vespasianus ueteranis assignauerat, eos ab ipsi, quibus assignati erant iam
+               possideri. quidam enim emerunt aliqua loca adieceruntque suis finibus et ipsud, uel
+               uia finiente uel flumine uel alio quolibet genere: sed nec uendentes ex acceptis suis
+               aut ementes adicientesque ad acceptas suas certum modum taxauerunt, sed ut quisque
+               modus aliqua, ut dixi, aut uia aut flumine aut aliquo genere finiri potuit, ita
+               uendiderunt emeruntque. ergo ad aes commodi reuocari potest, si duobus, inter quos
+               controuersia est, conuenerit. in eis autem, qui uectigalibus subiecti sunt, proximus
+               quisque possessioni suae iunxit. nam soliti erant antiqui in conductiones et in
+               emptiones modum conprehendere atque ita cauere: FVNDVM ILLVM, IVGERA TOT, IN SINGVLIS
+               IVGERIBVS. tantum itaque si in ea regione agitur, ubi haec erit consuetudo, aut
+               cautiones scilicet aut emptiones intuendae erunt. inter quos disputabitur acta
+               utriusque mensura: si nihil ad cautionem conueniat, ne utrius possessio modum
+               cautione conprehensum impleat, magna erit rei confusio, quaerendumque tunc quomodo in
+               uniuersa regione magis opinione quam mensura modum complecti soliti sint.</p>
             <p>
-               <q>"<hi rend="italic">De proprietate controuersia est plerumque ut in Campania cultorum agrorum siluae absunt in montibus ultra quartum aut quintum forte uicinum</hi>
-               </q>". nam ubi mons fuit proximus asper seu <milestone unit="page" n="p. 63 Thulin"/>sterelis, super quo fundi constitui nequiuerunt aut forte aquae inopia habitatio hominibus prorsus negata est, siluae tamen dum essent glandiferae, ne earum fructus perirent, diuiso monte particulatim datae sunt proprietates quaedam fundis in locis planis et uberibus constitutis, qui paruis finibus stringebantur. nam et in Suessano culti sunt, qui habent in ntonte Marico plagas siluarum determinatas, quarum proprietates <q>"<hi rend="italic">ad quos fundos pertinere debeant, discutiatur</hi>
-               </q>". nam et formae antiquae declarant ita esse. respiciendum erit et illud, sicut dixi superius, quem admodum solemus uidere quibusdam regionibus particulas in mediis aliorum agris. hoc argumentum prudentiae est quam professionis. uidendum quoque quoniam <q>"<hi rend="italic">est et pascuorum proprietas pertinens ad fundos, sed in commune; propter quod ea conpascua multis locis communia appellantur, quibusdam prouinciis pro indiuisa</hi>
-               </q>". haec fere pascua certis personis data sunt depascenda, sed in communi: quae multi per potentiam inuaserunt et colunt. de eorum proprietate ius ordinarium solet moueri, atque interuentu mensurarum demonstratur ut sit assignatus ager. <q>"<hi rend="italic">Nam per emptiones uel hereditates huius generis controuersiae fiunt</hi>
-               </q>". quaedam loca feruntur ad personas publicas attinere. nam personae publicae etiam coloniae appellantur. quae habent assignata in alienis finibus quaedam loca, quae solemus praefecturas appellare. harum praefecturarum proprietates manifeste ad colonos pertinent, non ad eos quorum fines sunt diminuti. solent et priuilegia quaedam habere beneficia principum, quod longe et semotis locis saltos quosdam reditus causa acciperunt. quae proprietas ad eos quibus data est indubitate pertinet. sunt et aliae proprietates quae municipiis a principibus sunt concessae.</p>     
+               <q>"<hi rend="italic">De proprietate controuersia est plerumque ut in Campania
+                     cultorum agrorum siluae absunt in montibus ultra quartum aut quintum forte
+                     uicinum</hi>
+               </q>". nam ubi mons fuit proximus asper seu <milestone unit="page" n="p. 63 Thulin"
+               />sterelis, super quo fundi constitui nequiuerunt aut forte aquae inopia habitatio
+               hominibus prorsus negata est, siluae tamen dum essent glandiferae, ne earum fructus
+               perirent, diuiso monte particulatim datae sunt proprietates quaedam fundis in locis
+               planis et uberibus constitutis, qui paruis finibus stringebantur. nam et in Suessano
+               culti sunt, qui habent in ntonte Marico plagas siluarum determinatas, quarum
+               proprietates <q>"<hi rend="italic">ad quos fundos pertinere debeant, discutiatur</hi>
+               </q>". nam et formae antiquae declarant ita esse. respiciendum erit et illud, sicut
+               dixi superius, quem admodum solemus uidere quibusdam regionibus particulas in mediis
+               aliorum agris. hoc argumentum prudentiae est quam professionis. uidendum quoque
+               quoniam <q>"<hi rend="italic">est et pascuorum proprietas pertinens ad fundos, sed in
+                     commune; propter quod ea conpascua multis locis communia appellantur, quibusdam
+                     prouinciis pro indiuisa</hi>
+               </q>". haec fere pascua certis personis data sunt depascenda, sed in communi: quae
+               multi per potentiam inuaserunt et colunt. de eorum proprietate ius ordinarium solet
+               moueri, atque interuentu mensurarum demonstratur ut sit assignatus ager. <q>"<hi
+                     rend="italic">Nam per emptiones uel hereditates huius generis controuersiae
+                     fiunt</hi>
+               </q>". quaedam loca feruntur ad personas publicas attinere. nam personae publicae
+               etiam coloniae appellantur. quae habent assignata in alienis finibus quaedam loca,
+               quae solemus praefecturas appellare. harum praefecturarum proprietates manifeste ad
+               colonos pertinent, non ad eos quorum fines sunt diminuti. solent et priuilegia
+               quaedam habere beneficia principum, quod longe et semotis locis saltos quosdam
+               reditus causa acciperunt. quae proprietas ad eos quibus data est indubitate pertinet.
+               sunt et aliae proprietates quae municipiis a principibus sunt concessae.</p>
             <p>
-               <q>"<hi rend="italic">De possessione fit controuersia quotiens de totius fundi statum per interdictum, hoc est iure ordinario, litigatur</hi>
-               </q>". hoc non est disciplinae nostrae iudicium sed apud praesidem prouinciae agitur, et ex lege restituitur possessio cui poterit adtineri. in his secundum locum habet disciplina nostra, sicut lex <milestone unit="page" n="p. 64 Thulin"/>ait: nisi de possessionis statu quaestio fuerit terminata, non licet mensori praeire ad loca.</p>
-            <p>De alluuione obseruatio est, si haec in occupatoriis agitur agris. quidquid uis aquae abstulerit, repetitionem nemo habet, quae res necessitatem ripae muniendae iniungit, ita tamen ut sine alterius damno quicquam fiat. si uero in diuisa et assignata regione tractabitur, nihil amittet possessor, quoniam formis per centurias certus cuique modus ascriptus est. circa Padum autem cum ageretur, quod flumen torrens et aliquando tam uiolentum decurrit, ut alueum mutet et multorum late agros trans ripa<supplied>m</supplied>, ut ita dicam, transferat, saepe etiam insulas efficit. at Cassius Longinus, uir prudentissimus, iuris auctor, hoc statuit, ut quicquid aqua lambiendo abstulerit, id possessor amittat, quoniam scilicet ripam suam sine alterius damno tueri debet; si uero maiore ui decurrens alueum mutasset, suum quisque modum agnosceret, quia non possessoris neglegentia sed tempestatis uiolentia abreptum apparet; si uero insulam fecisset, a cuius agro fecisset, id possideret; aut si ex communi quisque suum reciperet. Scio enim quibusdam regionibus, cum assignarentur agri, adscriptunt aliquid per centurias flumini. hoc autem prouidit auctor diuidendorum agrorum, ut quotiens tempestas fluuium concitasset, non per regionem excedens alueum uagaretur, sed sine iniuria cuiusquam deflueret. hos tamen agros, id est hunc omnem modum, qui flumini adscriptus est, R. P. quibusdam uendidit.</p>
-            <p>Haec quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum regelationum repentinas inundationes patitur. aliquibus locis impetrauerunt possessores a praeside prouinciae ut aliquam latitudinent flumini daret. nam et in Italia Pisaurum flumini latitudo est assignata eatenus quo usque alluebat.</p>     
+               <q>"<hi rend="italic">De possessione fit controuersia quotiens de totius fundi statum
+                     per interdictum, hoc est iure ordinario, litigatur</hi>
+               </q>". hoc non est disciplinae nostrae iudicium sed apud praesidem prouinciae agitur,
+               et ex lege restituitur possessio cui poterit adtineri. in his secundum locum habet
+               disciplina nostra, sicut lex <milestone unit="page" n="p. 64 Thulin"/>ait: nisi de
+               possessionis statu quaestio fuerit terminata, non licet mensori praeire ad loca.</p>
+            <p>De alluuione obseruatio est, si haec in occupatoriis agitur agris. quidquid uis aquae
+               abstulerit, repetitionem nemo habet, quae res necessitatem ripae muniendae iniungit,
+               ita tamen ut sine alterius damno quicquam fiat. si uero in diuisa et assignata
+               regione tractabitur, nihil amittet possessor, quoniam formis per centurias certus
+               cuique modus ascriptus est. circa Padum autem cum ageretur, quod flumen torrens et
+               aliquando tam uiolentum decurrit, ut alueum mutet et multorum late agros trans
+                  ripa<supplied>m</supplied>, ut ita dicam, transferat, saepe etiam insulas efficit.
+               at Cassius Longinus, uir prudentissimus, iuris auctor, hoc statuit, ut quicquid aqua
+               lambiendo abstulerit, id possessor amittat, quoniam scilicet ripam suam sine alterius
+               damno tueri debet; si uero maiore ui decurrens alueum mutasset, suum quisque modum
+               agnosceret, quia non possessoris neglegentia sed tempestatis uiolentia abreptum
+               apparet; si uero insulam fecisset, a cuius agro fecisset, id possideret; aut si ex
+               communi quisque suum reciperet. Scio enim quibusdam regionibus, cum assignarentur
+               agri, adscriptunt aliquid per centurias flumini. hoc autem prouidit auctor
+               diuidendorum agrorum, ut quotiens tempestas fluuium concitasset, non per regionem
+               excedens alueum uagaretur, sed sine iniuria cuiusquam deflueret. hos tamen agros, id
+               est hunc omnem modum, qui flumini adscriptus est, R. P. quibusdam uendidit.</p>
+            <p>Haec quaestiones maxime in Gallia to<supplied>ga</supplied>ta mouentur, quae multis
+               contexta fluminibus inmodicas Alpium niues in mare transmittit et subitarum
+               regelationum repentinas inundationes patitur. aliquibus locis impetrauerunt
+               possessores a praeside prouinciae ut aliquam latitudinent flumini daret. nam et in
+               Italia Pisaurum flumini latitudo est assignata eatenus quo usque alluebat.</p>
             <p>
                <q>"<hi rend="italic">De iure territorii controuersia est</hi>
                </q>", cum quidam priuatorum aut <q>"<hi rend="italic">pomerium eius urbis</hi>
                </q>" <q>"<hi rend="italic">priuatis operibus</hi>
-               </q>" inuerecunde uult peruadere aut auare de locis publicis, hoc est <q>"<hi rend="italic">ad ipsam urbem pertinentibus</hi>
-               </q>", quidam priuatorum usurpare temptauerit. <milestone unit="page" n="p. 65 Thulin"/>pomerium autem urbis est quod ante muros spatium sub certa mensura demensum est. sed et aliquibus urbibus et intra muros simili modo est statutum propter custodiam fundamentorum. <q>"<hi rend="italic">quod a priuatis operibus optineri non oportebit. hic locus est qui a publico nullo iure poterit amoueri. habet autem condiciones duas, unam urbani soli, alteram agrestis; urbani soli, quod tutela rei urbanae assignatum est, agrestis, quod publicis operibus datum est aut destinatum</hi>
-               </q>". in tutela rei urbanae assignatae sunt siluae, de quibus ligna in reparatione publicorum moenium traherentur. hoc genus agri tutelatum dicitur. nam aliquarum urbium <q>"<hi rend="italic">maxima pars finium coloniae est adtributa</hi>
-               </q>". coloniae sunt quae ex eo nomine accipiuntur, quod Romani in eisdem ciuitatibus colonos miserunt. illarum ergo urbium maxima finium pars data est coloniis, quae in remotiora loca et longe a mari positae uidebantur, ut numerus ciuium, quem multiplicare diuus Augustus conabatur, haberet spatia, in quae subsistere potuisset. nam et <q>"<hi rend="italic">in Piceno fertur inter montium Praecutianorum quandum partem oppidi Asculanorum fine circum dari. sed hoc conciliabulum fuisse et postea fertur in municipii ius relatum. nam omnia antiqua municipia habent suum priuilegium</hi>
-               </q>". ut Tudertini qui apud principes egerunt ut Fanestres incolae, si essent alienigenae, intra territorium inxolerent, honoribus fungi in colonia non deberent. sed Fanestres hoc postea impetrauerunt, ut eis liceret et fungi honoribus territorii. aeque iuris controuersia agitatur, quotiens propter exigenda tributa de possessione litigatur; cum dicat una pars in sui eam fine territorii <milestone unit="page" n="p. 66 Thulin"/>constituta<supplied>m</supplied>, et altera e contrario similiter quaeret. haec autem controuersia territorialibus est finienda terminibus. nam inuenimus saepe in publicis instrumentis significanter inscripta territoria ita ut EX COLLICVLO QVI APPELLATVR ILLE, AD FLVMEN ILLVD, ET PER FLVMEN ILLVD AD RIVVM ILLVM aut VIAM ILLAM, ET PER VIAM ILLAM AD INFIMA MONTIS ILLIVS, QVI LOCVS APPELLATVR ILLE, ET INDE PER IVGVM MONTIS ILLIVS IN SVMMVM, ET PER SVMMVM MONTIS PER DIVERGIA AQVAE AD LOCVM QVI APPELLATVR ILLE, ET INDE DEORSVM VERSVS AD LOCVM ILLVM, ET INDE AD COMPETVM ILLIVS, ET INDE PER MONVMENTVM ILLIVS AD locum unde primum coepit scriptura esse. saepe enim quorundam aut monumenta aut fossae aut quorundam sacellorum aut fontium, unde riui fluminaque incipiunt, obseruantur fines territoriorum. <q>"<hi rend="italic">Si autem rationem appellationis huius tractemus, territorium est quidquid hostis terrendi causa constitutum est.</hi>
-               </q>"        </p>
+               </q>" inuerecunde uult peruadere aut auare de locis publicis, hoc est <q>"<hi
+                     rend="italic">ad ipsam urbem pertinentibus</hi>
+               </q>", quidam priuatorum usurpare temptauerit. <milestone unit="page"
+                  n="p. 65 Thulin"/>pomerium autem urbis est quod ante muros spatium sub certa
+               mensura demensum est. sed et aliquibus urbibus et intra muros simili modo est
+               statutum propter custodiam fundamentorum. <q>"<hi rend="italic">quod a priuatis
+                     operibus optineri non oportebit. hic locus est qui a publico nullo iure poterit
+                     amoueri. habet autem condiciones duas, unam urbani soli, alteram agrestis;
+                     urbani soli, quod tutela rei urbanae assignatum est, agrestis, quod publicis
+                     operibus datum est aut destinatum</hi>
+               </q>". in tutela rei urbanae assignatae sunt siluae, de quibus ligna in reparatione
+               publicorum moenium traherentur. hoc genus agri tutelatum dicitur. nam aliquarum
+               urbium <q>"<hi rend="italic">maxima pars finium coloniae est adtributa</hi>
+               </q>". coloniae sunt quae ex eo nomine accipiuntur, quod Romani in eisdem ciuitatibus
+               colonos miserunt. illarum ergo urbium maxima finium pars data est coloniis, quae in
+               remotiora loca et longe a mari positae uidebantur, ut numerus ciuium, quem
+               multiplicare diuus Augustus conabatur, haberet spatia, in quae subsistere potuisset.
+               nam et <q>"<hi rend="italic">in Piceno fertur inter montium Praecutianorum quandum
+                     partem oppidi Asculanorum fine circum dari. sed hoc conciliabulum fuisse et
+                     postea fertur in municipii ius relatum. nam omnia antiqua municipia habent suum
+                     priuilegium</hi>
+               </q>". ut Tudertini qui apud principes egerunt ut Fanestres incolae, si essent
+               alienigenae, intra territorium inxolerent, honoribus fungi in colonia non deberent.
+               sed Fanestres hoc postea impetrauerunt, ut eis liceret et fungi honoribus territorii.
+               aeque iuris controuersia agitatur, quotiens propter exigenda tributa de possessione
+               litigatur; cum dicat una pars in sui eam fine territorii <milestone unit="page"
+                  n="p. 66 Thulin"/>constituta<supplied>m</supplied>, et altera e contrario
+               similiter quaeret. haec autem controuersia territorialibus est finienda terminibus.
+               nam inuenimus saepe in publicis instrumentis significanter inscripta territoria ita
+               ut EX COLLICVLO QVI APPELLATVR ILLE, AD FLVMEN ILLVD, ET PER FLVMEN ILLVD AD RIVVM
+               ILLVM aut VIAM ILLAM, ET PER VIAM ILLAM AD INFIMA MONTIS ILLIVS, QVI LOCVS APPELLATVR
+               ILLE, ET INDE PER IVGVM MONTIS ILLIVS IN SVMMVM, ET PER SVMMVM MONTIS PER DIVERGIA
+               AQVAE AD LOCVM QVI APPELLATVR ILLE, ET INDE DEORSVM VERSVS AD LOCVM ILLVM, ET INDE AD
+               COMPETVM ILLIVS, ET INDE PER MONVMENTVM ILLIVS AD locum unde primum coepit scriptura
+               esse. saepe enim quorundam aut monumenta aut fossae aut quorundam sacellorum aut
+               fontium, unde riui fluminaque incipiunt, obseruantur fines territoriorum. <q>"<hi
+                     rend="italic">Si autem rationem appellationis huius tractemus, territorium est
+                     quidquid hostis terrendi causa constitutum est.</hi>
+               </q>" </p>
             <p>
-               <q>"<hi rend="italic">De locis publicis siue populi Romani sine coloniarum municipiorumue controuersia est, quotiens ea loca, quae neque assignata neque uendita fuerint</hi>
+               <q>"<hi rend="italic">De locis publicis siue populi Romani sine coloniarum
+                     municipiorumue controuersia est, quotiens ea loca, quae neque assignata neque
+                     uendita fuerint</hi>
                </q>", <q>"<hi rend="italic">ab obtenebuntur, ut subseciua concessa</hi>
-               </q>". multis enim locis comperimus loca publica <milestone unit="page" n="p. 67 Thulin"/> repperiri, <q>"<hi rend="italic">ut ex proximo in Sabinis in monte Mutela</hi>
-               </q>", qui nunc a priuatis operibus obtinetur. nam et regione Reatina itidem sunt loca P. R.</p>   
-            <p>Loca autem quae sint publica uideamus. sunt siluae de quibus lignorum copia in lauacra publica ministranda caeduntur. sunt et loca publica quae in pascuis sunt relicta quibuscumque ad urbem uenientibus peregrinis. sunt in suburbanis loca publica inopum destinata funeribus, quae loca culinas appellant: sunt et loca noxiorum poenis destinata. ex his locis, cum sint suburbana, sine ulla religionis reuerentia solent priuati aliquid usurpare atque hortis suis applicare. sunt autem loca publica coloniarum, ubi prius fuere <q>"<hi rend="italic">conciliabula</hi>
+               </q>". multis enim locis comperimus loca publica <milestone unit="page"
+                  n="p. 67 Thulin"/> repperiri, <q>"<hi rend="italic">ut ex proximo in Sabinis in
+                     monte Mutela</hi>
+               </q>", qui nunc a priuatis operibus obtinetur. nam et regione Reatina itidem sunt
+               loca P. R.</p>
+            <p>Loca autem quae sint publica uideamus. sunt siluae de quibus lignorum copia in
+               lauacra publica ministranda caeduntur. sunt et loca publica quae in pascuis sunt
+               relicta quibuscumque ad urbem uenientibus peregrinis. sunt in suburbanis loca publica
+               inopum destinata funeribus, quae loca culinas appellant: sunt et loca noxiorum poenis
+               destinata. ex his locis, cum sint suburbana, sine ulla religionis reuerentia solent
+               priuati aliquid usurpare atque hortis suis applicare. sunt autem loca publica
+               coloniarum, ubi prius fuere <q>"<hi rend="italic">conciliabula</hi>
                </q>", et <q>"<hi rend="italic">postea sunt in municipii ius relata</hi>
-               </q>". sunt et alia loca publica quae praefecturae appellantur. nam et <q>"<hi rend="italic">pomeria</hi>
-               </q>" urbium, de quibus iam superius suo loco disputauimus, publica loca esse noscuntur. multis modis loca publica dici possunt, sed dum diuersis condicionibus constringuntur, non possunt nisi sua suis locis incedere. nam et ubi <q>"<hi rend="italic">uis aquae</hi>
+               </q>". sunt et alia loca publica quae praefecturae appellantur. nam et <q>"<hi
+                     rend="italic">pomeria</hi>
+               </q>" urbium, de quibus iam superius suo loco disputauimus, publica loca esse
+               noscuntur. multis modis loca publica dici possunt, sed dum diuersis condicionibus
+               constringuntur, non possunt nisi sua suis locis incedere. nam et ubi <q>"<hi
+                     rend="italic">uis aquae</hi>
                </q>" <q>"<hi rend="italic">aluei</hi>
                </q>" Tiberis <q>"<hi rend="italic">populi Romani</hi>
                </q>" tantum modo <q>"<hi rend="italic">insulam</hi>
                </q>" fecit, locus est publicus. <q>"<hi rend="italic">siluae</hi>
-               </q>" etiam sunt iuxta hoc alueo suis circum datae terminibus, quae casalia non utuntur.</p>
+               </q>" etiam sunt iuxta hoc alueo suis circum datae terminibus, quae casalia non
+               utuntur.</p>
             <p>
-               <q>"<hi rend="italic">De locis relictis et extra clusis controuersia est in agris assignatis. relicta autem ea loca sunt quae siue iniquitate locorum assignari nequiuerunt, siue ex uoluntate conditoris, hoc est mensoris, relicta limites minime acceperunt</hi>
-               </q>". dicuntur et ea relicta loca quae uis aquae obtinuit. haec loca et insoluta uocantur et <q>"<hi rend="italic">iuris subseciuorum</hi>
-               </q>" esse noscuntur. <q>"<hi rend="italic">Extra clusa loca sunt <milestone unit="page" n="p. 67 Thulin"/> aeque iuris subsecinorum, quae ultra limites et ultra finitima linea erunt. finitima autem linea aut mensuralis est, aut aliqua obseruatione aut terminorum ordine seruatur</hi>
-               </q>". ergo fines coloniae inclusi sunt montibus. propterea haec loca, quod assignata non sint, relicta appellantur; et extra clusa, quod extra ordinationes sint et tamen fine cludantur. haec plerumque proximi possessores inuadunt et oportunitate loci irritati agrum obtinent. cum his controuersiae a rebus solent moueri.</p>
+               <q>"<hi rend="italic">De locis relictis et extra clusis controuersia est in agris
+                     assignatis. relicta autem ea loca sunt quae siue iniquitate locorum assignari
+                     nequiuerunt, siue ex uoluntate conditoris, hoc est mensoris, relicta limites
+                     minime acceperunt</hi>
+               </q>". dicuntur et ea relicta loca quae uis aquae obtinuit. haec loca et insoluta
+               uocantur et <q>"<hi rend="italic">iuris subseciuorum</hi>
+               </q>" esse noscuntur. <q>"<hi rend="italic">Extra clusa loca sunt <milestone
+                        unit="page" n="p. 67 Thulin"/> aeque iuris subsecinorum, quae ultra limites
+                     et ultra finitima linea erunt. finitima autem linea aut mensuralis est, aut
+                     aliqua obseruatione aut terminorum ordine seruatur</hi>
+               </q>". ergo fines coloniae inclusi sunt montibus. propterea haec loca, quod assignata
+               non sint, relicta appellantur; et extra clusa, quod extra ordinationes sint et tamen
+               fine cludantur. haec plerumque proximi possessores inuadunt et oportunitate loci
+               irritati agrum obtinent. cum his controuersiae a rebus solent moueri.</p>
             <p>
                <q>"<hi rend="italic">De locis sacris et religiosis controuersiae plurimae</hi>
                </q>"<q>"<hi rend="italic">iure ordinario finiuntur</hi>
-               </q>". si enim loca sacra aedificabantur, quam maxime apud antiquos in confinio constituebantur, ubi trium uel quattuor possessionum terminatio conueniret. et unus quis possessor donabat certum modum sacro illi ex agro suo, et quantum donasset scripto faciebat, ut per diem sollemnitatis eorum priuatorum agri nullam molestiam inculcantis populi sustinerent. sed et siquid spatiosius cedebatur, sacerdotibus templi illius proficiebat. in Italia autem multi crescente religione sacratissima Christiana lucos profanos siue templorum loca occupauerunt et serunt. sed hoc ideo existimaui dicendum, ut magisterium suum si uult mensor ostendere, modum concessum fano illi demonstret. <q>"<hi rend="italic">Locorum autem religiosorum</hi>
-               </q>" similis est condicio. et his namque <q>"<hi rend="italic">secundum cautionem modus restituebatur</hi>
-               </q>" antiquitus. nam sanctum est plerumque ut incorruptum, et a sanciendo sanctum dicitur; religiosum a religando mentes, ne male agant homines. sacrum autem proprie dei est. <del>religiosum enim vel a relinquendo.</del> profanum autem quod, dum sanctum fuisset, postea in usu hominum factum, hoc est extra fano, extra sanctuario, profanum dictum est. <q>"<hi rend="italic">Moesilea uero habent iuris sui hortorum modum circum iacentem uel praescriptum agri finem</hi>
-               </q>". nam lucos frequenter in trifinia et quadrifinia inuenimus, sicut in suburbanis et circa publica itinera constitutum esse perspicimus.</p>
+               </q>". si enim loca sacra aedificabantur, quam maxime apud antiquos in confinio
+               constituebantur, ubi trium uel quattuor possessionum terminatio conueniret. et unus
+               quis possessor donabat certum modum sacro illi ex agro suo, et quantum donasset
+               scripto faciebat, ut per diem sollemnitatis eorum priuatorum agri nullam molestiam
+               inculcantis populi sustinerent. sed et siquid spatiosius cedebatur, sacerdotibus
+               templi illius proficiebat. in Italia autem multi crescente religione sacratissima
+               Christiana lucos profanos siue templorum loca occupauerunt et serunt. sed hoc ideo
+               existimaui dicendum, ut magisterium suum si uult mensor ostendere, modum concessum
+               fano illi demonstret. <q>"<hi rend="italic">Locorum autem religiosorum</hi>
+               </q>" similis est condicio. et his namque <q>"<hi rend="italic">secundum cautionem
+                     modus restituebatur</hi>
+               </q>" antiquitus. nam sanctum est plerumque ut incorruptum, et a sanciendo sanctum
+               dicitur; religiosum a religando mentes, ne male agant homines. sacrum autem proprie
+               dei est. <del>religiosum enim vel a relinquendo.</del> profanum autem quod, dum
+               sanctum fuisset, postea in usu hominum factum, hoc est extra fano, extra sanctuario,
+               profanum dictum est. <q>"<hi rend="italic">Moesilea uero habent iuris sui hortorum
+                     modum circum iacentem uel praescriptum agri finem</hi>
+               </q>". nam lucos frequenter in trifinia et quadrifinia inuenimus, sicut in suburbanis
+               et circa publica itinera constitutum esse perspicimus.</p>
             <p>
                <milestone unit="page" n="p. 69 Thulin"/>
-               <q>"<hi rend="italic">De aquae pluuiae transitu controuersia est, in qua si collectus pluuialis <supplied>a</supplied>quae transuersum secans finem alterius fundi influit</hi>
-               </q>", si aqua ex pluuia collecta riuum fecerit per longinquitatem temporum, et ut solet uideri, ripam ex utraque parte mediam <q>"<hi rend="italic">secans</hi>
+               <q>"<hi rend="italic">De aquae pluuiae transitu controuersia est, in qua si collectus
+                     pluuialis <supplied>a</supplied>quae transuersum secans finem alterius fundi
+                     influit</hi>
+               </q>", si aqua ex pluuia collecta riuum fecerit per longinquitatem temporum, et ut
+               solet uideri, ripam ex utraque parte mediam <q>"<hi rend="italic">secans</hi>
                </q>" erexerit, et hoc intra <q>"<hi rend="italic">fines alterius</hi>
-               </q>"; dumque riuus ille limite includitur, possessor uicini agri calumniose sibi uelit fines ad riuum usque defendere, non mediocris exinde controuersiae genus exoritur. sed hoc <q>"<hi rend="italic">mensoris</hi>
+               </q>"; dumque riuus ille limite includitur, possessor uicini agri calumniose sibi
+               uelit fines ad riuum usque defendere, non mediocris exinde controuersiae genus
+               exoritur. sed hoc <q>"<hi rend="italic">mensoris</hi>
                </q>" est peritia finiendum.</p>
             <p>
-               <q>"<hi rend="italic">De itineribus controuersia est, quae in arcifiniis agris iure ordinario finitur, in assignatis mensurarum ratione</hi>
-               </q>". <q>"<hi rend="italic">sed multi limites exigente ratione per diuia et confragosa loca eunt qua iter fieri non potest, et sunt in usu agrorum in eis locis, ubi proximus possessor est, cuius forte silua limitem detinet, et transitum inuerecunde denegat, cum itineri limitem aut locum limiti debeat</hi>
-               </q>". Nam plerumque uia, dum cum limite currit, etiam si uicinalis est aut lignaria aut priuata, finem praestat. regammante uero uia uel limite, dum a se utri<supplied>m</supplied>que discesserint, desi<supplied>ni</supplied>t uia finem praestare <supplied>et</supplied> erit controuersia: sed inspectio artifici<supplied>s</supplied> eam finiet.</p>
-            <p>Satis, ut puto, dilucide genera controuersiarum uel primum agri qualitatem exposui. nam et simplicius enarrare condiciones earum existimaui, quo facilius ad intellectum peruenirent. nunc quem ammodum singula pertractari debeant persequendum est, uel quod sint status earum, id est iniectiuus expositiuus subiectiuum reciperatiuus assumptiuus initialis materialis effectiuus. sunt enim VIII. ex his omne genus controuersiarum exoritur. iniectinus ergo status est generalis: nam siue de possessione siue de fine controuersia nascatur, per hoc repetitio iusta iniustaque inicitur. expositiuus est status controuersiae, quotiens finitimorum <milestone unit="page" n="p. 70 Thulin"/>argumentorum caret demonstrationem et partium magis exiget narrationem, per quem exponendum sit, quo sint genere terminandae, aut persuadendum iudici, etiam si loci natura finitimam exhibeat similitudinem. subiectiuus status est controuersiae, cum relinquitur status generalis et alio quolibet statu controuersia defenditur. reciperatiuus est status, quotiens non a trifinia aut quadrifinia sed ex quolibet alio finis loco incipientis termini recturam dirigit, et per incessum definitionis loca quaedam alteri fundo adquirit aut solum auferet et eius loco redditur. Assumptiuus primae controuersiae status est, qui est de positione terminorum, in rigorem aut in finem transcendit. Initialis controuersiae status de rigore pertinens ad materiam transcendit in controuersiam, quae est loco tertio de fine, status materialis non condicionem mutat neque materia efficit. Materialis status est ex quo omnes controuersiae incipiunt, de loco dum taxat. nam transcendentiam non habet de hoc effectiuus, sed dum consummatus fuerit nascitur. nam effectiuus est cum de loco litigatur et idoneas partes ad litigium aduocationes instituunt.</p>
-            <p>Respicio etenim quantum sit quod mensoris prouidentiae iniungatur; sed nec minus aduocatis. quorum ars licet diuersa sit, prudentiam tamen et simplicitatem eandem habere debent et qui iudicaturi sunt et qui aduocationes sunt praestaturi. iudicando autem mensor bonus uir et iustus agere debet, nulla ambitione aut sordibus moueri, seruare opinionem et arte et moribus. omnis illi artificii ueritas custodienda est, exclusis illis similitudinibus quae falsae pro ueris subiciuntur. quidam enim per imperitiam, quidam per inprudentiam peccant. totum autem hoc iudicandi officium hominem bonum iustum sobrium castum modestum et artificem egregium exigit. hoc autem possessores aequo animo ferre non possunt: nam cum his ueritas exposita fuerit, aduersus sinceritatem artis facere cogunt. multa sunt enim in professione quae generaliter pro ueris offerantur, multa quae specialiter, quaedam quae argumentaliter. quaedam coniecturaliter etiam mentiri artifices coguntur.</p>
+               <q>"<hi rend="italic">De itineribus controuersia est, quae in arcifiniis agris iure
+                     ordinario finitur, in assignatis mensurarum ratione</hi>
+               </q>". <q>"<hi rend="italic">sed multi limites exigente ratione per diuia et
+                     confragosa loca eunt qua iter fieri non potest, et sunt in usu agrorum in eis
+                     locis, ubi proximus possessor est, cuius forte silua limitem detinet, et
+                     transitum inuerecunde denegat, cum itineri limitem aut locum limiti debeat</hi>
+               </q>". Nam plerumque uia, dum cum limite currit, etiam si uicinalis est aut lignaria
+               aut priuata, finem praestat. regammante uero uia uel limite, dum a se
+                  utri<supplied>m</supplied>que discesserint, desi<supplied>ni</supplied>t uia finem
+               praestare <supplied>et</supplied> erit controuersia: sed inspectio
+                  artifici<supplied>s</supplied> eam finiet.</p>
+            <p>Satis, ut puto, dilucide genera controuersiarum uel primum agri qualitatem exposui.
+               nam et simplicius enarrare condiciones earum existimaui, quo facilius ad intellectum
+               peruenirent. nunc quem ammodum singula pertractari debeant persequendum est, uel quod
+               sint status earum, id est iniectiuus expositiuus subiectiuum reciperatiuus
+               assumptiuus initialis materialis effectiuus. sunt enim VIII. ex his omne genus
+               controuersiarum exoritur. iniectinus ergo status est generalis: nam siue de
+               possessione siue de fine controuersia nascatur, per hoc repetitio iusta iniustaque
+               inicitur. expositiuus est status controuersiae, quotiens finitimorum <milestone
+                  unit="page" n="p. 70 Thulin"/>argumentorum caret demonstrationem et partium magis
+               exiget narrationem, per quem exponendum sit, quo sint genere terminandae, aut
+               persuadendum iudici, etiam si loci natura finitimam exhibeat similitudinem.
+               subiectiuus status est controuersiae, cum relinquitur status generalis et alio
+               quolibet statu controuersia defenditur. reciperatiuus est status, quotiens non a
+               trifinia aut quadrifinia sed ex quolibet alio finis loco incipientis termini recturam
+               dirigit, et per incessum definitionis loca quaedam alteri fundo adquirit aut solum
+               auferet et eius loco redditur. Assumptiuus primae controuersiae status est, qui est
+               de positione terminorum, in rigorem aut in finem transcendit. Initialis controuersiae
+               status de rigore pertinens ad materiam transcendit in controuersiam, quae est loco
+               tertio de fine, status materialis non condicionem mutat neque materia efficit.
+               Materialis status est ex quo omnes controuersiae incipiunt, de loco dum taxat. nam
+               transcendentiam non habet de hoc effectiuus, sed dum consummatus fuerit nascitur. nam
+               effectiuus est cum de loco litigatur et idoneas partes ad litigium aduocationes
+               instituunt.</p>
+            <p>Respicio etenim quantum sit quod mensoris prouidentiae iniungatur; sed nec minus
+               aduocatis. quorum ars licet diuersa sit, prudentiam tamen et simplicitatem eandem
+               habere debent et qui iudicaturi sunt et qui aduocationes sunt praestaturi. iudicando
+               autem mensor bonus uir et iustus agere debet, nulla ambitione aut sordibus moueri,
+               seruare opinionem et arte et moribus. omnis illi artificii ueritas custodienda est,
+               exclusis illis similitudinibus quae falsae pro ueris subiciuntur. quidam enim per
+               imperitiam, quidam per inprudentiam peccant. totum autem hoc iudicandi officium
+               hominem bonum iustum sobrium castum modestum et artificem egregium exigit. hoc autem
+               possessores aequo animo ferre non possunt: nam cum his ueritas exposita fuerit,
+               aduersus sinceritatem artis facere cogunt. multa sunt enim in professione quae
+               generaliter pro ueris offerantur, multa quae specialiter, quaedam quae
+               argumentaliter. quaedam coniecturaliter etiam mentiri artifices coguntur.</p>
          </div>
       </body>
-  </text>
+   </text>
 </TEI>

--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -44,29 +44,29 @@
          </projectDesc>
          <editorialDecl>
 
-            <p n="">
+            <p>
                <hi rend="bold">Note di trascrizione e codifica del progetto digilibLT </hi>
             </p>
-            <p n="">Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
+            <p>Abbiamo riportato solo il testo stabilito dall'edizione di riferimento non seguendone
                l'impaginazione. Sono stati invece esclusi dalla digitalizzazione apparati,
                introduzioni, note e commenti e ogni altro contenuto redatto da editori moderni. </p>
-            <p n=""> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
+            <p> I testi sono stati sottoposti a doppia rilettura integrale per garantire la massima
                correttezza di trascrizione</p>
-            <p n="">Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
+            <p>Abbiamo normalizzato le U maiuscole in V seguendo invece l'edizione di riferimento
                per la distinzione u/v minuscole.</p>
-            <p n=""> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
-            <p n=""> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
+            <p> Non è stato normalizzato l'uso delle virgolette e dei trattini.</p>
+            <p> Non è stata normalizzata la formattazione nell'intero <hi rend="italic">corpus</hi>:
                grassetto, corsivo, spaziatura espansa.</p>
-            <p n="">Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
+            <p>Sono stati normalizzati e marcati nel modo seguente i diacritici.<lb/> espunzioni:
                &lt;del&gt;testo&lt;/del&gt; si visualizza [testo] <lb/> integrazioni:
                &lt;supplied&gt;testo&lt;/supplied&gt; si visualizza &lt;testo&gt;<lb/>
                <hi rend="italic">loci desperati</hi>: &lt;unclear&gt;testo&lt;/unclear&gt; o
                &lt;unclear/&gt; testo si visualizzano †testo† e †testo<lb/> lacuna materiale:
                &lt;gap/&gt; si visualizza [...]<lb/> lacuna integrata dagli editori:
                &lt;supplied&gt;&lt;gap/&gt;&lt;/supplied&gt; si visualizza &lt;...&gt; </p>
-            <p n="">Sono stati marcati i termini in lingua greca &lt;foreign
+            <p>Sono stati marcati i termini in lingua greca &lt;foreign
                xml:lang="grc"&gt;αγβ&lt;/foreign&gt; </p>
-            <p n="">Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
+            <p>Ulteriori informazioni sulle norme di trascrizione e codifica su <ref
                   target="http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf"
                   >Note di trascrizione e codifica di testi latini tardoantichi
                   [http://digiliblt.lett.unipmn.it/upload/docs/note_di_trascrizione_e_di_codifica.pdf]</ref>

--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<?oxygen RNGSchema="file:teilite.rnc" type="compact"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
@@ -82,7 +81,9 @@
       </profileDesc>
       <revisionDesc>
          <change who="Romain Verny" when="2021-04-29">
-            <item></item>
+            <list>
+               <item>Suppression de la déclaration RNGSchema en début de document</item>
+            </list>            
          </change>
       </revisionDesc>
    </teiHeader>

--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -85,7 +85,7 @@
                <item>Suppression de la déclaration RNGSchema en début de document</item>
                <item>profileDesc/langUsage/language : correction de l'indicateur de langue utilisé ("la" en "lat")</item>
                <item>encondingDesc/RefsDcl/cRefPattern : indication que le pointer extrait des paragraphes"</item>
-               <item>text/body/div : numérotation des paragraphes</item>
+               <item>text/body/div : numérotation des paragraphes + déplacement de la balise milestone dans le paragraphe n°1</item>
             </list>            
          </change>
       </revisionDesc>
@@ -95,8 +95,7 @@
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0012a.stoa003.digilibLT-lat1">
          <div type="opus">
             <head>Commentum de controuersiis</head>
-            <milestone unit="page" n="p. 58 Thulin"/>
-            <p n="1">Suscepimus quoque tractandos controuersiarum status cum diuino praesidio.</p>
+            <p n="1"><milestone unit="page" n="p. 58 Thulin"/>Suscepimus quoque tractandos controuersiarum status cum diuino praesidio.</p>
             <p n="2">
                <q>"<hi rend="italic">Materiae</hi>"</q>, inquit,<q>"<hi rend="italic"
                      >controuersiarum sunt duae, finis et locus. harum condicio alterutra

--- a/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
+++ b/data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml
@@ -76,13 +76,15 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
       <revisionDesc>
          <change who="Romain Verny" when="2021-04-29">
             <list>
                <item>Suppression de la déclaration RNGSchema en début de document</item>
+               <item>profileDesc/langUsage/language : correction de l'indicateur de langue utilisé ("la" en "lat")</item>
+               <item></item>
             </list>            
          </change>
       </revisionDesc>


### PR DESCRIPTION
### **Correction du fichier stoa0012a.stoa001 correspondant à l'issue #95** 

Pour rappel, le chemin vers le fichier est le suivant :
`data/stoa0012a/stoa003/stoa0012a.stoa003.digilibLT-lat1.xml`

Corrections effectuées pour rendre le fichier compatible avec CapiTainS :

- [ ] `TEI/teiHeader/profileDesc/langUsage/language` : correction du "la" en "lat" pour indiquer la langue utilisée
- [ ] `TEI/text/body/div/p` : numérotation des paragraphes + déplacement de la balise `milestone` dans le premier paragraphe
- [ ] `TEI/teiHeader/encodingDesc/refsDecl/cRefPattern` : précision que le pointer extrait des paragraphes
- [ ] Suppression de la déclaration RNGSchema en début de document