### PR TITLE
5/5 Correction du fichier - stoa0329.stoa001

### DIFF
--- a/data/stoa0329/stoa001/stoa0329.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0329/stoa001/stoa0329.stoa001.digilibLT-lat1.xml
@@ -30,7 +30,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
             <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>

--- a/data/stoa0329/stoa001/stoa0329.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0329/stoa001/stoa0329.stoa001.digilibLT-lat1.xml
@@ -30,7 +30,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei/text/body/div/div/div[@n='$1']))"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS"><cRefPattern n="chapter" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='1'])"><p>This pointer pattern extracts chapters</p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
             <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
@@ -73,10 +73,12 @@
       </encodingDesc>
       <profileDesc>
          <langUsage>
-            <language ident="la">Latino</language>
+            <language ident="lat">Latino</language>
          </langUsage>
       </profileDesc>
-  
+      <revisionDesc>
+         <change who="Akim OUCHEN" when="2021-04-29">Correction de la langue, du cRefPattern</change>
+      </revisionDesc>
    </teiHeader>
 
    <text>


### PR DESCRIPTION
 Issue #103

Correction de Fichier XML CapiTains 5/5 pour la validation du cours de GIT
_Itinerarium Burdigalense, Correzione linguistica_, Elisa Rugnone (stoa0329.stoa001.digilibLT-lat1.xml )

- [ ]  Correction de la langue
- [ ]  Ajout du `<cRefPattern>` pour extraire des chapitres

_Now do's my Proiect gather to a head_