### PR TITLE
Correction stoa0171a.stoa001.digilibLT-lat1.xml

### DIFF
--- a/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
@@ -4248,7 +4248,7 @@
 
             <div type="schol" n="543">
                <p> VIDVO ... LIGNO cuspide: ab ea parte quae ferro caret ac per hoc infirma. Metaphora a muliere: ut quae auxilio mariti caret infirma est, ita lignum quod non habet ferrum unde uulnus infligat infirmum est. </p>
-            </div>
+            </lg></div>
 
             <div type="schol" n="545">
                <p> (PALLENTIAQVE) IRA (ORA) <supplied>
@@ -9264,11 +9264,11 @@
                <p>aut certe Peliam, Neptuni filium, qui Iolci summam obtinebat. Hic enim responsum acceperat ut ab eo spoliaretur arce qui altero ei nudo pede occurrisset. Quapropter hoc uelocius sustinuit quo euitare captauit. Iason quidem natus ex Aesone, fratre regis, occursurus sacris quae Neptuno is faciebat, dum per Anaurum flumen transit, detentum limo alterum pedis calciamentum reliquit atque ita fato agente peruenit ad Peliam. Qui in illo timens quicquid <supplied>ab</supplied> oraculo fuerat dictum, sub specie gloriae eum misit ad Colchos ad auferendam auream arientis pellem. <del>Ergo <hi rend="italic">Pelias pinus</hi> Argo nauem dicit, quae in Pelio monte Thessaliae fabricata est.</del> HOSPITA quasi prima. INTACTI ... PONTI quia ante Argo nauem inuiolatus fuit. </p>
             </div>
 
-            <div type="schol" n="337">
+            <div type="schol" n="337a">
                <p> MINYAE <hi rend="italic">Minyae</hi> Thessali, a Minya rege Thessalorum, a cuius nomine omnes Argonautae 'Minyae' nominati sunt. </p>
             </div>
 
-            <div type="schol" n="337">
+            <div type="schol" n="337b">
                <p> (GEMINVS FRAGOR ARDVA) CANET / (PER LATERA) <supplied>
                      <hi rend="italic">canet</hi>
                   </supplied> spumat. Id est: dextra laeuaque reuulsi fluctus cano litore feruebant. </p>
@@ -18921,7 +18921,7 @@
                <p> TREPIDOS supplices. </p>
             </div>
 
-            <div type="schol" n="495a">
+            <div type="schol" n="495b">
                <p> HORRET EGENIS / (COETIBVS) horridior fit miseris. </p>
             </div>
 

--- a/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
@@ -31,7 +31,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="chapters" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])"><p>This pointer pattern extracts  chapters </p></cRefPattern>
+         <refsDecl n="CTS"><cRefPattern n="scholia" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])"><p>This pointer pattern extracts  scholia </p></cRefPattern>
             <cRefPattern n="books" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])"><p>This pointer pattern extracts books </p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>

--- a/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
@@ -31,7 +31,8 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <refsDecl n="CTS"><cRefPattern n="unknown" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts unknown</p></cRefPattern></refsDecl>
+         <refsDecl n="CTS"><cRefPattern n="chapters" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1']/tei:div[@n='$2'])"><p>This pointer pattern extracts  chapters </p></cRefPattern>
+            <cRefPattern n="books" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div[@n='$1'])"><p>This pointer pattern extracts books </p></cRefPattern></refsDecl>
          <projectDesc>
             <p>digilibLT. Biblioteca digitale di testi latini tardoantichi.</p>
             <p>Progetto diretto da Raffaella Tabacco (responsabile della ricerca) e Maurizio Lana</p>
@@ -74,7 +75,7 @@
             <language ident="la">Latino</language>
          </langUsage>
       </profileDesc>
-  
+      <revisionDesc><change who="Emilien Arnaud" when="2021-04-30">correction du sys. de citation Capitains  (refsDesc), correction des numéros des div de type="lib", correction d'un très grand nombre de forbidden characters dans les identifiants d'attributs des div $2. Schéma utilisé : si on a x-y, on a remplacé par x; si cela faisait doublon, on a remplacé par xa ou xb. malheureusement nous n'avons appliqué ce schéma normalisé qu'à partir du livre 2 : au livre 1 on a essayé d'avoir le moins de doublons possibles (donc parfois on remplacait x-y par y si le x faisait doublon). ligne 12592, écriture dans le 'p' d'un mot qui était placé de façon erronée en attribut de div </change></revisionDesc>  
    </teiHeader>
 
    <text>
@@ -82,10 +83,10 @@
 
       <body xml:lang="lat" n="urn:cts:latinLit:stoa0171a.stoa001.digilibLT-lat1">
 
-         <div type="lib" n="I">
+         <div type="lib" n="1">
             <head>LIBER I</head>
 
-            <div type="schol" n="1-2">
+            <div type="schol" n="1">
                <p> FRATERNAS ACIES ALTERNAQVE REGNA PROFANIS / DECERTATA ODIIS quia pacti erant fratres ut mutuis annis regnarent et sibi inuicem succederent. Hoc dicit: narramus gesta certamina causa regnorum. ALTERNA ut placuerat, non ut possessa sunt. PROFANIS quia per eos uiolata sunt iura naturae, et bene <hi rend="italic">profanis</hi>, quia nefas erat germanos odia retinere, ergo exsecrabilibus, contra naturam sumptis.</p>
             </div>
 
@@ -97,7 +98,7 @@
                <p> PIERIVS (... CALOR) Musicus.</p>
             </div>
 
-            <div type="schol" n="3-4">
+            <div type="schol" n="4">
                <p> VNDE IVBETIS / IRE DEAE quia multa sunt principia Thebanae historiae, unde possimus incohare narrationem.</p>
             </div>
 
@@ -105,15 +106,15 @@
                <p> SIDONIOS R(APTVS) Europam dicit, quam Iuppiter rapuit et uitiauit.</p>
             </div>
 
-            <div type="schol" n="5-6">
+            <div type="schol" n="6">
                <p> ET INEXORABILE P(ACTVM) / L(EGIS) A(GENOREAE) iusserat enim Cadmo filio suo Agenor, quem ad requirendam filiam Europam miserat, ut non nisi inuenta sorore rediret ad patrem.</p>
             </div>
 
-            <div type="schol" n="7-8">
+            <div type="schol" n="7">
                <p> TREPIDVM S(I) M(ARTIS) O(PERTI) / (AGRICOLAM) quia Cadmus Europam quaerens uenit ad ea loca in quibus post Thebae constructae sunt, ubi inuento dracone qui Marti consecratus erat et eo perempto dentes draconis seuit, unde terrigenae nati sunt, qui se mutuis uulneribus peremerunt. Ergo <hi rend="italic">Martis operti</hi> id est pugnae terrigenarum latentis. TREPIDVM... AGRICOLAM Cadmum.</p>
             </div>
 
-            <div type="schol" n="9-10">
+            <div type="schol" n="9">
                <p> (QVO CARMINE MVRIS) / IVSSERIT A(MPHION) T(YRIOS) A(CCEDERE) M(ONTES) his filius Iouis fuit <supplied>uel</supplied> ut alii dicunt Mercurii. cuius lyra accepta canens muros Thebanos dicitur constituisse, ut eius cantu spontanea se saxa muris imponerent. Vnde Vergilius:</p>
                <lg>
                   <l>'canto quae solitus, si quando a(rmenta) u(ocabat),</l>
@@ -136,7 +137,7 @@
                   <unclear>decoratam</unclear>. Dolum meditans Semeles limen ingressa est, cui ita locuta est: Si te, ut perhibent, integre amat Iuppiter, hoc ab eo impetra, ut talis ad te ueniat, qualis Iunoni solet uideri. Quae ita inducta Iouem rogauit. Qui cum negaret et diceret aspectum dei nullo modo ferre posse mortalem, tandem promisit tali se habitu ad eam esse uenturum, quali ad Iunonem consueuit. Qui cum uenisset cum fulmine, Semele sustinere non potuit et obiit. Iuppiter uero aperto eius uelocissime utero Liberum patrem <del>aperto</del> femore abdidisse dicitur, ut expletis nouem mensibus legitime nasceretur.</p>
             </div>
 
-            <div type="schol" n="12-14">
+            <div type="schol" n="12">
                <p> CVI SVMPSERIT ARCVM / INFELIX ATHAMAS (CVR NON EXPAVERIT INGENS / IONIVM SOCIO CASVRA PALAEMONE MATER) Leucothea, quae et Ino, Liberi patris nutrix fuisse dicitur. Huius marito Athamanti talem furorem Iuno immisit, ut filios suos uellet occidere, sperans quod Liberum patrem inuenire posset et simili sorte perimere<del>t</del>. Qui Athamas unum filium suum Learchum Herculis sagittis exstinxit. Leucothea uero, ubi maritum suum furere conspexit, cum Palaemone filio suo se dedit in mare. Quae postmodum in marinam deam conuersa est et uocatur Mater Matuta, filius eius deus Portunus. Vnde Vergilius:</p>
                <lg>
                   <l>'manu magna P(ortunus) e(untem)</l>
@@ -148,7 +149,7 @@
                <p> IONIVM quod se in Ionio mari Leucothea praecipitauerit.</p>
             </div>
 
-            <div type="schol" n="15-16">
+            <div type="schol" n="15">
                <p> GEMITVS ET PROSPERA (CADMI / PRAETERIISSE SINAM) id est infelicitates et felicitates Cadmi reticeo.</p>
             </div>
 
@@ -160,7 +161,7 @@
                <p> CONFVSA DOMVS quia idem filius et maritus, eadem mater et uxor, idem filii qui nepotes.</p>
             </div>
 
-            <div type="schol" n="17-18">
+            <div type="schol" n="17">
                <p> (QVANDO ITALA NONDVM / SIGNA NEC ARCTOOS AVSIM) SPIRARE T(RIVMPHOS) ideo Graeca bella scribo, quia Latina non possum.</p>
             </div>
 
@@ -172,7 +173,7 @@
                <p> CONIVRATO contra nos scilicet.</p>
             </div>
 
-            <div type="schol" n="21-22">
+            <div type="schol" n="21">
                <p> (DEFENSA PRIVS VIX PVBESCENTIBVS ANNIS) / BELLA IOVIS pugnam quam in Capitolio Domitianus gessit, quando patrem suum Vespasianum obsessum a Vitellio liberauit. Ergo <del>Vespasiano</del> imperatori sui temporis adulatur. (LATIAE) DECVS A(DDITE) F(AMAE) Titum Domitianum, filium Vespasiani, dicit.</p>
             </div>
 
@@ -180,11 +181,11 @@
                <p> SVBEVNTEM E(XORSA) P(ARENTIS) ad imitationem patris.</p>
             </div>
 
-            <div type="schol" n="24-31">
+            <div type="schol" n="24">
                <p> LICET A(RTIOR) ... (ET SIDERA DONES) quamuis densentur astra, dum spatiosus tibi locus paretur in caelo. Licet omnes stellae se contrahant, ut tibi locum faciant quem uolueris, licet Sol te magis uelit diei implere curricula quam se et tibi suum cedat officium aut <supplied>te</supplied>cum Iuppiter aequa parte caelum partiri desideret: tamen melius tibi erit terrae regnare quam caeli, et sis terrae uel maris dominus et superis caeleste dones imperium.</p>
             </div>
 
-            <div type="schol" n="[25]">
+            <div type="schol" n="25">
                <p> 
                   <del>PLAGA L(VCIDA) C(AELI) hoc est orientalis.</del>
                </p>
@@ -200,7 +201,7 @@
                <p> SOLLICITET tuo scilicet amore.</p>
             </div>
 
-            <div type="schol" n="27-29">
+            <div type="schol" n="29">
                <p> (LICET) IGNIPEDVM F(RENATOR) E(QVORVM) / (IPSE TVIS ALTE RADIANTEM CRINIBVS ARCVM / IMPRIMAT) id est Sol licet tibi cedat suam potestatem et tradat tibi currus suos. Vt Lucanus:</p>
                <l>'seu te flammigeros P(hoebi) c(onscendere) c(urrus)'.</l>
                <p>RADIANTEM C(RINIBVS) A(RCVM) circulum in quo sol suos cursus explet, quia ueluti arcus uidetur, quod sol ab oriente nascens usque in occidentalem partem desinit.</p>
@@ -210,17 +211,17 @@
                <p> ET SIDERA DONES concedas numinibus uel locis suis esse sinas.</p>
             </div>
 
-            <div type="schol" n="32-33">
+            <div type="schol" n="32">
                <p> (TEMPVS ERIT CVM PIERIO TVA FORTIOR) OESTRO / (FACTA CANAM NVNC TENDO CHELYN <supplied>
                      <hi rend="italic">oestro</hi>
                   </supplied> instinctu, stimulo, quem Romani 'asilum' dicunt, Graeci 'oestrum'. NVNC TENDO C(HELYN) <hi rend="italic">chelyn</hi> citharam. Graece enim <foreign xml:lang="grc">χέλυς</foreign> testudo dicitur, cuius neruis sonantibus Apollo citharam dicitur inuenisse. Nunc hoc dicit: se adhuc Romana bella scribere non posse, nisi tunc cum maior<supplied>e</supplied> pectore Phoebus aduenerit.</p>
             </div>
 
-            <div type="schol" n="33">
+            <div type="schol" n="33a">
                <p> SATIS sufficienter.</p>
             </div>
 
-            <div type="schol" n="33-34">
+            <div type="schol" n="33b">
                <p> ARMA REFERRE / AONIA Thebana, ab Aone rege, filio Neptuni, uel a monte Boeotiae. Ipsa est Aonia, quae et Boeotia, quae et Thebae. Alii dicunt quod fons isto nomine sit apud Siculos, ubi Musae coluntur.</p>
             </div>
 
@@ -250,7 +251,7 @@
                <p> ISMENON fluuium.</p>
             </div>
 
-            <div type="schol" n="41">
+            <div type="schol" n="41a">
                <p> QVEM PRIVS H(EROVM) (CLIO DABIS) ad inuocationem redit poeta. Interrogatiue quaerit ex Musa, quem uelit a se primum heroum describi. Figura <foreign xml:lang="grc">διαπόρησις</foreign> id est addubitatio. Vt Horatius:</p>
                <lg>
                   <l>'quid prius dicam solitis parentis</l>
@@ -258,7 +259,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="41-42">
+            <div type="schol" n="41b">
                <p> IMMODICVM I(RAE) / T(YDEA) Tydeus Oenei et <supplied>P</supplied>eriboeae filius, gener Adrasti. Et bene <hi rend="italic">immodicum irae</hi>, qui auctoris suae necis cerebro dicitur immoriens pastus.</p>
             </div>
 
@@ -266,16 +267,16 @@
                <p> LAVRIGERI S(VBITOS) A(N) V(ATIS) H(IATVS) Amphiaraum Lyncei et Hypermestrae filium dicit, qui hiatu terrae, dum curru dimicaret, absumptus est. Quem <hi rend="italic">laurigerum</hi> dixit eo quod Apollinis esset antistes.</p>
             </div>
 
-            <div type="schol" n="43">
+            <div type="schol" n="43a">
                <p> VRGET compellit ad scribendum.</p>
             </div>
 
-            <div type="schol" n="43-44">
+            <div type="schol" n="43b">
                <p> 
                   <del>ET</del> H(OSTILEM) P(ROPELLENS) C(AEDIBVS) A(MNEM) / T(VRBIDVS) HIPPOMEDON <supplied>M</supplied>nesimachi et Nasicae filius, qui, dum in Ismeno<del>nta</del> fluuio dimicaret, exstinctus est.</p>
             </div>
 
-            <div type="schol" n="44-45">
+            <div type="schol" n="44">
                <p> PLORANDAQVE B(ELLA) P(ROTERVI) / (ARCADOS) miseratione digna et in puerili aetate praesumpta. Bella Parthenopaei, Meleagri et Atalantes filii, dicit.</p>
             </div>
 
@@ -290,7 +291,7 @@
                <p> IMPIA IAM MERITA S(CRVTATVS) L(VMINA) D(EXTRA) <hi rend="italic">lumina</hi> merito <hi rend="italic">impia</hi>. <hi rend="italic">Dext<del>e</del>ra</hi> parricidae bene <hi rend="italic">merita</hi>, quae uindicauit.</p>
             </div>
 
-            <div type="schol" n="47-48">
+            <div type="schol" n="47">
                <p> MERSERAT A(ETERNA) D(AMNATVM) N(OCTE) P(VDOREM) / O(EDIPODES) absconderat pudorem. Omnis enim uerecundia de aspectu est.</p>
             </div>
 
@@ -299,7 +300,7 @@
                <l>'indulgent uino'.</l>
             </div>
 
-            <div type="schol" n="51-52">
+            <div type="schol" n="51">
                <p> (ADSIDVIS) CIRCVMVOLAT ALIS / S(AEVA) D(IES) A(NIMI) lux conscientiae atque Furiarum. Nam quamuis caecus esset, facinora sua conscientia arguente cernebat.</p>
             </div>
 
@@ -308,7 +309,7 @@
                <l>'perque domos Ditis u(acuas) e(t) i(nania) r(egna)'.</l>
             </div>
 
-            <div type="schol" n="56-57">
+            <div type="schol" n="56">
                <p> DI SONTES A(NIMAS) A(NGVSTA)Q(VE) T(ARTARA) P(OENIS) / Q(VI) R(EGITIS) in hac prece orantis artem et ordinem seruat. Primo meritum suum memorat, cum dicit:</p>
                <lg>
                   <l>'si bene quid merui',</l>
@@ -322,7 +323,7 @@
                   <hi rend="italic">Angusta</hi> autem Tartara merito, quippe cum scelera sobolis suae poenarum numerum uincant.</p>
             </div>
 
-            <div type="schol" n="57-58">
+            <div type="schol" n="57">
                <p> TVQVE VMBRIFERO S(TYX) L(IVIDA) F(VNDO) / QVAM VIDEO <hi rend="italic">Styx liuida</hi> id est nigra, ut Vergilius:</p> 
                <l>'liuentis plumbi'.</l> 
                <p>Vnde et 'liuidos' dixere inuidos uel 'nigros', ut Horatius:</p> 
@@ -338,7 +339,7 @@
                <p> TRAIECTVM V(VLNERE) P(LANTAS) responderat oraculum Laio, quod a filio suo posset occidi. Vnde natum Oedipum iussit proici transfixis cruribus. Harum omnium seriem fabularum in argumento digessimus.</p>
             </div>
 
-            <div type="schol" n="&lt;62-64&gt;">
+            <div type="schol" n="62">
                <p> 
                   <supplied>SI STAGNA PETI CIRRHAEA BICORNI / INTERFVSA IVGO POSSEM CVM DEGERE FALSO / CONTENTVS POLYBO</supplied> se increpat, <del>condemnat oracula</del> qui non contentus generis falsitate responsa consuluit. Nam ei cautio diuinationis fuit occasio parricidii. CIRRHAEA ista enim ciuitas iuxta Parnassum est montem, qui in duo iuga diuiditur, in Heliconem et Cithaeronem. BICORNI id est bicipiti Parnasso, ut Persius:</p>
                <lg>
@@ -355,29 +356,29 @@
                <p> LONGAEVVM I(MPLICVI) R(EGEM) bene <hi rend="italic">regem</hi>. Hoc enim solum parricidii tempore recognouit. </p>
             </div>
 
-            <div type="schol" n="66-67">
+            <div type="schol" n="66">
                <p> SI SPHINGOS I(NIQVAE) / C(ALLIDVS) A(MBAGES) T(E) P(RAEMONSTRANTE) R(ESOLVI) <hi rend="italic">callidus</hi> non ignarus: si Sphingos uideor soluisse ambages, o Furia, ut bene de te merito parricidae tuo incestum praemium dares. </p>
             </div>
 
-            <div type="schol" n="68-69">
+            <div type="schol" n="68">
                <p> (SI DVLCES FVRIAS ET LAMENTABILE MATRIS) / CONVBIVM (GAVISVS INI) concubitum matris <hi rend="italic">dulces furias</hi> dixit. Et bene totum etiam quod ignarus admisit, imputat Furiae, ut beneficiorum assiduitate suffulta tamquam suum sibi uindicet parricidam. GAVISVS I(NI) hic uis sceleris conscientia probatur admissi, quod tali conubio sit gauisus. </p>
             </div>
 
-            <div type="schol" n="69-70">
+            <div type="schol" n="69">
                <p> (NOCTEMQVE NEFANDAM) / SAEPE TVLI facile enim purgatur, quicquid semel uel casu committitur. </p>
             </div>
 
-            <div type="schol" n="71-72">
+            <div type="schol" n="71">
                <p> MOX AVIDVS P(OENAE) D(IGITIS) C(AEDENTIBVS) V(LTRO) / INCVBVI id est festinaui edere de me ipse supplicium, ne ulterius tanta scelera celarem. Nam cum caederent digiti, poenae magis quam mortis auidus pronus incubui. Nam desiderasse mortem hoc fuerat fugisse supplicium. </p>
             </div>
 
-            <div type="schol" n="73-74">
+            <div type="schol" n="73">
                <p> 
                   <del>EXAVDI S(I) D(IGNA) P(RECOR)</del> QVAEQVE IPSA F(VRENTI) / (SVBICERES) id est quae tu suadere potuisti. Furiarum est enim semper suadere crudelia. Vt Vergilius:</p> 
                <l>'tu potes unanimos a(rmare) i(n) p(roe- lia) f(ratres)'.</l>
             </div>
 
-            <div type="schol" n="74-75">
+            <div type="schol" n="74">
                <p> ORBVM V(ISV) R(EGNISQVE) C(ARENTEM) / N(ON) R(EGERE) id est orbatum regnis et uisu non regere ut caecum. </p>
             </div>
 
@@ -385,12 +386,12 @@
                <p> QVOS GENVI Q(VOCVMQVE) T(ORO) licet sint de incesto progeniti. </p>
             </div>
 
-            <div type="schol" n="79-80">
+            <div type="schol" n="79">
                <p> (ET VIDET ISTA DEORVM) / IGNAVVS G(ENITOR) uel cum sacrilegio optat audiri. Vt Vergilius:</p> 
                <l>'ferus omnia Iuppiter Argos'.</l>
             </div>
 
-            <div type="schol" n="80-81">
+            <div type="schol" n="80">
                <p> TV SALTEM D(EBITA) V(INDEX) / (HVC ADES) ut Vergilius:</p>
                <lg>
                   <l>'uos o mihi manes</l>
@@ -413,7 +414,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="82-83">
+            <div type="schol" n="82">
                <p> INDVE QVOD M(ADIDVM) T(ABO) (DIADEMA CRVENTIS / VNGVIBVS ABRIPVI) indue liberis meis diadema, quod ego Laio abripui cruore pollutum. </p>
             </div>
 
@@ -426,7 +427,7 @@
                <p> DISSILIANT multi 'dissiciant' legunt. Est autem sensus: aut ipsi filii germanitatem suam ferro dissipent aut ipsa germanitas ferro dissipetur. </p>
             </div>
 
-            <div type="schol" n="85-86">
+            <div type="schol" n="86">
                <p> (DA) TARTAREI REGINA BARATHRI / (QVOD CVPIAM VIDISSE NEFAS) <hi rend="italic">Tartarus</hi> est profunditas inferorum, <hi rend="italic">barathrum</hi> uero squaloris altitudo. Dicit autem hoc: fac ut tantum scelus filii audeant, quod optet etiam pater caecus uidere. </p>
             </div>
 
@@ -439,7 +440,7 @@
                <l>'amnemque seuerum'.</l>
             </div>
 
-            <div type="schol" n="89-90">
+            <div type="schol" n="89">
                <p> (SEVEROS) / ADVERTIT V(VLTVS) bene <hi rend="italic">uultus</hi>, non 'faciem' dixit. Vultus enim mutatur ex animi qualitate, facies semper est simplex. INAMOENVM a quibusdam tapinosis creditur, qui putant poetam 'squalidissimum' debuisse dicere. <hi rend="italic">Inamoenum</hi> ergo dixit, sine ulla amoenitate, et est una pars orationis. Vt Vergilius:</p> 
                <l>'tristisque palus inamabalis unda'.</l>
             </div>
@@ -457,12 +458,12 @@
                <p> TRISTIBVS (EXSILVIT RIPIS) bene ad nefas: tristibus locis exsiluit, quia habent etiam inferi<del>ora</del> loca amoena. </p>
             </div>
 
-            <div type="schol" n="93-94">
+            <div type="schol" n="94">
                <p> 
                   <del>DISCEDIT</del> INANE / V(VLGVS) umbrae quae solidis corporibus carent. </p>
             </div>
 
-            <div type="schol" n="95-96">
+            <div type="schol" n="95">
                <p> ET CALIGANTES A(NIMARVM) E(XAMINE) C(AMPOS) / (TAENARIAE LIMEN PETIT IRREMEABILE PORTAE) obscuros campos illa petit, in quibus est turba animarum. </p>
 
                <p>TAENARIAE L(IMEN) Malea promuntorium est Laconicae in cuius radicibus locum quendam profundum Taenarum uocant, in quo dicitur esse aditus inferorum. (LIMEN ...) IRREMEABILE eo quod ab inferis ad superos mortalium nullus remeat naturaliter. Vt Vergilius:</p>
@@ -494,7 +495,7 @@
                <l>'hic inter flumina nota'.</l>
             </div>
 
-            <div type="schol" n="101-102">
+            <div type="schol" n="102">
                <p> (NEQVE ENIM) VELOCIOR (VLLAS / ITQVE REDITQVE VIAS) ad assiduitatem rettulit ueniendi. Nam nouitas itineris moras solet afferre erroris. <supplied>COGNATAQVE TARTARA</supplied> ad crimen pertinet Thebanorum, quorum pro suis Furia finibus utebatur. COGNATAQVE T(ARTARA) M(AVVLT) 'neque' bis accipiendum. Hoc est: <hi rend="italic">neque uelocior ... neque mauult</hi>. Vt Vergilius:</p> 
                <l>'nec misero clipei mora profuit aeris',</l> 
                <p>id est <hi rend="italic">nec ... clipei ... nec aeris</hi>. MAVVLT nec magis uult habitare Tartara quam Thebas, postquam illic probauit parricidium et incestum libenter admissum. </p>
@@ -504,12 +505,12 @@
                <p> CENTVM pro innumerabilibus posuit. </p>
             </div>
 
-            <div type="schol" n="105-106">
+            <div type="schol" n="105">
                <p> (QVALIS PER NVBILA PHOEBES) / ATRACIA R(VBET) A(RTE) C(OLOR) hoc est: qualis color est lunae deficientis arte magica. <supplied>ATRACIA ... ARTE arte</supplied> Atracis, qui fuit Thessaliae <supplied>rex</supplied> et pater Hippodamiae, quam Pirithous duxit uxorem, qui primus artem magicam apud Thessaliam constituit. Ergo <hi rend="italic">Atracia <supplied>ars</supplied>
                   </hi> est magica scientia. </p>
             </div>
 
-            <div type="schol" n="108-109">
+            <div type="schol" n="108">
                <p> QVO LONGA S(ITIS) M(ORBIQVE) F(AMES)Q(VE) / (ET POPVLIS MORS VNA VENIT) quasi in pestilentia nulla sit mortis discretio. Vt Vergilius:</p>
                <lg>
                   <l>'nec singula morbi</l>
@@ -524,7 +525,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="109-110">
+            <div type="schol" n="109">
                <p> RIGET HORRIDA TERGO / P(ALLA) <hi rend="italic">riget</hi> dura est, <hi rend="italic">horrida</hi> sordida. Vt Vergilius:</p> 
                <l>'palla succincta cruenta'.</l>
                <p>
@@ -542,7 +543,7 @@
                <p> ATROPOS HOS A(TQVE) I(PSA) N(OVAT) P(ROSERPINA) C(VLTVS) ut ostenderet Furiarum ministerio et Fatorum decreta compleri et Proserpinae uoluntatem. NOVAT nouos retexendo facit. </p>
             </div>
 
-            <div type="schol" n="112-113">
+            <div type="schol" n="112">
                <p> TVM GEMINAS (QVATIT IRA MANVS) ut fratres utraque manu armaret. HAEC IGNE R(OGALI) / F(VLGVRAT) (HAEC VIVO MANVS AERA VERBERAT HYDRO) ut Vergilius:</p>
                <lg>
                   <l>'continuo sontes ultrix succincta f(lagello)</l>
@@ -566,7 +567,7 @@
                <l>'tot Erinys sibilat hydris'.</l>
             </div>
 
-            <div type="schol" n="116-117">
+            <div type="schol" n="116">
                <p> VNDE OMNIS A(CHAEI) / O(RA) M(ARIS) L(ATE) (PELOPEAQVE REGNA RESVLTANT) sicut Vergilius:</p>
                <lg>
                   <l>'Tartaream intendit uocem, q(ua) p(rotinus) o(mne)</l>
@@ -587,11 +588,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="118-119">
+            <div type="schol" n="119a">
                <p> ASPER / EVROTAS asper, quod bello acres procreet uiros, uel propter <foreign xml:lang="grc">μαστίγωσιν</foreign>, quibus uirtuti est in sacris caedi uerberibus sine corporis motu. <hi rend="italic">Eurotas</hi> autem fluuius est Lacedaemoniae. </p>
             </div>
 
-            <div type="schol" n="119-120">
+            <div type="schol" n="119b">
                <p> DVBIAMQVE I(VGO) (FRAGOR IMPVLIT OETEN / IN LATVS) <hi rend="italic">dubiam</hi> Oeten dixit, quia inter Thessaliam et Thraciam hic mons interiacet, ut, cuius esse uideatur, incertum sit. IMPVLIT hyperbole. Quasi casuram impulit ac dubiam fecit. </p>
             </div>
 
@@ -607,11 +608,11 @@
                </l> 
             </div>
 
-            <div type="schol" n="121-122">
+            <div type="schol" n="121">
                <p> IPSA S(VVM) G(ENETRIX) (CVRVO DELPHINE VAGANTEM / ABRIPVIT FRENIS GREMIOQVE PALAEMONA PRESSIT) Leucotheam dicit et bene ipsam elegit hoc loco ponere, quae iam malum didicerat Furiarum. <del>Et iucunde dictum <hi rend="italic">pressit</hi>.</del> et a Thebanis numinibus non recessit, quae ueluti praescia magis metuunt patriae quam Furiarum sonitus perhorrescunt. Et mire dicendo <hi rend="italic">pressit</hi> affectionem maternam explicuit. </p>
             </div>
 
-            <div type="schol" n="123-124">
+            <div type="schol" n="123">
                <p> (ATQVE EA CADMEO PRAECEPS VBI CVLMINE PRIMVM) / CONSTITIT ut Vergilius:</p>
                <lg>
                   <l>'hic primum paribus nitens C(yllenius) a(lis)</l>
@@ -629,7 +630,7 @@
                <p> GENTILISQVE <del>A(NIMOS) S(VBIIT)</del> F(VROR) id est quali furore illi fuerunt de terra progeniti, qui se ipsi interemerunt. Et est eiusdem familiae maximum signum, ut in <supplied>se</supplied> suorum furerent more maiorum. </p>
             </div>
 
-            <div type="schol" n="126-127">
+            <div type="schol" n="127">
                <p> (AEGRAQVE LAETIS) / INVIDIA subiit inuidia fratrum animos, quae semper laetis rebus infesta est. Vt Horatius:</p> 
                <l>'inuidus alterius <supplied>macrescit</supplied> rebus <supplied>opimis</supplied>'.</l> 
                <p>ATQVE PARENS O(DII) M(ETVS) quia de timore semper odium nascitur. Eos enim odio habemus quos timemus. Vt Vergilius:</p>
@@ -639,7 +640,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="127-128">
+            <div type="schol" n="128">
                <p> (REGENDI) / SAEVVS AMOR <supplied>
                      <hi rend="italic">saeuus</hi>
                   </supplied> fortissimus. Aut certe proprie dixit, quia reuera saeuum est imperare uelle germano. </p>
@@ -653,11 +654,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="138-139">
+            <div type="schol" n="138">
                <p> (ALTERNI PLACVIT SVB LEGIBVS ANNI) / EXILIO M(VTARE) D(VCEM) ut altero regnante alter esset extra urbem in exilio constitutus et completo anno rediret ad regnum, et cui successum fuerat, iret in exilium rediturus anno completo. </p>
             </div>
 
-            <div type="schol" n="139-140">
+            <div type="schol" n="139">
                <p> SIC I(VRE) M(ALIGNO) / F(ORTVNAM) T(RANSIRE) I(VBENT) iniqua commutatione felicitatem imperii exilii infelicitate commutant. </p>
             </div>
 
@@ -665,7 +666,7 @@
                <p> NEC IN REGEM P(ERDVRATVRA) S(ECVNDVM) licet iniqua esset ista diuisio, tamen ad secundum regem peruenire non potuit, quia expleto anno cum Polynices repeteret regnum, negante Eteocle mota sunt bella. </p>
             </div>
 
-            <div type="schol" n="144-146">
+            <div type="schol" n="144">
                <p> ET NONDVM C(RASSO) L(AQVEARIA) F(VLVA) M(ETALLO) / (MONTIBVS AVT ALTE GRAIIS EFFVLTA NITEBANT / ATRIA CONGESTOS SATIS EXPLICITVRA CLIENTES) haec cum stomacho pronuntianda. Lucanus:</p>
                <lg>
                   <l>'nec pretium tanti tellus p(ontusque) f(uroris)</l>
@@ -676,12 +677,12 @@
                <p>(NONDVM… / …/ ATRIA CONGESTOS SATIS) EXPLICITVRA (CLIENTES) large admissura, quae multos capere<supplied>n</supplied>t clientes et extendere<supplied>n</supplied>t, nondum erant.</p>
             </div>
 
-            <div type="schol" n="147-148">
+            <div type="schol" n="147">
                <p> NON IMPACATIS REGVM (ADVIGILANTIA SOMNIS / PILA) quibus susceptus dormiat imperator habens circa atria semper armatos. Et est sensus: non regum somnis impacatis pila uigilantia erant scilicet ad custodiam regum. <supplied>ADVIGILANTIA... / ... PILA</supplied> pro ipsis qui uigilant. Dixit <foreign xml:lang="grc">μετωνυμικῶς</foreign> 
                   <del>per id quod continet, id quod continetur</del>.</p>
             </div>
 
-            <div type="schol" n="149-150">
+            <div type="schol" n="149">
                <p> NEC CVRA M(ERO) C(OMMITTERE) G(EMMAS) / A(TQVE) A(VRVM) V(IOLARE) C(IBIS) nondum eis luxuria suaserat pocula habere gemmata, ut Vergilius:</p> 
                <l>'ut gemma bibat et Sarrano dormiat ostro'.</l> 
                <p>
@@ -691,30 +692,30 @@
                </p>
             </div>
 
-            <div type="schol" n="150-151">
+            <div type="schol" n="150">
                <p> (SED NVDA POTESTAS / ARMAVIT FRATRES PVGNA EST) DE PAVPERE R(EGNO) Eteocli et Polynici, qui ciuilia bella gesserunt, dicit non esse idoneum regnum, propter quod fratres odia suscitauerunt. Et exsequitur potentissima regna uaria descriptione. </p>
             </div>
 
-            <div type="schol" n="152-153">
+            <div type="schol" n="152">
                <p> DVMQVE VTER A(NGVSTAE) S(QVALENTIA) I(VGERA) D(IRCES) / V(ERTERET) Boeotiam dicit. <del>Ergo: <hi rend="italic">dum uter squalentia arua uerteret</hi> ....</del> SQVALENTIA inculta, ut Vergilius:</p> 
                <l>'squalent abductis arua colonis'.</l> 
                <p>VERTERET araret, ut Vergilius:</p> 
                <l>'et campum horrentem fractis i(nuertere) g(laebis)'.</l>
             </div>
 
-            <div type="schol" n="153-154">
+            <div type="schol" n="153">
                <p> (AVT TYRII SOLIO) NON ALTVS O(VARET) / (EXSVLIS AMBIGITVR) <hi rend="italic">altus</hi> magnus. Et est ordo: et dum ambigitur, uter fratrum ouaret in solio Tyrii exsulis hoc est Cadmi, qui a patre pulsus peracto exilio condidit Thebas. NON ALTVS quoniam modicum erat regnum. </p>
             </div>
 
-            <div type="schol" n="154-155">
+            <div type="schol" n="154">
                <p> PERIIT IVS F(AS)Q(VE) B(ONVM)Q(VE) / E(T) V(ITAE) M(ORTIS)Q(VE) P(VDOR) <hi rend="italic">ius</hi> legum est, quia unus foedus laesit; <hi rend="italic">fas</hi> hominum, quia fratres contra se arma sumpserunt; <hi rend="italic">bonum</hi>, quia usque ad interitum pugnauerunt; <hi rend="italic">et uitae m(ortis)q(ue) p(udor)</hi>, quod mutuis periere uulneribus et cremati sunt rogorum discrepantibus flammis. </p>
             </div>
 
-            <div type="schol" n="155-156">
+            <div type="schol" n="155">
                <p> QVO TENDITIS IRAS / (A MISERI) apostropha ad fratres. </p>
             </div>
 
-            <div type="schol" n="156-157">
+            <div type="schol" n="156">
                <p> QVID SI PETERETVR C(RIMINE) T(ANTO) / (LIMES VTERQVE POLI) dicit non oportuisse a fratribus arma sumi nec si ideo pugnaretur, ut unus orbis imperium possideret, uel si caeli possessio peteretur. CRIMINE non dicam 'bello'. Inter fratres enim uel leue odium crimen est. (LIMES) VTERQVE POLI utrumque complexus est mundi cardinem. Nam sol oriens occasum respicit, cum occidit prospectat orientem. Vt Lucanus:</p>
                <lg>
                   <l>'unde uenit Titan et nox u(bi) s(idera) c(ondit),</l>
@@ -723,15 +724,15 @@
                </lg>
             </div>
 
-            <div type="schol" n="159-160">
+            <div type="schol" n="159">
                <p> QVASQVE PROCVL T(ERRAS) O(BLIQVO) S(IDERE) T(ANGIT) / AVIVS utique sol <hi rend="italic">auius</hi> quasi sine uia, quia ab hac mundi parte semotus est. </p>
             </div>
 
-            <div type="schol" n="160-161">
+            <div type="schol" n="160">
                <p> AVT BOREA G(ELIDAS) M(ADIDI)V(E) T(EPENTES) I(GNE) N(OTI) <hi rend="italic">gelidas et tepentes</hi> septentrionalis et meridianae plagae partes ostendit. </p>
             </div>
 
-            <div type="schol" n="161-162">
+            <div type="schol" n="161">
                <p> NON SI TYRIAE PHRYGIAE(QVE SVB VNVM) / C(ONVECTENTVR) O(PES) non si unus possideat opes Phrygias et Tyrias. <hi rend="italic">Opes</hi> autem <hi rend="italic">Tyrias</hi> dixit, ut ostenderet Tyrios semper diuites fuisse, secutus Vergilium dicentem:</p>
                <lg>
                   <l>'portantur auari</l>
@@ -741,7 +742,7 @@
                <l>'aut pingues Phrygiae Mygdonias opes'.</l>
             </div>
 
-            <div type="schol" n="162-164">
+            <div type="schol" n="162">
                <p> LOCA DIRA ARCESQVE N(EFANDAE) / S(VFFECERE) O(DIO) F(VRIISQVE I(MMANIBVS) E(MPTVM) / (O)E(DIPODAE) S(EDISSE) L(OCO) declamatio, quae significat eas causas mouisse odia, quae restinguere debuissent. Fugere enim debuerant hi fratres loca dira et sceptra Oedipi parricidae potius quam ad haec bellorum crimina properarent. </p>
             </div>
 
@@ -753,12 +754,12 @@
                <p> ET NVSQVAM PAR STARE CAPVT id est tui consortem diadematis. </p>
             </div>
 
-            <div type="schol" n="168-169">
+            <div type="schol" n="169a">
                <p> 
                   <del>IAM MVRMVRA SERPVNT</del> / P(LEBIS) E(CHIONIAE) Thebani populi. Echionis enim et Agauae filius Pentheus rex Thebanorum fuit. </p>
             </div>
 
-            <div type="schol" n="169-170">
+            <div type="schol" n="169b">
                <p> TACITVMQVE A PRINCIPE VVLGVS / DISSIDET <hi rend="italic">tacitum</hi> id est tacite, siue <hi rend="italic">tacitum</hi> dixit timore perculsum. </p>
             </div>
 
@@ -766,30 +767,30 @@
                <p> ET QVI MOS POPVLIS VENTVRVS AMATVR hoc uult intellegi: non praesens diligitur Eteocles, sed desideratur futurus Polynices. </p>
             </div>
 
-            <div type="schol" n="171-173">
+            <div type="schol" n="171">
                <p> ATQVE ALIQVIS CVI MENS HVMILI L(AESISSE) V(ENENO) / S(VMMA) (NEC IMPOSITOS VMQVAM CERVICE VOLENTI / FERRE DVCES) utique unus ex plebe, cui erat mens laedendi summa. HVMILI...VENENO id est maledictionibus carpere meliores ut apud Homerum <supplied>
                      <gap/>
                   </supplied> dicit autem illum locutum, cui mos erat in dignitate regia posito<supplied>s</supplied> maleloquii ueneno perstringere et impositum iugum seruitutis indomita ceruice deicere. <del>Cui est uotum uel modice laedere id est inuidere potentibus</del>.</p>
             </div>
 
-            <div type="schol" n="173-174">
+            <div type="schol" n="173">
                <p> HANCNE OGYGIIS AIT A(SPERA) R(EBVS) / F(ATA) T(VLERE) V(ICEM) Ogyges, ut Varro docet in libris de gente populi Romani, rex fuit Thebanorum, sub quo primum diluuium factum est longe ante quam illud, quod sub Deucalione factum esse narratur. Aut certe ab Ogygio uno terrigena, Thebanorum primo rege, a quo Thebani antiquas res 'Ogygias' nominabant, qui<supplied>a</supplied> primus eis imperauit. </p>
             </div>
 
-            <div type="schol" n="174-175">
+            <div type="schol" n="174">
                <p> TOTIENS M(VTARE) T(IMENDOS) / (ALTERNOQVE IVGO DVBITANTIA SVBDERE COLLA) quia uicissim placuerat imperare. Illi, inquit, ut imperent uices mutant, nos seruitia non mutamus. </p>
             </div>
 
-            <div type="schol" n="176">
+            <div type="schol" n="176a">
                <p> 
                   <del>PARTITI</del> V(ERSANT) P(OPVLORVM) F(ATA) id est sub imperio et dicione habent. </p>
             </div>
 
-            <div type="schol" n="176-177">
+            <div type="schol" n="176b">
                <p> MANVQVE F(ORTVNAM) F(ECERE) L(EVEM) id est contemptibilem. <supplied>ut: </supplied> 'nam Fortuna solet reges facere et exsules'. Isti fecerunt ut circa <hi rend="italic">reges ... et exsules</hi> ea fortuna seruetur, ut ex illorum uoluntate constitutum sit quando debeant exilium petere, quando ad imperium remeare. Itaque in illis Fortuna, quae semper solet esse dubia, non habet potestatem, quippe cum de futuris certi sint. Et ipsi regunt fata populi, dum excluserunt fortunam. </p>
             </div>
 
-            <div type="schol" n="177-178">
+            <div type="schol" n="177">
                <p> SEMPERNE V(ICISSIM) / E(XSVLIBVS) S(ERVIRE) D(ABOR) quia semper dux erat mutandus exilio. Et licet sit grauis omnis seruitus, grauior tamen est quae subiacet indignis. VICISSIM rerum omnium mutabilitate aut uice seruiendi. Nam uere <hi rend="italic">uicem</hi> pro 'poena' posuit. </p>
             </div>
 
@@ -801,11 +802,11 @@
                <p> SEDIT placuit. </p>
             </div>
 
-            <div type="schol" n="181-183">
+            <div type="schol" n="181">
                <p> EX QVO SIDONII (NEQVIQVAM BLANDA IVVENCI / PONDERA CARPATHIO IVSSVS SALE QVAERERE CADMVS / EXSVL HYANTEOS INVENIT REGNA PER AGROS) non Sidonius iuuencus, sed Sidonium pondus. De Sidone enim fuit Europa, quam pater Agenor Cadmo inquirendam mandauit. Ille cum pererrasset mare <hi rend="italic">Carpathium</hi> id est Aegyptium — nam Carpathus insula est inter Aegyptum et Rhodon — cum nec sororem reperire potuisset, secundum praecepta patris in exilio remansit et duce Apolline peruenit ad Thebas Boeotiae, quas <hi rend="italic">Hyanteas</hi> uocant a Nympha quae illic colitur. </p>
             </div>
 
-            <div type="schol" n="&lt;184&gt;">
+            <div type="schol" n="184">
                <p> 
                   <supplied>FRATERNASQVE ACIES</supplied> ut Horatius:</p>
                <lg>
@@ -824,7 +825,7 @@
                <p> QVAS GERIT O(RE) M(INAS) aut ore loquitur cum superbia aut minas gerit in facie. </p>
             </div>
 
-            <div type="schol" n="&lt;189&gt;">
+            <div type="schol" n="189">
                <p> 
                   <supplied>HICNE VMQVAM PRIVATVS ERIT</supplied> ubique iam hoc queritur, quod nemo succedit, cum superius uices gemeret seruitutis. </p>
             </div>
@@ -837,12 +838,12 @@
                <p> QVID MIRVM N(ON) S(OLVS) E(RAT) ideo bonus, quia non erat solus. </p>
             </div>
 
-            <div type="schol" n="191-192">
+            <div type="schol" n="192a">
                <p> NOS VILIS I(N) O(MNES) / P(ROMPTA) M(ANVS) C(ASVS) ut Vergilius:</p> 
                <l>'nos animae uiles'.</l>
             </div>
 
-            <div type="schol" n="192">
+            <div type="schol" n="192b">
                <p> CVICVMQVE non lecto. </p>
             </div>
 
@@ -861,7 +862,7 @@
                </p>
             </div>
 
-            <div type="schol" n="197-198">
+            <div type="schol" n="197">
                <p> RAPIDI SVPER A(TRIA) C(AELI) / L(ECTVS) C(ONCILIO) D(IVVM) C(ONVENERAT) O(RDO) concilium deorum describit. <hi rend="italic">Rapidi</hi> autem caeli uolubilis, ut Vergilius:</p> 
                <l>'rapidiue potentia solis'.</l> 
                <p>ATRIA CAELI poetice, ut est:</p> 
@@ -881,11 +882,11 @@
                <p> PRIMAEQVE O(CCIDVAE)Q(VE) D(OMVS) orientis occasusque loca describit. </p>
             </div>
 
-            <div type="schol" n="200-201">
+            <div type="schol" n="201">
                <p> EFFVSA S(VB) O(MNI) / T(ERRA) A(TQVE) V(NDA) D(IE) <hi rend="italic">effusa</hi> patens. SVB OMNI ... DIE sub omni caelo. </p>
             </div>
 
-            <div type="schol" n="201-202">
+            <div type="schol" n="202">
                <p> MEDIIS SESE A(RDVVS) I(NFERT) / I(PSE) D(EIS) <supplied>
                      <hi rend="italic">ipse</hi>
                   </supplied> id est Iuppiter. <supplied>ARDVVS</supplied> ut Vergilius:</p>
@@ -894,12 +895,12 @@
                <l>'caelicolae medium quem ad limina ducunt'.</l>
             </div>
 
-            <div type="schol" n="203-205">
+            <div type="schol" n="203">
                <p> (NEC PROTINVS AVSI) / CAELICOLAE VENIAM D(ONEC) P(ATER) I(PSE) S(EDENDI) / (TRANQVILLA IVBET ESSE MANV) hoc est: donec Iuppiter protenta manu hortaretur. VENIAM ... SEDENDI id est beneficium. Vt Vergilius:</p> 
                <l>'orantes ueniam'.</l>
             </div>
 
-            <div type="schol" n="205-206">
+            <div type="schol" n="205">
                <p> (TVRBA VAGORVM) / SEMIDEVM qui in inferioribus zonis degunt, id est qui nec mortales nec superi sunt. ET SVMMIS C(OGNATI) N(VBIBVS) A(MNES) secundum Lucretium, qui dicit ex sudore terrae nebulas oriri, ex nebulis nubes, ex nubibus pluuias, e quibus amnes augentur. Hinc Vergilius:</p> 
                <l>'caelo gratissimus amnis'.</l> 
                <p>Dicit enim occulto tractu aquas in caelum reuerti et inde in nubibus imbrem esse. </p>
@@ -913,7 +914,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="209-210">
+            <div type="schol" n="209">
                <p> RADIANT M(AIORE) S(ERENO) / (CVLMINA) quasi serenitas caelo maior illuxerit. </p>
             </div>
 
@@ -925,29 +926,29 @@
                </lg>
             </div>
 
-            <div type="schol" n="214-215">
+            <div type="schol" n="214">
                <p> TERRARVM DELICTA N(EC) E(XSVPERABILE) D(IRIS) / I(NGENIVM) M(ORTALE) Q(VEROR) <supplied>
                      <hi rend="italic">delicta</hi>
                   </supplied> quae homines deliquerunt. DIRIS Furiis, unde et Furiae Dirae sunt appellatae. Queritur ergo Iuppiter de hominum peccatis, quos dicit superasse se malis. Nam fortiores illos dicit esse ad committenda peccata quam se ad uindicandum, et commemorat, quae mala commiserint. </p>
             </div>
 
-            <div type="schol" n="215-216">
+            <div type="schol" n="215">
                <p> QVONAM VSQVE N(OCENTVM) / E(XIGAR) I(N) P(OENAS) hoc est: quousque cogor laborare, dum suppliciis criminosos afficio. </p>
             </div>
 
-            <div type="schol" n="216-218">
+            <div type="schol" n="216">
                <p> (TAEDET SAEVIRE CORVSCO / FVLMINE) IAM PRIDEM C(YCLOPVM) O(PEROSA) F(ATISCVNT) / B(RACCHIA) (ET AEOLIIS DESVNT INCVDIBVS IGNES) hyperbole. Dixerat uti fulminibus non libere. Addidit augmentum, ut dicat deesse fulmina. Cyclopes enim fatigati sunt suggerendo fulmina. Ergo hoc <hi rend="italic">taedet</hi> et quod intulit <hi rend="italic">desunt. Fatiscunt</hi> autem lassata sunt. ET AEOLIIS DESVNT I(NCVDIBVS) I(GNES) ad fulmina fabricanda negat ignem posse sufficere. </p>
             </div>
 
-            <div type="schol" n="219-222">
+            <div type="schol" n="219">
                <p> ATQVE A(DEO) T(VLERAM) F(ALSO) R(ECTORE) S(OLVTOS) / S(OLIS) E(QVOS) (CAELVMQVE ROTIS ERRANTIBVS VRI / ET PHAETHONTEA MVNDVM SQVALERE FAVILLA / NIL ACTVM) deest 'patienter': <supplied>ADEO</supplied> ut mundum Phaethon incendio concremaret. SOLVTOS SOLIS EQVOS non sine frenis, sed, quia regi non poterant, licenter errantes. ROTIS ERRANTIBVS quasi a legitimo cursu deuiantibus. ET PHAETHONTEA M(VNDVM) S(QVALERE) F(AVILLA) Phaethon, Solis et Clymenae filius, patrem currus petiuit. Quos cum regere non potuisset, fulmine est praecipitatus in Padum. Dicit ergo Iuppiter nil illud incendium profuisse, quo humanum genus emendari non potuit. </p>
             </div>
 
-            <div type="schol" n="222-223">
+            <div type="schol" n="222">
                <p> NIL ACTVM NEQVE T(V) V(ALIDA) Q(VOD) C(VSPIDE) L(ATE / I(RE) P(ER) I(LLICITVM) P(ELAGO) G(ERMANE) D(EDISTI) id est: nec illud profuit ad emendationem humani generis, quod diluuium factum est. Neptunus enim impulsu cuspidis coegit excedere fluctus litorum legem et uniuersas terras obruere. Dicit ergo Iuppiter nihil emendationi humani generis <supplied>profuisse</supplied> supplicia, cum nihilominus peccare non desinant. </p>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224">
                <p> 
                   <del>NVNC</del> G(EMINAS) <del>P(VNIRE)</del> D(OMOS) (QVIS SANGVINIS AVCTOR / IPSE EGO) duas familias significat Thebanorum et Argiuorum, quorum se originem dixit existere, id est Argiuorum a Perseo — Perseus autem Iouis et Danaae filius fuit — Thebanorum per Cadmum, qui ab Epapho ex Iouis origine uenit. Constat ergo utrique genti Iouem esse auctorem. </p>
             </div>
@@ -965,7 +966,7 @@
                <p> ERRORESQVE F(EROS) N(EMORVM) Athamantis scilicet, qui furiata mente cum Learchum filium iugularet, leonem se putauit occidere. </p>
             </div>
 
-            <div type="schol" n="230-231">
+            <div type="schol" n="230">
                <p> ET RETICENDA D(EORVM) / C(RIMINA) et hoc <foreign xml:lang="grc">ἀμφίβολον</foreign>: aut quae homines in deos commiserunt aut quae dii irrogauere mortalibus. Si hominum in deos, haec sunt: Niobe Latonae, Pentheus Libero, Semele Iunoni; uel propter Tantalum, qui uolens deorum mentes inquirere Pelopem filium suum diis posuit epulandum. Quae a Pentheo inlata sunt in Liberum, Ouidius refert <supplied>
                      <gap/>
                   </supplied> haec enim deorum crimina. </p>
@@ -984,11 +985,11 @@
                <p> PROPRIOS MONSTRO R(EVOLVTVS) I(N) O(RTVS) nomine usus est pro aduerbio, id est: <hi rend="italic">monstro</hi> pro 'monstrose'. <supplied>REVOLVTVS IN ORTVS</supplied> quia reuocauit semina in ortus suos. </p>
             </div>
 
-            <div type="schol" n="237">
+            <div type="schol" n="237a">
                <p> PROIECITQVE DIEM induxit sibi caecitatem, ut cito uindicta sequeretur. </p>
             </div>
 
-            <div type="schol" n="237-238">
+            <div type="schol" n="237b">
                <p> AETHERE NOSTRO / (VESCITVR) id est luce quam nos largimur. Vt est:</p>
                <lg>
                   <l>'uescitur aura</l>
@@ -1004,7 +1005,7 @@
                <p> CALCAVERE OCVLOS insultauere caecitati patris. </p>
             </div>
 
-            <div type="schol" n="239-240">
+            <div type="schol" n="240">
                <p> IAM IAM RATA V(OTA) T(VLISTI) / (DIRE SENEX) apostropha ad ipsum Oedipum. <unclear>RATA sensu uocis regentem.</unclear>
                </p>
             </div>
@@ -1013,11 +1014,11 @@
                <p> ADRASTVS SOCER qui pro genero Polynice pugnauit. Atqui adhuc non erat socer, sed quia deus est, futura praedicit. </p>
             </div>
 
-            <div type="schol" n="244-245">
+            <div type="schol" n="245">
                <p> (SVPERIS) ADIVNCTA SINISTRIS / (CONVBIA) <hi rend="italic">adiuncta</hi> pro 'adiungenda'. Nondum enim adiuncta erant. SINISTRIS infensis numinibus et contrariis, quia morituri sunt. </p>
             </div>
 
-            <div type="schol" n="246-247">
+            <div type="schol" n="246">
                <p> NEQVE ENIM ARCANO D(E) P(ECTORA) F(ALLAX) / T(ANTALVS) (ET SAEVAE PERIIT INIVRIA MENSAE) reddit causas, cur etiam Argiuos uelit euertere: scilicet propter Tantali scelus, qui decipere se credidit deos quando epulandum his apposuit filium, uel quod epulando cum diis secreta eorum mortalibus prodidit. Ob quod facinus dignas apud inferos poenas soluit. <del>
                      <hi rend="italic">Fallax</hi> autem quia deorum prodebat consilia.</del>
                </p>
@@ -1033,12 +1034,12 @@
                   </supplied> quod Thebarum gaudebat exitio de suis urbibus iam secura. </p>
             </div>
 
-            <div type="schol" n="250-251">
+            <div type="schol" n="250">
                <p> MENE O IVSTISSIME DIVVM / (ME BELLO CERTARE IVBES) inuidiose se pro Argis dixit. Vt Vergilius:</p> 
                <l>'nos, tua progenies'.</l>
             </div>
 
-            <div type="schol" n="251-253">
+            <div type="schol" n="251">
                <p> SCIS SEMPER VT ARCES / CYCLOPVM (MAGNIQVE PHORONEOS INCLVTA FAMA / SCEPTRA VIRIS OPIBVSQVE IVVEM) quia semper Iuno fauit Argiuis, ut Vergilius:</p> 
                <l>'prima quod ad Troiam p(ro) c(aris) g(esserat) A(rgis)'.</l> 
                <p>
@@ -1049,7 +1050,7 @@
                <p> MAGNIQVE PHORONEOS <del>I(NCLVTA F(AMA)</del> rex Argiuorum, qui primus dicitur Iunoni templa dicasse et sacrificiorum instituisse sollemnia. </p>
             </div>
 
-            <div type="schol" n="253-255">
+            <div type="schol" n="253">
                <p> (LICET IMPROBVS ILLIC) / CVSTODEM PHARIAE S(OMNO) L(ETOQVE) I(VVENCAE) / (EXSTINGVAS) Argum <del>ergo</del> describit, quem Mercurius dicitur occidisse. <supplied>SOMNO LETOQVE</supplied> bene prius <hi rend="italic">somno</hi>. Nam hic, qui centum habebat oculos, nisi somno oppressus non poterat occidi. </p>
             </div>
 
@@ -1070,11 +1071,11 @@
                   </supplied> sed Iuppiter conuersus in aurum uitiauit Danaen. Ex quo coitu Perseus natus dicitur, qui Acrisium obiecto Gorgonis capite conuertit in saxum. </p>
             </div>
 
-            <div type="schol" n="256-257">
+            <div type="schol" n="256">
                <p> MENTITIS IGNOSCO TORIS (ILLAM ODIMVS VRBEM / QVAM VVLTV CONFESSVS ADIS) id est: non irascor illi ciuitati ubi mutatus adulteria commisisti. Cum aliis enim maiestate dissimulata concumbis, ad Semelen uero professus numen intrasti. </p>
             </div>
 
-            <div type="schol" n="257-258">
+            <div type="schol" n="257">
                <p> VBI CONSCIA MAGNI / SIGNA TORI T(ONITRVS) A(GIS) hoc est: quibus mecum coire consuesti. <hi rend="italic">Tonitrus</hi> genere masculino protulit. </p>
             </div>
 
@@ -1089,7 +1090,7 @@
                <l>'quin age et ipsa manu felices erue siluas'.</l>
             </div>
 
-            <div type="schol" n="261-262">
+            <div type="schol" n="261">
                <p> ET SAMON ET VETERES ARMIS E(XSCINDE) M(YCENAS) / V(ERTE) S(OLO) S(PARTEN) Samos et Mycenae atque Sparta, Graeciae ciuitates, Iunoni sacratae sunt. Samos etiam cara Iunoni; haec enim prima Iunonis nuptias uidisse dicitur. Ideo cara insula attestante Vergilio:</p> 
                <l>'posthabita coluisse Samo'.</l> 
                <p>Spartam uero dixit ciuitatem Laconicae regionis. </p>
@@ -1119,11 +1120,11 @@
                <p> FVRIAS pro criminibus posuit et peccatis ut illud: 'furias Aiacis O(ilei)'. </p>
             </div>
 
-            <div type="schol" n="274-275">
+            <div type="schol" n="274">
                <p> ILLIC MAVORTIVS AXIS / OENOMAI Elidem dicit et Pisas, ubi Oenomaus regnauit, rex crudelissimus. </p>
             </div>
 
-            <div type="schol" n="275-276">
+            <div type="schol" n="275">
                <p> GETICOQVE PECVS STABVLARE SVB HAEMO / DIGNIVS id est: equi digni erant stabulari in Scythia, ubi equi Diomedis erant, qui humana carne pascebantur. </p>
             </div>
 
@@ -1132,7 +1133,7 @@
                   <del>MELIVS</del> GENEROS <del>PASSVRA</del> NOCENTES Polynicen per patris incestum et Tydeum, qui fratrem suum Toxeum occiderat. </p>
             </div>
 
-            <div type="schol" n="288-289">
+            <div type="schol" n="288">
                <p> (MVLTA SVPER THEBIS ...) AVSVRAM<del>QVE</del> DIONEN / (DICERE) Veneris matrem dicit sollicitam futuram propter Harmoniam, Veneris et Martis filiam, Cadmi uxorem. </p>
             </div>
 
@@ -1140,11 +1141,11 @@
                <p> REGNIS<del>QVE ILLAPSVS</del> OPACIS umbrosis, sine sole. </p>
             </div>
 
-            <div type="schol" n="296-298">
+            <div type="schol" n="296">
                <p> (QVEM ... NONDVM / VLTERIOR LETHES ACCEPIT RIPA PROFVNDI) / LEGE EREBI quia dicuntur inhumatorum animae multis errare temporibus. </p>
             </div>
 
-            <div type="schol" n="299-300">
+            <div type="schol" n="299">
                <p> (ARGOLICISQVE) TVMENTEM / (HOSPITIIS) iactantem se exilio propter cognationem Adrasti. Et hoc quasi deus ad eum dicit, nam futura sunt haec. </p>
             </div>
 
@@ -1160,7 +1161,7 @@
                <l>'tum uirgam capit'.</l>
             </div>
 
-            <div type="schol" n="306-307">
+            <div type="schol" n="307">
                <p> QVA PELLERE DVLCES / A(VT) S(VADERE) I(TERVM) SOMNOS mortis somnos dulces dixit, nam in uita dulces non sunt. Vt Cicero: 'hoc iter uitae tam confragosum putamus, <del>ui</del>tam plenum iniuriarum ac miseriarum atque laborum' et Vergilius:</p> 
                <l>'quae lucis miseris tam dira cupido?'.</l>
             </div>
@@ -1189,11 +1190,11 @@
                <p> FVRTO clam. Exsulem enim nisi furtim non licebat eos fines attingere, quibus fuerat expulsus. </p>
             </div>
 
-            <div type="schol" n="314">
+            <div type="schol" n="314a">
                <p> AONIAE Thebanae regionis. </p>
             </div>
 
-            <div type="schol" n="314-315">
+            <div type="schol" n="314b">
                <p> (ANIMIS) MALE DEBITA REGNA / (CONCIPIT) non 'indebita' sed <hi rend="italic">male debita</hi>, ut 'male sana', dixit, quae esset proeliorum incommodis petiturus. Aut certe male concipit animo regna sibi debita, quae sciebat germanum nunquam redditurum sponte. </p>
             </div>
 
@@ -1201,13 +1202,13 @@
                <p> SIGNIS CVNCTANTIBVS tarde procedentibus. Ad desiderium rettulit spem gerentis. </p>
             </div>
 
-            <div type="schol" n="316-317">
+            <div type="schol" n="316">
                <p> (TENET VNA DIES NOCTESQVE RECVRSANS) / CVRA VIRVM <supplied>
                      <hi rend="italic">recursans</hi>
                   </supplied> ad cogitationem eius rettulit, non ad diem. </p>
             </div>
 
-            <div type="schol" n="&lt;317-319&gt;">
+            <div type="schol" n="317">
                <p> 
                   <supplied>SI QVANDO HVMILEM DECEDERE REGNO / GERMANVM ET SEMET THEBIS OPIBVSQVE POTITVM / CERNERET</supplied> id est: si regni cupiditas ad finem <supplied>
                      <gap/>
@@ -1220,11 +1221,11 @@
                <l>'uitamque uolunt pro laude pacisci'.</l>
             </div>
 
-            <div type="schol" n="320-321">
+            <div type="schol" n="320">
                <p> NVNC QVERITVR CEV TARDA FVGAE D(ISPENDIA) (SED MOX / ATTOLIT FLATVS DVCIS) descriptio hominis anxii: nunc superbiam secum regnantis reputat fratris, modo uotis erigitur in regio spiritu. </p>
             </div>
 
-            <div type="schol" n="321-322">
+            <div type="schol" n="321">
                <p> SEDISSE SVPERBVS / (DEIECTO IAM FRATRE PVTAT) sibi effectum uoti frustra gaudebat. </p>
             </div>
 
@@ -1254,7 +1255,7 @@
                <p> FERRE ITER IMPAVIDVM non iter <supplied>impauidum</supplied> sed ipse impauidus. </p>
             </div>
 
-            <div type="schol" n="326-328">
+            <div type="schol" n="327">
                <p> (SEV PRAEVIA DVCIT ERINYS) SEV FORS ILLA VIAE / SIVE HAC IMMOTA VOCABAT / ATROPOS hoc est: illud iter aut furor suasit aut casus aut fatum. PRAEVIA dux uiae. <hi rend="italic">Praeuii</hi> enim dicuntur duces uiarum. </p>
             </div>
 
@@ -1269,14 +1270,14 @@
                <l>'orgia nocturnusque u(ocat) c(lamore) C(ithaeron)'.</l>
             </div>
 
-            <div type="schol" n="330-332">
+            <div type="schol" n="330">
                <p> 
                   <del>INDE</del> PLAGAM (... /... / PRAETERIT) <supplied>
                      <hi rend="italic">plagam</hi>
                   </supplied> id est regionem. Descriptio itineris illius. QVA MOLLE SEDENS (IN PLANA) id est: qua paulatim tumores collium in planum relaxans. MOLLE pro 'molliter'. </p>
             </div>
 
-            <div type="schol" n="&lt;331&gt;">
+            <div type="schol" n="331">
                <p> 
                   <supplied>PORRIGITVR</supplied> ubi in campum effunditur nimis extensum. LASSVM(QVE INCLINAT AD AEQVORA MONTEM) utique fluctibus caesum, uel quia in hanc partem deuexus uires amiserit in excelsa crescendo. </p>
             </div>
@@ -1308,7 +1309,7 @@
                <p>id est inter Ionium et Aegaeum describit Corinthum positam ciuitatem. </p>
             </div>
 
-            <div type="schol" n="336-337">
+            <div type="schol" n="336">
                <p> IAMQVE PER EMERITI SVRGENS CONFINIA PHOEBI / (TITANIS) a re militari, quasi et sol die<del>i</del> militare uideatur. EMERITI occidentis. <hi rend="italic">Confinia (Phoebi)</hi> bene dixit, quia iuxta ipsum oritur. Quomodo <hi rend="italic">emeritos</hi> dicimus <unclear>simili labore donatos</unclear>, sic et <hi rend="italic">emeritus</hi> sol occidens dicitur post laborem, cui noctis astra succedunt, ut Vergilius:</p> 
                <l>'emeritaeque exspectant praemia palmae'.</l>
             </div>
@@ -1345,7 +1346,7 @@
                <p> LABORATAE ... VITAE per laborem peractae. </p>
             </div>
 
-            <div type="schol" n="342-343">
+            <div type="schol" n="342">
                <p> SED NEC PVNICEO R(EDITVRVM) N(VBILA) C(AELO) / (PROMISERE IVBAR) hoc uult poeta monstrare: serenum diem non contigisse Polynici. Nec enim ulla serenitatis signa promiserat solis occasus. <hi rend="italic">Puniceo</hi> ergo 'sereno' dixit. Vt Vergilius:</p> 
                <l>'caeruleus pluuiam denuntiat, igneus Euros'.</l>
             </div>
@@ -1358,7 +1359,7 @@
                <p> DENSIOR A TERRIS densiorem noctem nebulam dicit, quod quando ima petunt nebulae, <del>serenitas est, quando altum,</del> sine dubio imbres futuros ostendunt. ET NVLLI PERVIA FLAMMAE quam neque solis neque aurorae ualeat flamma penetrare. </p>
             </div>
 
-            <div type="schol" n="346-347">
+            <div type="schol" n="346">
                <p> 
                   <del>IAM CLAVSTRA</del> RIGENTIS / (AEOLIAE) frigidae, quia prope est ubi habitant uenti. </p>
             </div>
@@ -1372,13 +1373,13 @@
                   <del>DVM</del> CAELVM pro nubibus posuit. </p>
             </div>
 
-            <div type="schol" n="352-353">
+            <div type="schol" n="352">
                <p> SICCO QVOS ASPER HIATV / P(RAESOLIDAT) B(OREAS) physicam rationem secutus est. Nam si primo Auster pluuias faciat, mox sequitur Boreas et easdem aut in niuem aut in grandinem mutat. Inde Ouidius:</p> 
                <l>'utque ferunt imbres gelidis concrescere uentis'</l> 
                <p>id est gelari.</p>
             </div>
 
-            <div type="schol" n="353-354">
+            <div type="schol" n="353">
                <p> NEC NON ABRVPTA TREMESCVNT / FVLGVRA coruscationes enim quasi ruptis nubibus tremunt. <hi rend="italic">Fulgura</hi> a fulgore dicta sunt. </p>
             </div>
 
@@ -1393,11 +1394,11 @@
                <p>Notandum autem, quod nomen 'a' littera terminatum longum est. Latinitas hoc non habet, sed ideo, quoniam Graecum est nomen, in eo melius Graeca ratio considerabitur. </p>
             </div>
 
-            <div type="schol" n="355-356">
+            <div type="schol" n="356a">
                <p> CONTERMINA LVCIS / (... CAPITA) confinia atque uicina his lucis montium Argiuorum. </p>
             </div>
 
-            <div type="schol" n="356">
+            <div type="schol" n="356b">
                <p> ARCADIAE CAPITA ALTA MADENT quinque montium cacumina Arcadiae regionis ostendit id est Cyllenii, Lycaei, <unclear>Licorionis, Agolionis</unclear> , Maenali, RVIT festinat impetu exire. Vt Vergilius:</p> 
                <l>'qua data porta, ruunt'.</l> 
                <p>AGMINE multitudine aquarum. Vt Vergilius:</p> 
@@ -1408,7 +1409,7 @@
                <p> INACHVS fluuius regionis Argiuae. ERASINVS fluuius. <supplied>AD ARCTOS</supplied> in septentrione<supplied>m</supplied>.</p>
             </div>
 
-            <div type="schol" n="358-359">
+            <div type="schol" n="358">
                <p> CALCANDAQVE FLVMINA (NVLLAE / AGGERIBVS TENVERE MORAE) si his fluminibus, quae ante aquae penuria calcabantur hoc est pedibus transiri poterant, riparum aggestiones opponeres, quo minus effunderentur, nullam faceres moram. </p>
             </div>
 
@@ -1421,12 +1422,12 @@
                <p> (VETERI SPVMAVIT) LERNA (VENENO) lacus est apud Argos, in quo Hydram superasse Hercules dicitur. Ait ergo in hoc stagno tantam uim undarum fuisse ut iterum ueneno scatere uideretur. Notandum autem quod <hi rend="italic">ueteri</hi> dixit, cum omne nomen generis neutri quod in '-us' exit numquam nisi 'e' littera terminetur, ut 'pecus pecore', 'nemus nemore'. </p>
             </div>
 
-            <div type="schol" n="362">
+            <div type="schol" n="362a">
                <p> BRACCHIA SILVARVM ramos arborum dixit. Vt Vergilius:</p> 
                <l>'in medio ramos annosaque bracchia pandens'. </l>
             </div>
 
-            <div type="schol" n="362-363">
+            <div type="schol" n="362b">
                <p> NVLLISQVE ASPECTA PER AEVVM / SOLIBVS hoc est: inuisa soli multis temporibus. Vt est: 'solis inaspectam radiis'. </p>
             </div>
 
@@ -1443,7 +1444,7 @@
                <l>'et summis cognati nubibus amnes'. </l>
             </div>
 
-            <div type="schol" n="366">
+            <div type="schol" n="366a">
                <p> AVRE PAVENS auditu timens. Vt Vergilius:</p>
                <lg>
                   <l>'sonus excitat omnis</l>
@@ -1451,7 +1452,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;366-367&gt;">
+            <div type="schol" n="366b">
                <p> 
                   <supplied>RAPTAS / PASTORVM PECORVMQVE DOMOS</supplied> ut Vergilius:</p> 
                <l>'cum stabulis a(rmenta) t(ulit).'</l>
@@ -1491,7 +1492,7 @@
                <p> TALIS OPACA (LEGENS NEMORVM) id est qualis nauta timens, tamen sine ulla segnitie uir fortis ingressum iter emetiebatur. </p>
             </div>
 
-            <div type="schol" n="377-379">
+            <div type="schol" n="377">
                <p> VASTO METVENDA VMBONE (FERARVM / EXCVTIENS STABVLA ET PRONO VIRGVLTA REFRINGIT / PECTORE) <supplied>
                      <hi rend="italic">umbone</hi>
                   </supplied> pro clipeo, a parte totum. FERARVM EXCVTIENS STABVLA id est siluas. Nunc clipeo ferarum lustra discutit, nunc pectoris impulsu. </p>
@@ -1501,7 +1502,7 @@
                <p> DAT STIMVLOS ANTIMO V(IS) M(AESTA) T(IMORIS) id est: nimium timendo non timet. Sic enim tunc time<del>n</del>t, dum non time<del>n</del>t. Vt Cicero: 'non timere sine aliquo timore possumus'. VIS (MAESTA) TIMORIS tristitia est. </p>
             </div>
 
-            <div type="schol" n="380-382">
+            <div type="schol" n="380">
                <p> DONEC AB INACHIIS (VICTA CALIGINE TECTIS / EMICVIT LVCEM DEVEXA IN MOENIA FVNDENS / LARISSAEVS APEX) <supplied>
                      <hi rend="italic">Inachiis</hi>
                   </supplied> Argiuis, ab Inacho fluuio. Dicit tam diu errasse Polynicen, quam diu de <hi rend="italic">Inachiis tectis</hi> id est de Argiua ciuitate uictis tenebris lux emicuisset. <del>De ciuitatis arce, quae Larissa nominatur</del> non nos autem debet confundere, quod et Thessaliae ciuitas Larissa dicitur. Haec enim, quam nunc commemorat, arx est ciuitatis Argiuae. <del>Quae Larissa dicitur</del> (EMICVIT LVCEM) DEVEXA IN MOENIA FVNDENS quasi imaginem lucis accipere debeas. Vt Vergilius:</p> 
@@ -1510,7 +1511,7 @@
                </p>
             </div>
 
-            <div type="schol" n="382-383">
+            <div type="schol" n="382">
                <p> ILLO SPE CONCITVS O(MNI) / E(VOLAT) id est ad illam partem, unde, posteaquam lumen emicuisse uidit, desiit timere. </p>
             </div>
 
@@ -1518,11 +1519,11 @@
                <p> IVNONIA TEMPLA P(ROSYMNAE) Prosymna ciuitas est, ubi colitur Iuno. </p>
             </div>
 
-            <div type="schol" n="384">
+            <div type="schol" n="384a">
                <p> LAEVVS HABENS sinistro latere praeteriens. </p>
             </div>
 
-            <div type="schol" n="384-385">
+            <div type="schol" n="384b">
                <p> HINC HERCVLEO SIGNATA VAPORE / L(ERNAEI) S(TAGNA) (ATRA VADI) <supplied>
                      <hi rend="italic">hinc</hi>
                   </supplied> ad dextrum latus Lernae stagna. HERCVLEO VAPORE SIGNATA <supplied>
@@ -1531,7 +1532,7 @@
                   <foreign xml:lang="grc">ἀπὸ τῶν ὑδάτων</foreign> nomen obtinuit. </p>
             </div>
 
-            <div type="schol" n="385-386">
+            <div type="schol" n="385">
                <p> TANDEMQVE R(ECLVSIS) / I(NFERTVR) P(ORTIS) signum est pacificae ciuitatis. </p>
             </div>
 
@@ -1583,12 +1584,12 @@
                <p>Hoc est: responsi quidem nesciebat euentum, cura autem torquebatur ancipiti. </p>
             </div>
 
-            <div type="schol" n="401-402">
+            <div type="schol" n="401">
                <p> ECCE AVTEM ANTIQVAM FATO CALYDONA RELINQVENS / (OLENIVS TYDEVS) Calydon <del>Pleuron</del> et Olenos ciuitates sunt Aetoliae, unde fuit Tydeus. Atque ideo modo Olenium dicit, modo Calydonium. <del>Modo Pleuronium</del>. Hic autem Tydeus fratrem suum Toxeum interemit. Moris autem fuit antiqui, sicut etiam Homerus dicit, ut reus homicidii exsularet. Ergo Tydeus conscius parricidii dimisit paternum regnum et casu eadem nocte iisdem confectus imbribus, quibus Polynices, Argos uenit. Calydona<del>m</del> uero urbem esse Aetoliae Vergilius loquitur dicendo:</p> 
                <l>'quod scelus aut Lapithis tantum aut Calydona merentem'. </l>
             </div>
 
-            <div type="schol" n="402-403">
+            <div type="schol" n="402">
                <p> FRATERNI SANGVINIS (.../CONSCIVS HORROR) quia occiderat auunculum suum Thoan<supplied>tem</supplied>, Althaeae matris fratrem, uel, ut quidam uolunt, Apharea. <del>Manifestius tamen est, quod Melanippum fratrem suum, dum uenatur, occidit.</del>
                </p>
             </div>
@@ -1613,7 +1614,7 @@
                <p> RABIEM litem. </p>
             </div>
 
-            <div type="schol" n="409-410">
+            <div type="schol" n="409">
                <p> (HAVD PASSI SOCIIS) DEFENDERE NOCTEM / (CVLMINIBVS) prohibere iniuriam tempestatis non passi sunt. Vt Vergilius:</p> 
                <l>'hunc, oro, defende furorem'</l> 
                <p>id est prohibe. </p>
@@ -1649,7 +1650,7 @@
                <p>Viribus ergo compensauit, quod proceritatem natura non cessit, ut paruo corpori ingens robur infunderet. </p>
             </div>
 
-            <div type="schol" n="419-420">
+            <div type="schol" n="419">
                <p> TELORVM AVT GRANDINIS INSTAR / R(IPHAEAE) telorum propterea, quod uulnera infligebant, <hi rend="italic">grandinis</hi>, quod assidue. RIPHAEAE id est Scythicae. Riphaeus mons Scythiae, in quo semper nimiae tempestates sunt. Vt Vergilius:</p> 
                <l>'Riphaeo tunditur Euro'. </l>
             </div>
@@ -1658,7 +1659,7 @@
                <p> FLEXOQVE GENV duplicato, quod Graeci <foreign xml:lang="grc">διπλοῖς γόνασιν</foreign> uocant. </p>
             </div>
 
-            <div type="schol" n="421-422">
+            <div type="schol" n="421">
                <p> NON ALITER QVAM PISAEO S(VA) L(VSTRA) T(ONANTI) / (CVM REDEVNT) Pisae ciuitas Elidis, ubi Olympica corona est, hoc est: ubi agon in honorem Olympici Iouis celebratur finito quinquennio. </p>
             </div>
 
@@ -1666,7 +1667,7 @@
                <p> CRVDIS … SVDORIBVS duris aut magnis siue uehementibus. </p>
             </div>
 
-            <div type="schol" n="423-424">
+            <div type="schol" n="423">
                <p> TENEROS (CAVEAE DISSENSVS) EPHEBOS / (CONCITAT) <supplied>
                      <hi rend="italic">teneros</hi>
                   </supplied> imprudentes. <del>CAVEAE DISSENSVS</del> id est: fauor populi dissidentis instigat ephebos. Et expressit fauentum studia. </p>
@@ -1676,7 +1677,7 @@
                <p> EXCLVSAEQVE EXPECTANT PRAEMIA MATRES sacrorum lege prohibitum est Olympicum certamen spectare mulieres. </p>
             </div>
 
-            <div type="schol" n="425-426">
+            <div type="schol" n="425">
                <p> (ALACRES ODIO) NVLLAQVE CVPIDINE LAVDIS / (ACCENSI INCVRRVNT) non pecunia aut praemii nimietate certabant, nec laudis auidi; solius erat uirtutis contentio. </p>
             </div>
 
@@ -1689,7 +1690,7 @@
                <p> IVVENIS THEBANE apostropha ad Polynicen. </p>
             </div>
 
-            <div type="schol" n="433-434">
+            <div type="schol" n="433">
                <p> MAGNIS CVI SOBRIA CVRIS / (P(ENDEBAT) S(OMNO) I(AM) D(ETERIORE) S(ENECTVS) <hi rend="italic">pendebat</hi> sollicita erat. Vt Vergilius:</p> 
                <l>'suspensi poenam exspectant'.</l> 
                <p>SOMNO IAM DETERIORE quia <supplied>in</supplied> ingenti cura minor est somnus. <supplied>SENECTVS</supplied> deficiente calore sanguinis minimum quietis senectus capit. Ordo: cui magnis curis pendebat <supplied>sobria</supplied> senectus. </p>
@@ -1699,7 +1700,7 @@
                <p> NVMEROSA LVCE cum multis lampadibus. </p>
             </div>
 
-            <div type="schol" n="439-440">
+            <div type="schol" n="439">
                <p> EXTERNI IVVENES (NEQVE ENIM MEVS AVDEAT ISTAS / CIVIS IN VSQVE MANVS) <supplied>
                      <hi rend="italic">iuuenes</hi>
                   </supplied> alterius generis. <supplied>EXTERNI</supplied> ut Vergilius:</p>
@@ -1710,7 +1711,7 @@
                <p>Talis est ergo sensus: externi estis, o iuuenes, nam ciuis meus nunquam usque adeo litis suae audet finem extendere ut transferat in manus furorem. Aut certe illud uult magis intellegi: tantam ciuium suorum metu regis esse formidinem ut nullus audeat manu litem conserere. </p>
             </div>
 
-            <div type="schol" n="442-443">
+            <div type="schol" n="442">
                <p> (VSQVE ADEONE) ANGVSTA DIES (ET TRISTE PARVMPER / PACEM ANIMO SOMNVMQVE PATI) <supplied>
                      <hi rend="italic">angusta dies</hi>
                   </supplied> ad discordiam conserendam. TRISTE tristis res. (PARVMPER) PACEM ANIMO (SOMNVMQVE PATI) <supplied>ordo: </supplied> et animo triste est pacem paulisper pati. Adeo dies uestrae pugnae non suffecit, ut noctem quieti non daretis? </p>
@@ -1720,7 +1721,7 @@
                <p> PRODITE dicite. </p>
             </div>
 
-            <div type="schol" n="444-446">
+            <div type="schol" n="444">
                <p> (NAM VOS) HAVD HVMILES (TANTA IRA DOCET GENERISQVE SVPERBI / MAGNA PER EFFVSVM CLARESCVNT SIGNA CRVOREM) ut Vergilius:</p> 
                <l>'degeneres animos timor arguit'.</l> 
                <p>Quisquis enim timet in certamine, degener est. Econtra qui imperterritus fuerit, generosi sanguinis indolem profitetur. </p>
@@ -1730,7 +1731,7 @@
                <p> OBLIQVA TVENTES id est: inuicem se iuuenes male obliquis oculis intuentes. </p>
             </div>
 
-            <div type="schol" n="450-451">
+            <div type="schol" n="450">
                <p> (HAEC PASSIM TVRBATIS VOCIS AMARAE) / CONFVDERE SONIS pariter dicendo significationem turbauere uerborum. IN ORDINE iam non turbato sono. </p>
             </div>
 
@@ -1747,11 +1748,11 @@
                <p> (TECTO) CAELVM PROHIBERE <hi rend="italic">caelum</hi> pro aere et nimbis posuit. Id est: pluuiam tecto declinare. </p>
             </div>
 
-            <div type="schol" n="455-456">
+            <div type="schol" n="456">
                <p> QVIS ISTE / (ARCVIT) id est: quam gerit potestatem, qui hospitalitatis communionem sic prohibet? </p>
             </div>
 
-            <div type="schol" n="457-458">
+            <div type="schol" n="457">
                <p> BIMEMBRES (CENTAVROS) duplicium membrorum. Vt Iuuenalis in quinto:</p>
                <lg>
                   <l>'egregium sanctumque uirum si cerno, bimembri</l>
@@ -1759,15 +1760,15 @@
                </lg>
             </div>
 
-            <div type="schol" n="459">
+            <div type="schol" n="459a">
                <p> COMPOSITOS ex uariis gentibus. </p>
             </div>
 
-            <div type="schol" n="459-460">
+            <div type="schol" n="459b">
                <p> (IVRA INSITA ...) / FASQVE SVVM iura humanitatis atque concordiae. </p>
             </div>
 
-            <div type="schol" n="&lt;460&gt;">
+            <div type="schol" n="460">
                <p> 
                   <supplied>NOBIS SOCIARE CVBILIA TERRAE</supplied> 
                   <del>et</del> deest 'non licuit' per iracundiam. </p>
@@ -1781,11 +1782,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="462-465">
+            <div type="schol" n="462">
                <p> (ME ... / ... MAGNI DE) STIRPE CREATVM / OENEOS (ET MARTI NON DEGENERARE PATERNO / ACCIPIES) Mars Meleagri pater, Meleager Oenei, Oeneus Tydei, quamuis plerique dicant eum Marte procreatum conuerso in uultum Oenei. Ordo talis: accipies <supplied>me</supplied> non degenerasse a paterna uirtute. ACCIPIES senties siue experieris. SANGVIS HEBET stupet originis uirtus horrore parricidii perpetrati. </p>
             </div>
 
-            <div type="schol" n="466-467">
+            <div type="schol" n="466">
                <p> ILLE REFERT CONTRA (SED MENS SIBI CONSCIA FATI / CVNCTATVR PROFERRE PATREM) Polynices respondet iniuriis, sed incesti conscius celauit nomen parentis. <supplied>CONSCIA FATI</supplied> ergo si accusabis, <hi rend="italic">facti</hi> legis, si purgas, <hi rend="italic">fati</hi>. CVNCTATVR PROFERRE PATREM timet Oedipum nominare, quia frater est et pater. </p>
             </div>
 
@@ -1794,11 +1795,11 @@
                <l>'excepitque manu dextraque amplexus inhaesit'. </l>
             </div>
 
-            <div type="schol" n="473-474">
+            <div type="schol" n="473">
                <p> (NEC VANA VOCE LOCVTVS) / FATA SENEX bene dixit <hi rend="italic">fata</hi>. Quicquid enim senex loquitur, propemodum fatum est. Et reuera quasi instinctu numinis locutus est. Nam ex discordia magna familiaritas conflata est inter Tydeum et Polynicen. </p>
             </div>
 
-            <div type="schol" n="474-476">
+            <div type="schol" n="474">
                <p> (SIQVIDEM HANC PERHIBENT POST VVLNERA IVNCTIS / ESSE FIDEM QVANTA PARTITVM) EXTREMA (PROTERVO / THESEA PIRITHOO) <supplied>
                      <hi rend="italic">extrema</hi>
                   </supplied> extreme. Nomen pro aduerbio. PROTERVO (... PIRITHOO) quod amore Proserpinae inferos penetrare non timuit. <hi rend="italic">Esse</hi> ergo pro 'fuisse' dixit et recte. Nam omnia, quae nimis bona aut mala sunt, pro praesentibus ascribuntur. <hi rend="italic">Extrema</hi> ergo, quia fides extrema erat usque ad inferos. Id est: quanta fide perhibent fuisse extrema partitum Pirithoo Thesea. <del>THESEA PIRITHOO</del> hanc talem fidem uult esse qualem colebat antiquitas. Quattuor namque amicitiarum exempla fuisse certissimum est: Thesei et Pirithoi, Orestis et Pyladis, Achillis et Patrocli, Tydei et Polynicis. Theseus et Pirithous conspirauerunt filias Iouis uxores ducere: Theseo rapuerunt Helenam adhuc paruam, Pirithous cum filiam Iouis quaereret et non inueniret, quia apud inferos erat Proserpina, coniurauerunt ut descenderent pariter. Qui deprehensi poenas dederunt. — Orestes post necem matris Furias passus <supplied>est</supplied>. Vt Vergilius:</p> 
@@ -1813,7 +1814,7 @@
                <p>Huic Pylades tulit in calamitate solacium, cuius auxilio Furiis liberatus est. — Patroclus deside Achille causa Briseidis armis ipsius indutus uenit ad Troiam atque ibi manu procubuit Hectoris. — Tydeus uero causa Polynicis pergit ad Thebas ibique dimicans periit. </p>
             </div>
 
-            <div type="schol" n="479-480">
+            <div type="schol" n="479">
                <p> VENTIS VT DECERTATA (RESIDVNT / AEQVORA) parenthesis per similitudinem. Lucanus:</p>
                <lg>
                   <l>'sed ut timidus Boreas post flamina uentus</l>
@@ -1829,7 +1830,7 @@
                <p> PASSI SVBIERE PENATES ordo est: tunc (478) ... passi subiere penates, id est: tunc permiserunt sibi ut pariter Adrasti domum subirent. </p>
             </div>
 
-            <div type="schol" n="483-484">
+            <div type="schol" n="483">
                <p> INANEM / ... LEONEM hoc est pellem leonis. Vt ipse álibi</p> 
                <l>'inanem tigridem'</l> 
                <p>dicit. </p>
@@ -1839,7 +1840,7 @@
                <p> IMPEXIS <supplied>... IVBIS</supplied> compositis aut non compositis. VTRIMQVE ex utroque humero. </p>
             </div>
 
-            <div type="schol" n="485-487">
+            <div type="schol" n="485">
                <p> (ILLIVS IN SPECIEM) QVEM PER TEVMESIA (TEMPE / AMPHITRYONIADES FRACTVM IVVENALIBVS ARMIS / ANTE CLEONAEI VESTITVS PROELIA MONSTRI) <supplied>
                      <hi rend="italic">Teumesia Teumesum</hi>
                   </supplied> 
@@ -1864,7 +1865,7 @@
                <l>'obtutu tenet ora soloque i(mmobilis) h(aeret)'. </l>
             </div>
 
-            <div type="schol" n="493-494">
+            <div type="schol" n="493">
                <p> (LAETVSQVE PER ARTVS) / HORROR IIT medie dictum. Horror enim aut gaudiorum est aut maeroris. Sed modo gaudii intellegendum. Timoris horror est, quem Vergilius dicit:</p> 
                <l>'horror ubique animos, simul i(psa) s(ilentia) t(errent)',</l> 
                <p>laetitiae, ut Terentius:</p>
@@ -1903,7 +1904,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="500-501">
+            <div type="schol" n="501">
                <p> (DVM PROXIMVS AEGRIS / INFVNDAT TITAN) AGILES (ANIMANTIBVS ORTVS) <supplied>
                      <hi rend="italic">agiles</hi>
                   </supplied> celeres. Summa est enim celeritas illi redeundi. <supplied>ANIMANTIBVS</supplied> celeres ergo in nostro officio. </p>
@@ -1914,7 +1915,7 @@
                   <del>TV MIHI</del> PERPLEXIS ... (ERRORIBVS) quibus agimur, quia oraculum de generis erat obscurum. </p>
             </div>
 
-            <div type="schol" n="503-504">
+            <div type="schol" n="503">
                <p> ADVEHIS (ALMA FIDEM VETERISQVE EXORDIA FATI / DETEGIS) id est: responsa Apollinis soluis. VETERIS ... FATI praeteriti responsi. </p>
             </div>
 
@@ -1944,7 +1945,7 @@
                <l>'canis albicant pruinis'.</l>
             </div>
 
-            <div type="schol" n="[514]">
+            <div type="schol" n="514a">
                <p> 
                   <del>ADOLERE FOCOS uerbum proprie est sacra reddentium, quod significat uotis uel supplicationibus numen auctius fieri. Ergo <hi rend="italic">adolere</hi> accumulare. Vnde Vergilius:</del>
                </p> 
@@ -1952,13 +1953,13 @@
                   <del>'adolet dum altaria t(aedis)'</del>.</l>
             </div>
 
-            <div type="schol" n="514-515">
+            <div type="schol" n="514b">
                <p> (EPVLAS ... RECENTES) INSTAVRARE IVBET <supplied>
                      <hi rend="italic">instaurare</hi>
                   </supplied> renouare, sacrificium celebrare, ut intellegamus superiore die uota Apollini persoluta, quae nunc aduentu iuuenum praecipit renouari in honorem Apollinis. </p>
             </div>
 
-            <div type="schol" n="&lt;515-516&gt;">
+            <div type="schol" n="515">
                <p> 
                   <supplied>DICTIS PARERE MINISTRI / CERTATIM ACCELERANT</supplied> ut Maro:</p> 
                <l>'centum aliae totidemque pares aetate ministri'. </l>
@@ -1994,17 +1995,17 @@
                <p> TACITA nomen pro aduerbio 'tacite'. </p>
             </div>
 
-            <div type="schol" n="534-536">
+            <div type="schol" n="534">
                <p> (MISERABILE VISV / PALLADOS ARMISONAE PHARETRATAEQVE ORA DIANAE / AEQVA FERVNT) TERRORE MINVS <supplied>
                      <hi rend="italic">terrore minus</hi>
                   </supplied> id est sine terrore. Pulchritudinem potuit dare deae, potestatem uero non potuit praebere mortali. Sensus uero talis est: quantum ad pulchritudinem, Mineruae et Dianae similes erant, quantum ad terrorem, minores. </p>
             </div>
 
-            <div type="schol" n="536-538">
+            <div type="schol" n="536">
                <p> NOVA DEINDE PVDORI / V(ISA) V(IRVM) F(ACIES) (PARITER PALLORQVE RVBORQVE / PVRPVREAS HAVSERE GENAS) <hi rend="italic">noua ... facies</hi> id est peregrinorum uisa est pudicis uirginibus, quae per pudorem et palluerunt et rubuerunt. PVRPVREAS HAVSERE GENAS <hi rend="italic">purpureas</hi> pulchras. HAVSERE consumpsere, quia desierunt esse purpureae. </p>
             </div>
 
-            <div type="schol" n="538-539">
+            <div type="schol" n="538">
                <p> (OCVLIQVE) VERENTES (AD PATREM) <supplied>
                      <hi rend="italic">uerentes</hi>
                   </supplied> uerecundiam patientes. </p>
@@ -2014,7 +2015,7 @@
                <p> AD SANCTVM REDIERE PATREM primo patrem, post iuuenes, et ite<supplied>ru</supplied>m patrem aspexerunt. Mores expressit erubescentium, quae si nouam uiderint faciem, statim suos oculos ad notam sibi personam retorquent. </p>
             </div>
 
-            <div type="schol" n="541-543">
+            <div type="schol" n="541">
                <p> IASIDES (PATERAM FAMVLOS EX MORE POPOSCIT, / QVA DANAVS LIBARE DEIS SENIORQVE PHORONEVS / ADSVETI) <supplied>
                      <hi rend="italic">Iasides</hi>
                   </supplied> patronymicum <del>Iasii filius</del>. <supplied>EX MORE</supplied> ab antiquis ducibus ducto. <supplied>SENIOR ... PHORONEVS</supplied> qui ante Danaum fuit. Iasius et Phoroneus antiqui reges Argiuorum fuere, qui primi Iunoni sacrificauerunt. <hi rend="italic">Poposcit</hi> ergo Adrastus <hi rend="italic">ex more pateram</hi>, qua assuerant Argiuorum antiqui principes diis litare. Vt Vergilius:</p>
@@ -2032,7 +2033,7 @@
                <p> ITA VISVS <del>IN AVRAS</del> ad probationem rei, tamquam uerum esset, exposuit. </p>
             </div>
 
-            <div type="schol" n="546-547">
+            <div type="schol" n="546">
                <p> (ILLA) GRAVES OCVLOS (LANGVENTIAQVE ORA / PAENE MOVET) <supplied>
                      <hi rend="italic">graues</hi>
                   </supplied> morituros, et quia omnem uim nocendi in oculis habebat, quaerebat abscisa sectorem. <del>Ad admirationem ueri finxit et sensum</del>.</p>
@@ -2055,7 +2056,7 @@
                <l>'longaeui palmas nequiquam a(d) s(idera) t(endunt)'. </l>
             </div>
 
-            <div type="schol" n="554-555">
+            <div type="schol" n="554">
                <p> COMITVM FAMVLVMQVE ... / ... MANVS id est amicorum et seruorum multitudo. PVDICA / FRONDE id est lauro. Pulchre propter Daphnen, quae uirgo permansit. </p>
             </div>
 
@@ -2063,7 +2064,7 @@
                <p> CVI FESTA DIES Apollini scilicet. Vt est: 'festa uelamus fronde p(er) u(rbem)'. </p>
             </div>
 
-            <div type="schol" n="557-559">
+            <div type="schol" n="557">
                <p> FORSITAN O IVVENES (QVAE SINT EA SACRA QVIBVSQVE / PRAECIPVVM CAVSIS PHOEBI OBTESTEMVR HONOREM ... EXQVIRANT ANIMI) sensus talis est: credo, sanctissimi iuuenes, unde nobis sint sacrorum ista sollemnia, animos uestros uelle cognoscere. </p>
             </div>
 
@@ -2071,11 +2072,11 @@
                <p> SINVOSA VOLVMINA spatiosa. Longum hyperbaton: postquam (562) ... perculit (567). </p>
             </div>
 
-            <div type="schol" n="564">
+            <div type="schol" n="564a">
                <p> (AMPLEXVM DELPHOS SQVAMISQVE ...) TERENTEM crebris amplexibus tenuantem. </p>
             </div>
 
-            <div type="schol" n="564-565">
+            <div type="schol" n="564a">
                <p> (ANNOSA / ROBORA) CASTALIIS (... FONTIBVS) magnae arbores iuxta Castalium fontem sunt, qui in Boeotia esse dicitur Musis consecratus. </p>
             </div>
 
@@ -2095,7 +2096,7 @@
                <l>'sola domum et tantos seruabat nata penates'. </l>
             </div>
 
-            <div type="schol" n="573-574">
+            <div type="schol" n="573">
                <p> FELIX SI DELIA NVNQVAM / FVRTA (NEC OCCVLTVM PHOEBO SOCIASSET AMOREM) id est felix, si nunquam fuisset Apollinis perpessa concubitus. </p>
             </div>
 
@@ -2121,17 +2122,17 @@
                <p> CVSTODI huius in historia Helenus nomen inuenitur. </p>
             </div>
 
-            <div type="schol" n="&lt;584-585&gt;">
+            <div type="schol" n="584">
                <p> 
                   <supplied>CLAVSA ARBVTEI SVB CORTICE LIBRI / MEMBRA TEPENT</supplied> quasi indumenta eius essent ex libris et arbuto. <hi rend="italic">Arbutei</hi> ergo pro '<supplied>i</supplied>lignei' posuit, nam arbutus tegimen non habet. </p>
             </div>
 
-            <div type="schol" n="586">
+            <div type="schol" n="586a">
                <p> ET PECORI COMMVNE S(OLVM) ut ostenderet pecori pastorique domum esse communem. Vt Iuuenalis:</p> 
                <l>'et pecus et dominos communis clauderet umbra'. </l>
             </div>
 
-            <div type="schol" n="586-587">
+            <div type="schol" n="586b">
                <p> SED FATA NEC ILLVM / CONCESSERE LAREM id est: fatorum necessitas puerum uiuere nec in indigno loco permisit. Vt Vergilius:</p> 
                <lg>
                   <l>'ostendent terris hunc tantum fata nec ultra</l>
@@ -2153,7 +2154,7 @@
                <p> ADIT percutit. </p>
             </div>
 
-            <div type="schol" n="591-592">
+            <div type="schol" n="592">
                <p> PVLSI EX ANIMO (GENITORQVE PVDORQVE / ET METVS) conscientiae haec sunt tria supplicia: uerecundia <supplied>patris</supplied>, pudor, et supplicii metus. Haec omnia mortui filii dolor exclusit. </p>
             </div>
 
@@ -2191,13 +2192,13 @@
                <p> NOCTVRNO (... PASSV) quod noctu incederet, nam quasi infernum monstrum uitabat aspectum. </p>
             </div>
 
-            <div type="schol" n="602-603">
+            <div type="schol" n="602">
                <p> (ANIMAS) A STIRPE RECENTES / (ABRIPERE ALTRI CVM GREMIIS) <supplied>
                      <hi rend="italic">recentes</hi>
                   </supplied> mox natas id est pueriles animas. </p>
             </div>
 
-            <div type="schol" n="&lt;603-604&gt;">
+            <div type="schol" n="603">
                <p> 
                   <supplied>MORSVQVE CRVENTO / DEVESCI ET MVLTVM PATRIO PINGVESCERE LVCTV</supplied> ut ostenderet, quam rem dolor Apollinis uindicaret. </p>
             </div>
@@ -2229,7 +2230,7 @@
                <p> FERRATI ... VNGVES duri. </p>
             </div>
 
-            <div type="schol" n="615-616">
+            <div type="schol" n="615">
                <p> PROFVNDO / (REDDIT HABERE IOVI) <supplied>
                      <hi rend="italic">profundo</hi>
                   </supplied> insatiabili, qui semper mortuos rapit. <del>HABERE</del> IOVI utique Plutoni, ut:</p> 
@@ -2240,7 +2241,7 @@
                <p> (IVVAT IRE ET) VISERE IVXTA quia uiuo monstro comminus accedere non licebat. </p>
             </div>
 
-            <div type="schol" n="617-618">
+            <div type="schol" n="617">
                <p> (VTERIQVE NEFANDAM) / PROLVVIEM cadaueribus humanis uteri confectam proluuiem. </p>
             </div>
 
@@ -2265,7 +2266,7 @@
                <p> IMPASTAE FVGISTIS AVES eleganter <hi rend="italic">impastae</hi> per hyperbolen dixit, ut 'etiam esurientes abstinuistis', ne satiatae abstinuisse crederentur. Hic ergo aut propter formam aut propter foetorem fugisse <hi rend="italic">impastas uolucres</hi> dixit. </p>
             </div>
 
-            <div type="schol" n="628-629">
+            <div type="schol" n="628">
                <p> BIVERTICIS ... / PARNASSI qui in duos diuiditur colles. </p>
             </div>
 
@@ -2273,7 +2274,7 @@
                <p> INIQVO irato. </p>
             </div>
 
-            <div type="schol" n="630-631">
+            <div type="schol" n="630">
                <p> (CELSA) CYCLOPVM / TECTA uelut Cyclopum. Idonee enim omnia constructa aedificia Cyclopea dixit antiquitas. </p>
             </div>
 
@@ -2281,13 +2282,13 @@
                <p> (SVPERIECTO) NEBVLARVM I(NCENDIT) A(MICTV) id est: morbo uitiauit seu polluit. NEBVLARVM ... AMICTV nebularum aere pestilenti. </p>
             </div>
 
-            <div type="schol" n="&lt;632&gt;">
+            <div type="schol" n="632a">
                <p> 
                   <supplied>LABVNTVR DVLCES ANIMAE</supplied> ut Lucanus:</p> 
                <l>'sed languor cum morte uenit'. </l>
             </div>
 
-            <div type="schol" n="632-633">
+            <div type="schol" n="632b">
                <p> MORS FILA S(ORORVM) / E(NSE) M(ETIT) non iam pollice fila rumpuntur, sed ad saeuiendum in facinus ferro exsecantur. Tanta festinatio Mortis fuerat. </p>
             </div>
 
@@ -2295,15 +2296,15 @@
                <p> (CAPTAMQVE TENENS) FERT M(ANIBVS) V(RBEM) hoc est: in urbe dominatur. </p>
             </div>
 
-            <div type="schol" n="634">
+            <div type="schol" n="634a">
                <p> DVCI Crotopo. </p>
             </div>
 
-            <div type="schol" n="634-635">
+            <div type="schol" n="634b">
                <p> LAEVVS / I(GNIS) iniquissimus pestilentiae furor. </p>
             </div>
 
-            <div type="schol" n="&lt;635&gt;">
+            <div type="schol" n="635">
                <p> 
                   <supplied>ET IN TOTVM REGNARET SIRIVS ANNVM</supplied> siue Sirius, qui certis temporibus uideri pestilens solet, nunc sibi anni spatia uindicaret. </p>
             </div>
@@ -2312,11 +2313,11 @@
                <p> IVVENES QVI C(AEDE) P(OTITI) id est: qui peremerant monstrum. </p>
             </div>
 
-            <div type="schol" n="638">
+            <div type="schol" n="638a">
                <p> FORTVNATE A(NIMI) apostropha ad ipsum iuuenem qui pro patria optauit mori. </p>
             </div>
 
-            <div type="schol" n="638-639">
+            <div type="schol" n="638b">
                <p> (LONGVMQVE IN SAECVLA) DIGNE / P(ROMERITVRE) D(IEM) <hi rend="italic">digne</hi> aduerbium est. </p>
             </div>
 
@@ -2324,11 +2325,11 @@
                <p> COMMINVS O(RA) F(ERENS) cum ob declinandam mortem posset Coroebus se occulere, propior tamen se Apollini furenti obtulit de poena securus. </p>
             </div>
 
-            <div type="schol" n="643-644">
+            <div type="schol" n="643">
                <p> NON MISSVS THYMBRAEE TVOS (SVPPLEXVE PENATES / ADVENIO) <hi rend="italic">Thymbraeus</hi> dicitur Apollo sub herba thymbra, quae in templo Troados abundat. MISSVS humilis, deiectus, aut coactus. Sed sponte huc ueni, non ad supplicium, sed magis ad iracundiam tuam lacessendam. </p>
             </div>
 
-            <div type="schol" n="644-645">
+            <div type="schol" n="644">
                <p> MEA ME P(IETAS) E(T) C(ONSCIA) V(IRTVS) / (HAS EGERE VIAS) <hi rend="italic">pietatem</hi> posuit, quia ciues suos internecione monstri seruauerat, <hi rend="italic">uirtutem</hi>, quia non timebat interitum aut quia uirtute monstrum occiderat. </p>
             </div>
 
@@ -2336,7 +2337,7 @@
                <p> MORTALE NEFAS ostendit se culpa carere peccati, siquidem nil sanctum uiolauerit, cum constet <hi rend="italic">nefas</hi> peremptum fuisse <hi rend="italic">mortale</hi>.</p>
             </div>
 
-            <div type="schol" n="647-648">
+            <div type="schol" n="647">
                <p> (NIGRA TABE) SINISTRI / ... POLI <supplied>
                      <hi rend="italic">tabe</hi>
                   </supplied> corrupti aeris siue nullum habente remedium sanitatis. </p>
@@ -2346,7 +2347,7 @@
                <p> INIQVE iniuste, qui pro aliena culpa alios punis. </p>
             </div>
 
-            <div type="schol" n="649-650">
+            <div type="schol" n="649">
                <p> (IACTVRAQVE) VILIOR ORBI / (MORS HOMINVM) cui orbi iactura uilior est? <del>Id est</del> diis, quibus uilius damnum sit homines perire quam monstra. </p>
             </div>
 
@@ -2361,11 +2362,11 @@
                <p>DIVVM OPTIME per ironiam dictum. Non enim conueniebat ut, quem supra <hi rend="italic">iniquum</hi> dixerat, nunc praeconio laudis efferret. </p>
             </div>
 
-            <div type="schol" n="653">
+            <div type="schol" n="653a">
                <p> (AN ILLVD) / LENE MAGIS CORDI iucundum est, si tibi cordi sunt magis monstra quam homines. </p>
             </div>
 
-            <div type="schol" n="653-654">
+            <div type="schol" n="653b">
                <p> QVOD DESOLATA DOMORVM / (TECTA VIDES) id est orbitate uacuas domus et tecta iam paene inania. </p>
             </div>
 
@@ -2385,34 +2386,34 @@
                <p> PROINDE M(OVE) P(HARETRAS) meretur reus ueniam cum sibi eligit poenam. SONOROS grauiter sonantes. <hi rend="italic">Sonat</hi> enim quod leuiter strepit, <hi rend="italic">sonorat</hi>, quod grauiter. </p>
             </div>
 
-            <div type="schol" n="659">
+            <div type="schol" n="659a">
                <p> INSIGNEMQVE A(NIMAM) (LETO DEMITTE) artificiosa concessio quae habet quandam correctionem. Si insignis est, non meretur ut pereat. Est et apud Vergilium ista concessio:</p> 
                <l>'i, sequere Italiam, uentis'</l> 
                <p>— addidit <supplied>t</supplied>errorem —</p> 
                <l>'pete regna per undas'. </l>
             </div>
 
-            <div type="schol" n="659-661">
+            <div type="schol" n="659b">
                <p> (ILLVM) / PALLIDVS (INACHIIS QVI DESVPER IMMINET ARGIS / DVM MORIOR DISPELLE GLOBVM) globum pestilentiae, antequam moriar, discute. </p>
             </div>
 
-            <div type="schol" n="661-662">
+            <div type="schol" n="661">
                <p> (SORS AEQVA) MERENTES / (RESPICID bene promeritos semper respicit aequa fortuna. Nam cum paratus uenisset ad mortem, Apollinis fauore seruatus est, quia non merebatur occidi. </p>
             </div>
 
-            <div type="schol" n="662-663">
+            <div type="schol" n="662">
                <p> ARDENTEM (TENVIT REVERENTIA CAEDIS / LETOIDEN) <supplied>
                      <hi rend="italic">ardentem</hi>
                   </supplied> saeuientem. TENVIT repressit. REVERENTIA quia iustum uirum non sine pudoris sui iactura potuisset occidere. </p>
             </div>
 
-            <div type="schol" n="663-664">
+            <div type="schol" n="663">
                <p> (TRISTEMQVE VIRO) SVMMISSVS (HONOREM / LARGITVR VITAE) <supplied>
                      <hi rend="italic">summissus</hi>
                   </supplied> flexus siue misericordia inclinatus. HONOREM / (... VITAE) id est praemium donatae uitae, quod uir fortis, qui se saluti uouerat ciuium, non libenter accepit. </p>
             </div>
 
-            <div type="schol" n="665-666">
+            <div type="schol" n="665">
                <p> (TV) STVPEFACTI (A LIMINE PHOEBI / EXORATVS ABIS) <supplied>
                      <hi rend="italic">stupefacti</hi>
                   </supplied> uirtutis tuae admirantis audaciam. </p>
@@ -2432,15 +2433,15 @@
                <p> (HAS) FORTE INVISITIS ARAS duce fortuna ad haec sacra uenistis. </p>
             </div>
 
-            <div type="schol" n="669-671">
+            <div type="schol" n="669">
                <p> (CALYDONIVS) OENEVS / (ET PORTHAONIAE… / … TIBI CVRA DOMVS) Tydeum dicit, Oenei et Althaeae filium. <del>ET</del> PORTHAONIAE regionis Aetoliae, in qua Portheus, Tydei patruus, regnauit. <del>Sensus: Oeneus Calydonius et Porthaoniae tibi cura domus</del>.</p>
             </div>
 
-            <div type="schol" n="670-671">
+            <div type="schol" n="670">
                <p> SI CERTVS A(D) A(VRES) / (CLAMOR IIT) id est: si bene audisse me memini. </p>
             </div>
 
-            <div type="schol" n="&lt;671-672&gt;">
+            <div type="schol" n="671">
                <p> 
                   <supplied>TV PANDE QVIS ARGOS / ADVENIAS</supplied> et ad Polynicem uersus: tu quis sis, indica, qui ad Argos ueneris. QVIS ex quo genere uel quo sanguine procreatus. </p>
             </div>
@@ -2449,11 +2450,11 @@
                <p> QVANDO quoniam. </p>
             </div>
 
-            <div type="schol" n="673-674">
+            <div type="schol" n="673">
                <p> DEIECIT (MAESTOS EXTEMPLO ISMENIVS HEROS / IN TERRAM VVLTVS) signum uerecundiae. Erubuit Polynices propter <supplied>patris</supplied> parricidium et matris incestum. Indolem uenerandi pudoris agnoscit, <supplied>et</supplied> erubescit crimen familiae, ne similis iudicetur. ISMENIVS HEROS Polynices a fluuio Thebarum. </p>
             </div>
 
-            <div type="schol" n="674-675">
+            <div type="schol" n="674">
                <p> (TACITEQVE AD TYDEA LAESVM) / OBLIQVARE OCVLOS uerecundia coepit opprimi, quoniam necesse erat, ut dedecus generis sui inimicus agnosceret. </p>
             </div>
 
@@ -2472,16 +2473,16 @@
                <p>Aut ad terrigenas referendum est, quos constat draconis dentibus genitos qui fuerit in tutela Martis. </p>
             </div>
 
-            <div type="schol" n="681-682">
+            <div type="schol" n="681">
                <p> TVM MOTVS A(DRASTVS) / (HOSPITIIS) motus affectu, quo quis circa hospites suos solet moueri. </p>
             </div>
 
-            <div type="schol" n="&lt;682&gt;">
+            <div type="schol" n="682">
                <p> 
                   <supplied>AGNOVIT ENIM</supplied> aut quod ipse Oedipoden aliquando susceperat aut quod ipse ab Oedipo fuerat aliquando susceptus. </p>
             </div>
 
-            <div type="schol" n="683-684">
+            <div type="schol" n="683">
                <p> (SCIMVS ...) NEC SIC A(VERSVM) F(AMA) M(YCENIS) / (VOLVIT ITER) non ita a nobis fama auersum uoluit iter, ut ea, quae longe constituti compererint, nos finitimi nesciamus. Vergilius:</p> 
                <l>'nec tam auersus equos Tyria Sol iungit ab urbe'. </l>
             </div>
@@ -2497,11 +2498,11 @@
                   </supplied> propter nimium frigus. Hoc est: siqui sub septentrionali plaga sunt constituti. </p>
             </div>
 
-            <div type="schol" n="686">
+            <div type="schol" n="686a">
                <p> GANGEN fluuius Indiae. </p>
             </div>
 
-            <div type="schol" n="686-687">
+            <div type="schol" n="686b">
                <p> AVT NIGRVM O(CCASIBVS) I(NTRAT) / O(CEANVM) quasi eo loci domicilium noctis sit, ubi est solis occasus. </p>
             </div>
 
@@ -2509,48 +2510,48 @@
                <p> INCERTO (LITORE SYRTES) quia subito de mari siccus fit locus. SYRTES <foreign xml:lang="grc">ἀπὸ τοῦ σύρειν</foreign> id est <supplied>trahere</supplied>.</p>
             </div>
 
-            <div type="schol" n="688">
+            <div type="schol" n="688a">
                <p> DESTITVVNT reciprocis meatibus deserunt. </p>
             </div>
 
-            <div type="schol" n="688-689">
+            <div type="schol" n="688b">
                <p> (NE PERGE QVERI) CASVSVE PRIORVM / (ADNVMERARE TIBI) non habes necis maculam. Culpa est prioris fortunae, non tua. </p>
             </div>
 
-            <div type="schol" n="689-690">
+            <div type="schol" n="689">
                <p> (NOSTRO QVOQVE SANGVINE MVLTVM) / ERRAVIT PIETAS in nostro etiam genere pietas aberrauit. <del>694 SERVATOREMQVE P(ARENTVM)</del> cum responsum accepisset Thyestes aliter malorum remedium inueniri non posse, nisi cum Pelopeia filia concubuisset, paruissetque responsis, natus est ex ea Aegisthus, Clytaemestrae adulter, Agamemnonis parricida. Aut propter Tantalum dicit, sceleribus ne suos quidem caruisse maiores. </p>
             </div>
 
-            <div type="schol" n="691">
+            <div type="schol" n="691a">
                <p> TV MODO DISSIMILIS ut tu non sis criminosus. </p>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691b">
                <p> (REBVS) MEREARE S(ECVNDIS) / (EXCVSARE TVOS) sensus: enitendum tibi est, ut factis tuis non solum parentibus uideare dissimilis, sed etiam illos facias innocentes. </p>
             </div>
 
-            <div type="schol" n="692-693">
+            <div type="schol" n="682">
                <p> ET IAM TEMONE S(VPINO) / L(ANGVET) H(YPERBOREAE) G(LACIALIS) P(ORTITOR) V(RSAE) Ophiuchum significat, qui sub Vrsa est. Aduentu enim diei incipiunt sidera septentrionis hebescere. </p>
             </div>
 
-            <div type="schol" n="696">
+            <div type="schol" n="696a">
                <p> PHOEBE P(ARENS) inuocatio siue hymnus Apollinis. </p>
             </div>
 
-            <div type="schol" n="696-697">
+            <div type="schol" n="696b">
                <p> (TE) LYCIAE P(ATAREA) (NIVOSIS / EXERCENT DVMETA IVGIS) Lyciae ciuitas est Patara, Apollini sacra. Vnde Horatius:</p> 
                <l>'lycius et Patareus Apollo'. </l>
             </div>
 
-            <div type="schol" n="697-698">
+            <div type="schol" n="697">
                <p> (RORE PVDICO) / CASTALIAE ubi quondam uirgo Castalia, quam cum Apollo amaret et uim uellet inferre, in fontem se praecipitauit. </p>
             </div>
 
-            <div type="schol" n="699">
+            <div type="schol" n="699a">
                <p> (TROIAM) THYMBRAEVS HABES Thymbra locus est Troiae ab herba cognominatus, quam Latine 'puleium' dicimus. </p>
             </div>
 
-            <div type="schol" n="&lt;699-700&gt;">
+            <div type="schol" n="699b">
                <p> 
                   <supplied>VBI FAMA VOLENTEM / INGRATIS PHRYGIOS VMERIS SVBIISSE MOLARES</supplied> illic <supplied>
                      <gap/>
@@ -2558,7 +2559,7 @@
                </p>
             </div>
 
-            <div type="schol" n="701-702">
+            <div type="schol" n="701">
                <p> (SEV IVVAT AEGAEVM FERIENS) LATONIVS V(MBRA) / C(YNTHVS) (ET ASSIDVAM PELAGO NON QVAERERE DELON) Cynthus mons est Deli, cuius tantam uult esse magnitudinem ut umbra sua Aegaei maris ambitum protegat. Ipse enim Latonam susceperat, cum adhuc Delos erraret. Et est sensus: si te non iuuat esse in Delo, quae instabilitate sua hospes est litorum diuersorum. </p>
             </div>
 
@@ -2567,33 +2568,33 @@
                <l>'lentandus remus in unda'. </l>
             </div>
 
-            <div type="schol" n="704-705">
+            <div type="schol" n="704">
                <p> (AETHERII) DONO C(ESSERE) P(ARENTES) / (AETERNVM FLORERE GENAS) Apollinem imberbem philosophi tradunt eo, quod ipse sit sol. Sol autem ignis est, qui nunquam senescit. Et est sensus: dono cesserunt aetherei parentes genas aeternum florere. </p>
             </div>
 
-            <div type="schol" n="705-706">
+            <div type="schol" n="705">
                <p> (TV DOCTVS INIQVAS) / PARCARVM P(RAENOSSE) M(ANVS) quia quaecumque Fata parant, tu nosti, et omne futurum tibi patet. <supplied>FATVMQVE QVOD VLTRAST</supplied> 
                   <del>id est:</del> quia adhuc decreta non sunt. </p>
             </div>
 
-            <div type="schol" n="&lt;707&gt;">
+            <div type="schol" n="707a">
                <p> 
                   <supplied>SVMMO PLACITVRA IOVI</supplied> quae summo Ioui displicere non poterunt. </p>
             </div>
 
-            <div type="schol" n="707-708">
+            <div type="schol" n="707b">
                <p> QVIS LETIFER ANNVS / (QVAE MVTENT SCEPTRA COMETAE) letifer annus multa complexus est, famem, morbum, immutationemque regnorum. Quae mala, etsi diuersis modis distincta sunt, unius tamen pestilentis anni esse noscuntur. </p>
             </div>
 
-            <div type="schol" n="709">
+            <div type="schol" n="709a">
                <p> TV PHRYGA S(VBMITTIS) C(ITHARAE) Marsyam dicit, qui uictus submissus est poenae. S(VBMITTIS) inferiorem facis. </p>
             </div>
 
-            <div type="schol" n="709-710">
+            <div type="schol" n="709b">
                <p> (TV MATRIS HONORI / TERRIGENAM) TITYON (STYGIIS EXTENDIS HARENIS) <supplied>Tityos</supplied>, Terrae filius, Latonam, Apollinis matrem, amasse dicitur, sed ne sacrilegae libidinis commento impune potiretur, ab Apolline uinctus est et deductus ad Tartara. Cuius iecur <supplied>a</supplied> uulture tunditur, in aeternitatem supplicii pullulantibus fibris. </p>
             </div>
 
-            <div type="schol" n="711-712">
+            <div type="schol" n="711">
                <p> TE VIRIDIS P(YTHON) (THEBANAQVE MATER OVANTEM / HORRVIT IN PHARETRIS) <supplied>
                      <hi rend="italic">uiridis</hi>
                   </supplied> aut epitheton est serpentum, quia uirides sunt, aut <supplied>
@@ -2604,7 +2605,7 @@
                <l>'atque eadem scrofa <supplied>Niobe</supplied> fecundior alba'. </l>
             </div>
 
-            <div type="schol" n="712-714">
+            <div type="schol" n="712">
                <p> (VLTRIX TORVA MEGAERA / IEIVNVM) PHLEGYAN (SVBTER CAVA SAXA IACENTEM / AETERNO PREMIT ACCVBITV) Phlegyas, filius Martis, qui apud Delphos templum Apollinis incendit. Eius Vergilius meminit:</p>
                <lg>
                   <l>'Phlegyasque miserrimus omnis</l>
@@ -2613,7 +2614,7 @@
                <p>AETERNO P(REMIT) A(CCVBITV) id est: super ipsum accumbit, ne quando possit requiem capere. </p>
             </div>
 
-            <div type="schol" n="714-715">
+            <div type="schol" n="714">
                <p> (DAPIBVSQVAE PROFANIS) / INSTIMVLAT <supplied>id est: </supplied> inicit illi cupiditatem. Fames quidem urget, ut capiat, sed comedere timore fastidit. Comesse enim non sinitur, cui fastidium irrogatur. </p>
             </div>
 
@@ -2625,16 +2626,16 @@
                <p> SEV TE R(OSEVM) T(ITANA) V(OCARI) dicit Apollinem a diuersis gentibus uariis appellari nominibus. Apud Achaemenios enim Titan uocatur, apud Aegyptios Osiris, apud Persas, ubi in antro colitur, Mithra<supplied>s</supplied> uocatur. Quae sacra primum Persae habuerunt, a Persis Phryges, a Phrygibus Romani. Apud Persas Sol proprio nomine Mithra<supplied>s</supplied> dicitur, ut Osthanes refert. </p>
             </div>
 
-            <div type="schol" n="&lt;718&gt;">
+            <div type="schol" n="718a">
                <p> 
                   <supplied>GENTIS ACHAEMENII RITV</supplied> Persae ab Achaemene, <supplied>Persei</supplied> et Andromedae filio, qui eis imperauit, nunc<supplied>upantur</supplied> Achaemenii. Illi Mithram Solem dicunt, cuius et sacrorum ritus inuenisse dicuntur. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718b">
                <p> SEV PRAESTAT OSIRIM / (FRVGIFERVM) secundum Aegyptios, qui Osirim Solem interpretantur, per quem prouentum frugibus existimant posse contingere. </p>
             </div>
 
-            <div type="schol" n="719-720">
+            <div type="schol" n="719">
                <p> (SEV PERSEI SVB RVPIBVS ANTRI) / INDIGNATA S(EQVI) T(ORQVENTEM) C(ORNVA) M(ITHRAM) <del>
                      <hi rend="italic">sub rupibus</hi>: Persae in spelaeis coli Solem primi inuenisse dicuntur. Est enim in spelaeo Persico habitu cum tiara et utrisque manibus bouis cornua comprimens. Quae interpretatio ad Lunam dicitur. Nam <hi rend="italic">indignata sequi</hi> fratrem occurrit illi et lumen subtexit. His autem uersibus sacrorum Solis mysteria patefecit. Sol enim, Lunam minorem potentia sua et humiliorem docens, taurum insidens cornibus torquet. Quibus dictis Statius Lunam bicornem intellegi uoluit, non animalia, quibus uehitur.</del> 
                   <del>Prius ordinem dicit, postmodum sensum.</del> 
@@ -2649,7 +2650,7 @@
 
          </div>
 
-         <div type="lib" n="II">
+         <div type="lib" n="2">
             <head>LIBER II</head>
 
             <div type="pr" n="pr">
@@ -2672,12 +2673,12 @@
                <p>hi autem appellantur diuersis nominibus tam a Graecis quam a nobis. Illi Zephyrum, nos <supplied>Fauonium, illi Notum, nos</supplied> Austrum uocamus; nos Aquilonem, illi Borean dicunt; illi Eurum, nos <supplied>Subsolanum, illi Libem, nos</supplied> Africum uocamus.</p>
             </div>
 
-            <div type="schol" n="5">
+            <div type="schol" n="5a">
                <p> 
                   <del>AVRA</del> POLI <hi rend="italic">polus</hi> est circuitus, qui in se totum continet. </p>
             </div>
 
-            <div type="schol" n="5-6">
+            <div type="schol" n="5b">
                <p> (STYX INDE NOVEM CIRCVMFLVA CAMPIS / HINC OBIECTA VIAS) TORRENTVM INCENDIA (CLVDVNT) tardius ab inferis Mercurius remeabat propter crassum aerem et sine uento et propter Stygis impedimenta et fluuios ardentia fluenta uoluentes. </p>
             </div>
 
@@ -2685,7 +2686,7 @@
                <p> PONE retro. </p>
             </div>
 
-            <div type="schol" n="8-10">
+            <div type="schol" n="8a">
                <p> CAPVLO (NAM LARGIVS ILLI / TRANSABIIT COSTAS COGNATIS ICTIBVS ENSIS / IMPIVS) totus ensis mersus est in uulnere Laii quod ei Oedipus intulit. Vt Vergilius:</p> 
                <l>'capulo tenus abdidit ensem'.</l>
             </div>
@@ -2709,7 +2710,7 @@
                <l>'ferruginea subuectat corpora cimba'. </l>
             </div>
 
-            <div type="schol" n="14">
+            <div type="schol" n="14a">
                <p> MIRATVR P(ATVISSE) R(ETRO) <supplied>
                      <hi rend="italic">miratur</hi>
                   </supplied> nouitatem: cum introeuntibus solis pateat, <supplied>non</supplied> deesse ipsum iter <del>et</del> redeuntibus. Vt Vergilius:</p>
@@ -2721,7 +2722,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="14-16">
+            <div type="schol" n="14b">
                <p> NEC LIVIDA T(ABES) / (INVIDIAE FVNCTIS QVAMQVAM ET IAM LVMINE CASSIS / DEFVIT) mores inuidentium bene 'liuorem' dixit. Ordo hic est: nec liuida tabes inuidiae defuit functis. Hoc est: mortuis non recedit, a naturae malo, liuor inuidiae. Vt Vergilius:</p>
                <lg>
                   <l>'inuidia infelix furias amnemque seuerum</l>
@@ -2730,7 +2731,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;16-18&gt;">
+            <div type="schol" n="16a">
                <p> 
                   <supplied>VNVS IBI ANTE ALIOS CVI LAEVA VOLVNTAS / SEMPER ET AD SVPEROS ... / INSVLTARE MALIS REBVSQVE AEGRESCERE LAETIS</supplied> 
                   <del>ad animi enim</del> adiecit <del>ET IAM L(VMINE) C(ASSIS)</del> quia,</p> 
@@ -2805,13 +2806,13 @@
                <p> FERREA T(ER)G(EMINO) (DOMVISSET LVMINA SOMNO) propter bina lumina trium capitum, quasi tot illi somnos miserit, quot capita luminibus armarentur. </p>
             </div>
 
-            <div type="schol" n="[32]">
+            <div type="schol" n="32a">
                <p> 
                   <del>EST LOCVS I(NACHIAE) D(IXERVNT) T(AENARA) G(ENTES) haec 'topothesia' dicitur, nam in eiusmodi descriptione, ubi ueri loci <supplied>f</supplied>acies demonstratur, 'topographia' dicitur; ubi fictum quid uelit, 'topothesia'; 'cosmographia' dicitur mundi descriptio.</del>
                </p>
             </div>
 
-            <div type="schol" n="32-34">
+            <div type="schol" n="32b">
                <p> 
                   <supplied>EST LOCVS INACHIAE DIXERVNT TAENARA GENTES / QVA FORMIDATVM MALEAE SPVMANTIS IN AVRAS / IT CAPVT</supplied> chorographia. Taenaros locus Laconiae, in quo aditus dicitur esse inferorum. Vt:</p> 
                <l>'Taenarias etiam fauces, alta ostia Ditis'.</l> 
@@ -2820,42 +2821,42 @@
                <p>Inde mons exsurgit, qui Taenaros dicitur. </p>
             </div>
 
-            <div type="schol" n="35-36">
+            <div type="schol" n="a">
                <p> (IMBRESQVE) SERENVS / DESPICIT <supplied>despicit</supplied> infra se nubes. </p>
 
                <p>ET TANTVM F(ESSIS) I(NSIDITVR) A(STRIS) altitudinem uoluit exprimere, quasi illic astra requiem sumant. </p>
             </div>
 
-            <div type="schol" n="[33-34]">
+            <div type="schol" n="33">
                <p> 
                   <del>MALEAE S(PVMANTIS) I(N) A(VRAS) / (IT CAPVT) Maleum promuntorium est. IN AVRAS <supplied>IT CAPVT</supplied> erigitur. <supplied>SPVMANTIS</supplied> in qua fracti spumant fluctus.</del> 
                </p>
             </div>
 
-            <div type="schol" n="[35]">
+            <div type="schol" n="35b">
                <p>
                   <del>SERENVS quia nubes excedit.</del> 
                </p>
             </div>
 
-            <div type="schol" n="[36]">
+            <div type="schol" n="36">
                <p>
                   <del> ET TANTVM F(ESSIS) I(NSIDITVR) A(STRIS) super ipsum fessa astra considunt, id est: propter eminentiam sui sedem praestat astris rapido cursu fatigatis.</del>
                </p>
             </div>
 
-            <div type="schol" n="[41-42]">
+            <div type="schol" n="41a">
                <p> 
                   <del> (AST VBI PRONA DIES LONGOS SVPER AEQVORA FINES / EXIGIT) ATQVE INGENS MEDIO N(ATAT) (VMBRA) P(ROFVNDO) in tantum Taenarum montem elatum dicit, ut meridianis horis, quibus sol occidui caeli occupat partem, umbra eius inumbret medium mare.</del>
                </p>
             </div>
 
-            <div type="schol" n="&lt;41-42&gt;">
+            <div type="schol" n="41b">
                <p> 
                   <supplied>LONGOS SVPER AEQVORA FINES / EXIGIT</supplied> ultra fines litorum progrediens. </p>
             </div>
 
-            <div type="schol" n="&lt;43-44&gt;">
+            <div type="schol" n="43">
                <p> 
                   <supplied>INTERIORE SINV FRANGENTIA LITORA CVRVAT / TAENAROS</supplied> dicit nescio qua parte Taenarum recuruari ad uicem portus, in quo refert equos suos consueuisse stabulare Neptunum. Est autem hyperbaton, talis ut sit ordo:</p>
                <lg>
@@ -2886,7 +2887,7 @@
                <p> ILLIC in eadem regione. AEGAEO ... GVRGITE mari ab Aegeo, Neptuni filio, Thesei patre. </p>
             </div>
 
-            <div type="schol" n="46-47">
+            <div type="schol" n="46">
                <p> (PRIOR) HAVRIT (HARENAS / VNGVLA POSTREMI SOLVVNTVR IN AEQVORA PISCES) <supplied>
                      <hi rend="italic">haurit</hi>
                   </supplied> ferit. Vergilius:</p> 
@@ -2894,7 +2895,7 @@
                <p>Quasi per transitum Neptuni equos mira ratione descripsit. </p>
             </div>
 
-            <div type="schol" n="48-49">
+            <div type="schol" n="48">
                <p> DEVIVS V(MBRAS) / T(RAMES) A(GIT) hoc animae mortuorum destinantur ad Tartara. <hi rend="italic">Deuium</hi> autem tramitem dixit, quod sit deuius uiuis. TRAMES itineris compendium. </p>
             </div>
 
@@ -2915,7 +2916,7 @@
                <p> AGRICOLAS C(AMPIS) A(VDITVS) A(BEGIT) quasi iuxta habitantes terrore suo fugauit agricolas. </p>
             </div>
 
-            <div type="schol" n="&lt;57&gt;">
+            <div type="schol" n="57">
                <p> 
                   <supplied>VIVIS ADFLATIBVS ORA SERENAT</supplied> aurae uitalis afflatu laetior factus est. <supplied>VIVIS</supplied> id est superioribus. </p>
             </div>
@@ -2933,15 +2934,15 @@
                <p> (RECTO) DECEDIT L(IMITE) C(AELI) quasi non solum obuius Mercurio Somnus assurgat, sed ueniente <supplied>deo de</supplied> tramite certo declinet. </p>
             </div>
 
-            <div type="schol" n="62">
+            <div type="schol" n="62a">
                <p> INFERIOR quia super lunares polos dixerat ire Mercurium. </p>
             </div>
 
-            <div type="schol" n="62-63">
+            <div type="schol" n="62b">
                <p> PRAEREPTA .../ (... SIDERA) non enim naturae lege, sed ferro uita defunctus est. </p>
             </div>
 
-            <div type="schol" n="63-64">
+            <div type="schol" n="63">
                <p> (ARDVA CIRRHAE) / POLLVTAMQVE S(VO) D(ESPECTAT) P(HOCIDA) B(VSTO) illam tangit historiam: cum deus somnum caperet, quidam, cuius nomen fabulae tenent, dormienti tetendit insidias. Qui tamen conata peregisset, nisi eum filia Palaestra excitauisset. Qui cum odio terrae migrasset ad caelum, creditus est obiisse. Quo facto iniuriosam meruit sepulturam. Sed melius de Laio creditur, qui cum ad Naubolum hospitem Phocidis pergeret, occisus a filio est. DESPECTAT P(HOCIDA) de iugo Cirrhae uidit bustum suum, quod fuerat in Phocide. <del>Cirrha Boeotiae planities, in quo campo Apollini lustrum datur. <hi rend="italic">Phocis</hi> ergo Boeotia est.</del>
                </p>
             </div>
@@ -2950,7 +2951,7 @@
                <p> PAENE R(ETRO) T(VRBATVS) A(BIT) significare uoluit quia, ut fama est, timet umbra, quae passa est. </p>
             </div>
 
-            <div type="schol" n="71-72">
+            <div type="schol" n="71">
                <p> ET TVNC F(ORTE) D(IES) (NOTO SIGNATA TONANTIS / FVLMINE) id est primus natalis Liberi, quo fulminata est Semele et exsecto utero Liber Iouis femini insertus est. Secundus enim dies natalis Dionysi ille dicitur, quo exactis mensibus legitimi partus Iouis est productus ex femine, quem diem homini scire fas non est. Ideo et <foreign xml:lang="grc">Διθύραμβος</foreign> dicitur id est bis genitus. </p>
             </div>
 
@@ -2966,7 +2967,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="76-77">
+            <div type="schol" n="76">
                <p> ANHELVM / (PROFLABANT SVB LVCE DEVM) Somnum, ut Vergilius:</p>
                <l>
                   <supplied>'toto proflabat pectore somnum'</supplied>
@@ -2981,7 +2982,7 @@
                <l>'tympana uos buxusque uocant'. </l>
             </div>
 
-            <div type="schol" n="79-80">
+            <div type="schol" n="79">
                <p> (SANAS / IMPVLERAT MATRES) BACCHO MELIORE C(ITHAERON) non sic irato Baccho, ut cum Agaue occidit filium furens. Vel <hi rend="italic">meliore</hi>, qu<supplied>i</supplied>a propter diem <del>ut</del> ipse Liber ignoscat. CITHAERON mons Boeotiae, ubi Liberi patris sacra celebrantes matres Pentheum discerpserunt. Nunc ergo <hi rend="italic">sanas</hi> dicit sine furore. </p>
             </div>
 
@@ -2997,7 +2998,7 @@
                   <hi rend="italic">Ossa</hi> mons inter Thraciam et Thessaliam. </p>
             </div>
 
-            <div type="schol" n="85-86">
+            <div type="schol" n="85">
                <p> AT OGYGII S(I) (QVANDO) A(FFLAVIT) I(ACCHI) / (SAEVVS ODOR) <supplied>
                      <hi rend="italic">Ogygii</hi>
                   </supplied> Thebani ab <supplied>
@@ -3030,25 +3031,25 @@
                <p> REGIS ECHIONII Eteoclis ab Echione rege Thebanorum. </p>
             </div>
 
-            <div type="schol" n="&lt;92-93&gt;">
+            <div type="schol" n="92">
                <p> 
                   <supplied>PRO GNARA NIHIL MORTALIA FATI / CORDA SVI</supplied> exclamatio, ut:</p> 
                <l>'nescia mens hominum fati sortisque futurae',</l> 
                <p>quod futurus parricida munera securitatis amplectitur. </p>
             </div>
 
-            <div type="schol" n="&lt;93&gt;">
+            <div type="schol" n="93">
                <p> 
                   <supplied>HABET ILLE SOPOREM</supplied> aut quia rex aut quia regnum destruxit aut quia perfidus, ideo quietem capere non debet. </p>
             </div>
 
-            <div type="schol" n="95-96">
+            <div type="schol" n="95">
                <p> (LONGAEVI VATIS) OPACOS / TIRESIAE V(VLTVS) Tiresias, Eueris filius, genere Thebanus, uates, qui fertur in feminam uersus, cum <supplied>
                      <gap/>
                   </supplied> dis certantibus Ioue et Iunone, utrum mas an femina maiorem sentiret coitus uoluptatem, nouem partibus libidinis dixit feminam potiorem et una uirum. Ob quod caecatus est a Iunone. — est et alia talis fabula: in monte Cyllenio Tiresias dracones coeuntes calcasse dicitur. Ob id in mulieris figuram uersus, ut Ouidius refert, monitus sortibus in eodem loco rediit in figuram pristinam. Eo tempore, ut diximus, inter Iouem et Iunonem fuit certatio, in quo sexu esset maior libido, Tiresia iudice, qui expertus fuerat. Cum Ioui iudicasset, illa irata manus eius praecidit et excaecauit. Iuppiter ob id fecit, ut septem aetates uiueret uatesque praeter ceteros mortales ueracissimus haberetur. </p>
             </div>
 
-            <div type="schol" n="&lt;97-98&gt;">
+            <div type="schol" n="97">
                <p> 
                   <supplied>MANSERE COMAE PROPEXAQVE MENTO / CANITIES PALLORQVE SVVS</supplied> quae similia Tiresiae uideri poterant, non mutauit. Vt Vergilius:</p>
                <lg>
@@ -3057,19 +3058,19 @@
                </lg>
             </div>
 
-            <div type="schol" n="98-99">
+            <div type="schol" n="98">
                <p> FALSA C(VCVRRIT) / I(NFVLA) non sua, quasi uatem sola infula mentiretur. </p>
             </div>
 
-            <div type="schol" n="99-100">
+            <div type="schol" n="99">
                <p> (GLAVCAEQVE INNEXVS) OLIVAE (/ VITTARVM PROVENIT HONOS) ipse honos uittarum adnexus glaucae oliuae. </p>
             </div>
 
-            <div type="schol" n="100-101">
+            <div type="schol" n="100">
                <p> TANGERE R(AMO) / P(ECTORA) Eteoclis dormientis. </p>
             </div>
 
-            <div type="schol" n="105-108">
+            <div type="schol" n="105">
                <p> TV VELVTI M(AGNVM) (SI IAM TOLLENTIBVS ASTRIS / IONIVM NIGRA IACEAT SVB NVBE MAGISTER / IMMEMOR ARMORVM VERSANTISQVE AEQVORA CLAVI / CVNCTARIS) hyperbaton est. Id est: tu cunctaris, ita quietem agis ut gubernator dormiens uentis mare uersantibus. </p>
             </div>
 
@@ -3077,7 +3078,7 @@
                <p> SIC FAMA id est: sic de eo Fama loquitur, uel notum est, quod dico, omnibus. </p>
             </div>
 
-            <div type="schol" n="109-110">
+            <div type="schol" n="109">
                <p> (VIRESQVE PARAT QVIS REGNA) CAPESSAT / (QVIS NEGET INQVE TVA SENIVM DESTINAT AVLA) quasi perpetuo retenturus. Sallustius: 'expergiscimini aliquando et capessite rem publicam'. QVIS NEGET id est: uiribus quibus neget tibi, scilicet omnia negaturus fraude pactorum. (INQVE TVA SENIVM SIBI) DESTINAT AVLA in aula, in qua tu iaces, in eadem tuus frater sibi senectutem te pollicetur expulso. </p>
             </div>
 
@@ -3097,7 +3098,7 @@
                <p> AVT CADMO D(OMINAS) I(NFERRE) M(YCENAS) <hi rend="italic">Cadmo</hi> pro Thebis, <hi rend="italic">Mycenas</hi> pro Argis. </p>
             </div>
 
-            <div type="schol" n="120-121">
+            <div type="schol" n="120">
                <p> PALLIDA T(VRBANT) / S(IDERA) L(VCIS) E(QVI) <supplied>
                      <hi rend="italic">pallida</hi>
                   </supplied> pallentia Solis aduentu. LVCIS lucis id est Solis. </p>
@@ -3107,11 +3108,11 @@
                <p> PERFVNDIT V(VLNERE) S(OMNVM) <hi rend="italic">uulnere</hi> pro 'sanguine' posuit. Non <hi rend="italic">somnum</hi> perfudit, sed ipsum Eteoclen dormientem. Vulnere ergo suo Laius sanguine Eteoclen perfudit, ut eum pollutum sceleribus imbueret. </p>
             </div>
 
-            <div type="schol" n="126">
+            <div type="schol" n="126a">
                <p> MONSTRIS pro 'terroribus' posuit. </p>
             </div>
 
-            <div type="schol" n="126-127">
+            <div type="schol" n="126b">
                <p> (VANVMQVE CRVOREM) / EXCVTIENS putans se uero sanguine esse perfusum. </p>
             </div>
 
@@ -3137,11 +3138,11 @@
                <p>Est ergo Mygdonia regio in finibus Asiae, a rege Mygdone. </p>
             </div>
 
-            <div type="schol" n="137-138">
+            <div type="schol" n="137">
                <p> (ILLI ...) SERAS / (ADVERTIT) F(LAMMAS) hoc est: Aurorae flammas Lucifer serus accendit. Siue ad comparationem dixit ceterorum siderum, quia omnibus stellis tardius occidit Lucifer. ADVERTIT id est: ad eam et contra eam uertit. </p>
             </div>
 
-            <div type="schol" n="138-139">
+            <div type="schol" n="138">
                <p> (ALIENVMQVE AETHERA TARDO) / LVCIFER EXIT EQVO nam uerso caelo ad aduentum Aurorae, cum cetera sint apud antipodas, Lucifer solus apud nos inuenitur. Hoc est <hi rend="italic">alienum ... aethera</hi>, qui est diei, siue quia caelum stellis nocte concessum est. Ergo Lucifer officio suo nocte non fungitur, cum eum oriri constet prope lucis aduentum. Hinc <hi rend="italic">alieno ... aethere</hi> uidetur exoriens. </p>
             </div>
 
@@ -3154,7 +3155,7 @@
                <p> DIRCAEVS (... HEROS) Polynices a Dirce fonte Thebanorum. ACHELOIVS H(EROS) Tydeus ab Acheloo fluuio, qui per Aetolos fluit in Calydonem. </p>
             </div>
 
-            <div type="schol" n="&lt;143-144&gt;">
+            <div type="schol" n="143">
                <p> 
                   <supplied>ILLOS POST VERBERA FESSOS / EXCEPTAMQVE HIEMEM</supplied> causa, cur tardius Tydeus et Polynices a somno surrexerint, Adrastus uero celerius. </p>
             </div>
@@ -3163,7 +3164,7 @@
                <p> AT INACHIO (... REGI) notanda elegantia poetae, qui tres duces fluuiorum cognominibus designauit: Dircaeum Polynicen, Acheloium Tydeum, Inachium Adrastum. </p>
             </div>
 
-            <div type="schol" n="148-151">
+            <div type="schol" n="148">
                <p> (POSTQVAM) ... / INSIDVNT hyperbaton, id est: postquam insidunt. </p>
             </div>
 
@@ -3171,7 +3172,7 @@
                <p> (QVO SERERE) ARCANAS APTVM (ATQVE EVOLVERE CVRAS) uenerunt ad locum aptum, secretum fabulis uel curis. Nam ab eo quod in secretis locis curae publicae disserantur, ad hoc electa loca 'curias' nominauit antiquitas. </p>
             </div>
 
-            <div type="schol" n="152-153">
+            <div type="schol" n="152">
                <p> (QVOS NON SINE NVMINE REGNIS) / INVEXIT NOX ATRA MEIS quos per imbres et fulmina non sine fato in regnum meum Apollo perduxit. </p>
             </div>
 
@@ -3180,7 +3181,7 @@
                <l>'Iuppiter et laeto d(escendet) p(lurimus) i(mbri)'. </l>
             </div>
 
-            <div type="schol" n="158-159">
+            <div type="schol" n="158">
                <p> (GEMINAE MIHI NAMQVE NEPOTVM) / LAETA FIDES (AEQVO PVBESCVNT SIDERE NATAE) ordo: Argia et Deipyle geminae mihi natae pubescunt, nepotum laeta fides. </p>
             </div>
 
@@ -3193,20 +3194,20 @@
                <p> SVPER pro 'inter'. </p>
             </div>
 
-            <div type="schol" n="162-163">
+            <div type="schol" n="162">
                <p> HAS TVMIDI SOLIO (ET LATE DOMINANTIBVS ARMIS / OPTAVERE VIRI) <supplied>
                      <hi rend="italic">tumidi solio</hi>
                   </supplied> imperio superbi. Et artificiose, ne uideatur hos procorum inopia generos elegisse, ait se multos repudiasse et honore praestantes. </p>
             </div>
 
-            <div type="schol" n="&lt;163&gt;">
+            <div type="schol" n="163">
                <p> 
                   <supplied>OEBALIOS</supplied> accipiamus 'Laconicos'. Oebalus enim Laconum rex fuit. <del>
                      <supplied>ACHAEA PER OPPIDA MATRES</supplied> Atalanten significat, Parthenopaei matrem.</del>
                </p>
             </div>
 
-            <div type="schol" n="&lt;165-166&gt;">
+            <div type="schol" n="165">
                <p> 
                   <supplied>NEC PLVRA TVVS DESPEXERAT OENEVS / FOEDERA</supplied> Oeneus, Tydei pater, cuius Deianira filia a multis in coniugium exoptata procis. Pro qua Hercules et Achelous, Aetoliae amnis, certasse dicuntur. Deianiram ergo, Oenei et Althaeae filiam, uno tempore in coniugium petebant Hercules et Achelous acceptaque lege ab Oeneo, ut qui uirtute superasset, Deianiram duceret, congressi in certamine. Cum superaretur Achelous ab Hercule, per diuersas immutatus est figuras. OENEVS Tydei pater. Ideo ait <hi rend="italic">tuus</hi>.</p>
             </div>
@@ -3223,11 +3224,11 @@
                <p> VT RESPONSA IVVENT ut me delectet tales generos Apollinis meruisse responso. </p>
             </div>
 
-            <div type="schol" n="173-175">
+            <div type="schol" n="173">
                <p> (FIXOSQVE OCVLOS PER MVTVA PAVLVM / ORA TENENT VISQVE INTER SESE ORDINE FANDI / CEDERE) SED CVNCTIS TYDEVS AVDENTIOR ACTIS talis ubique monstrabitur, etiam tempore, quo ei moriendum est. Sensus talis est: dum sibi inuicem detulerunt, pendebat amborum ore loquendi principium. Dubitabant ergo, quis prior deberet incipere. Quod intellectum est ex eo, quod se mutuis intuebantur aspectibus. </p>
             </div>
 
-            <div type="schol" n="176-177">
+            <div type="schol" n="176">
                <p> O QVAM TE PARCVM IN PRAECONIA F(AMAE) / (MENS AGITAT MATVRA TVAE) ordo: o quam te parcum agitat mens matura in praeconia famae tuae. Hoc est: pudore nimio plurimum tuis laudibus detrahis. </p>
             </div>
 
@@ -3235,21 +3236,21 @@
                <p> FERENTEM feliciter praecedentem. </p>
             </div>
 
-            <div type="schol" n="178">
+            <div type="schol" n="178a">
                <p> FORTVNAM DOMAS quae solet alios secundis rebus extollere. Vt Vergilius:</p> 
                <l>'et seruare modum rebus lassata secundis'. </l>
             </div>
 
-            <div type="schol" n="&lt;178-179&gt;">
+            <div type="schol" n="178b">
                <p> 
                   <supplied>CVI CEDAT ADRASTVS / IMPERIIS</supplied> quippe quo nullus potior inuenitur. </p>
             </div>
 
-            <div type="schol" n="179-181">
+            <div type="schol" n="179">
                <p> QVIS TE SOLIO SICYONIS AVITAE / (EXCITVM INFRENOS COMPONERE LEGIBVS ARGOS / NESCIAT) Sicyon ciuitas est Achaiae, in qua primo regnauit. Vnde Argos rogatus Adrastus aduenit, ut mores barbaros naturae suae lenitate componeret. </p>
             </div>
 
-            <div type="schol" n="181-184">
+            <div type="schol" n="181">
                <p> (ATQVE VTINAM HIS MANIBVS PERMITTERE GENTIS / ... QVAS DORICVS ALLIGAT INTVS) / ISTHMOS (ET ALTERNO QVAS MARGINE SVMMOVET INFRA / NON FVGERET DIRAS LVX INTERCISA MYCENAS) <supplied>
                      <hi rend="italic">Doricus ... Isthmos</hi>
                   </supplied> Peloponnesum significat omnem, aut quod summouet Helladem aut Ioniam <supplied>ab illa</supplied>. Adhuc enim illis locis Thesei uersum legunt:</p> 
@@ -3262,16 +3263,16 @@
                <p> SAEVA NEC ELEAE (GEMERENT CERTAMINA VALLES) Elea ciuitas est Oenomai, cuius crudelitatem detestatur, quod in petitores filiae suae Hippodamiae crudelis exstiterit. </p>
             </div>
 
-            <div type="schol" n="&lt;186-187&gt;">
+            <div type="schol" n="186">
                <p> 
                   <supplied>ET QVAE / TV POTIOR THEBANE QVERI</supplied> uel de quibus crudelitatibus et tu, Thebane Polynices, queri poteris. </p>
             </div>
 
-            <div type="schol" n="191-192">
+            <div type="schol" n="191a">
                <p> (TAMEN OMNIS CORDE) RESEDIT / TRISTITIA (ADFIXIQVE ANIMO CESSERE DOLORES) bene: praesentibus gaudiis praeterita oblitus est, quo ostenditur humana uarietas. </p>
             </div>
 
-            <div type="schol" n="193-195">
+            <div type="schol" n="193">
                <p> NEC MINVS HAEC LAETI (TRAHIMVS SOLACIA QVAM SI / PRAECIPITI CONVVLSA NOTO PROSPECTET AMICAM / PVPPIS HVMVM) notandum, quod comparationem miscet allocutioni, ut supra:</p>
                <lg>
                   <l>'ueluti, magnum <supplied>si iam tollentibus austris,</supplied>
@@ -3292,13 +3293,13 @@
                </lg>
             </div>
 
-            <div type="schol" n="195-197">
+            <div type="schol" n="195">
                <p> (IVVAT INGRESSOS FELICIA REGNI / OMINA QVOD SVPEREST FATI VITAEQVE LABORVM) / FORTVNA TRANSIRE TVA <supplied>
                      <hi rend="italic">fortuna transire tua</hi>
                   </supplied> sub tutela fortunae tuae. Hoc est: iunctos felicibus infelices posse aduersa superare. Dicunt ergo laetari se, quod futuras aerumnas suas felicitatis eius prosperitate ualeant euitare. </p>
             </div>
 
-            <div type="schol" n="[191]">
+            <div type="schol" n="191b">
                <p> 
                   <del>NONDVM LAETA VENVS quod superius deest, hic redditur. Iuuat laeta Venus</del>. Docet poeta infelices felicibus iunctos fortunam et laborem uitae contra fata posse transire. Sic Cicero in Philippicarum primo: 'multa etiam contingunt praeter naturam praeterque fatum'. Et hoc diuersum est: nam quod putant, <del>quod</del> infelices felicibus iunctos <del>et</del> immutantes fortunam fata superasse, uel <del>ex</del> ipsius felicitatis factos sine fato esse participes, hoc non est. Nam ut miser iungeretur felici homini, per quem ad bonum statum peruenire po<del>tui</del>sset, id ipsum fati fuit. Vt:</p> 
                <l>'fata per Aeneae iuro'</l> 
@@ -3312,7 +3313,7 @@
                <p>Denique infinito<supplied>s</supplied> scimus fidos carosque potentibus, potentia omni promerita priuatos fato prohibente, et alios nuper agnitos et nullius fructus cum essent humiles laborum, ab eisdem multa bona meruisse. <supplied>FELICIA REGNI OMINA</supplied> quia felicia ista sunt uota. </p>
             </div>
 
-            <div type="schol" n="202">
+            <div type="schol" n="202a">
                <p> PRIMISQVE HYMENAEIS Vergilius:</p>
                <lg>
                   <l>'cui pater i(ntactam) d(ederat) p(rimisque) i(ugarat)</l>
@@ -3328,11 +3329,11 @@
                <p> GAVDIA MENTE PARANT dum uotis exagitant<supplied>ur</supplied>, uidentur parare, quod gaudeant. Ordo ergo: alacres Argi</p>
             </div>
 
-            <div type="schol" n="&lt;202&gt;">
+            <div type="schol" n="202b">
                <p> ... gaudia mente parant. </p>
             </div>
 
-            <div type="schol" n="206-207">
+            <div type="schol" n="206">
                <p> LYCAEOS / PARTHENIOSQVE (SVPER SALTVS) montes Arcadiae. Et in Lycaeo templum est Panos, in quo natus asseritur. Vnde Vergilius:</p> 
                <l>'Panos de more Lycaei'.</l> 
                <p>Famam ergo ait in haec loca penetrasse. </p>
@@ -3358,14 +3359,14 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;211-212&gt;">
+            <div type="schol" n="211">
                <p> 
                   <supplied>HOSPITIA ET THALAMOS ET FOEDERA REGNI / PERMIXTVMQVE GENVS</supplied> 
                   <hi rend="italic">'canit'</hi> ubique subaudiendum ab eo quod dicturus est:</p> 
                <l>'quis furor est? iam bella canit'. </l>
             </div>
 
-            <div type="schol" n="215-216">
+            <div type="schol" n="215">
                <p> (SPECIES EST) CERNERE AVORVM / (COMMINVS) imagines auorum comminus cernere. Est operae pretium descriptio eorum quorum statuae in Adrasti domo fuerant constitutae. Vt Vergilius:</p>
                <lg>
                   <l>'quin etiam ueterum effigies ex ordine auorum</l>
@@ -3402,11 +3403,11 @@
                <p> TORVAQVE IAM DANAI F(ACINVS) M(EDITANTIS) I(MAGO) Danaus, Beli filius, ex pluribus coniugibus quinquaginta iilias habuit, totidemque Aegyptus, frater eius, filios, qui Danaum fratrem filias suis filiis in matrimonium postulauit. Danaus responso comperit quod generi sui manibus interiret. Argos profectus est et primum dicitur nauem fecisse, a cuius nomine Argo dicta est nauis. Aegyptus misit filios suos ad persequendum fratrem hisque praecepit ut aut Danaum interficerent aut ad se non redirent, ut Agenor filio imperauerat. Qui postquam uenerunt Argos, coeperunt patruum oppugnare. Danaus postquam uidit se resistere non posse, filias suas fratris sui filiis spopondit uxores. Quae patris iussu uiros uniuersae suos interfecerunt. Sola Hypermestra Lynceo pepercit. </p>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224">
                <p> (PROCERVM MANVS OMNIS ET ALTO) / QVIS PROPIOR DE REGE GRADVS (STANT ORDINE PRIMI) quisquis regem affinitate contingit, id est proceres et illi qui regibus genere iungebantur <del>et</del> stabant primi, ut singulorum ordo poscebat et generis gradus. (ALTO / ...) STANT ORDINE PRIMI <supplied>ordo</supplied>: alto ordine stant primi. Hos autem dicit, quod Tullius sic nominauit: 'qui uiuunt in regnis' hoc est qui regibus obsecuntur. STANT ... PRIMI illi etiam proximi regi stabant qui ornabantur generis dignitate. </p>
             </div>
 
-            <div type="schol" n="227-228">
+            <div type="schol" n="227">
                <p> CASTA MATRVM C(INXERE) C(ORONA) / A(RGOLIDES) multitudine religiosa, id est pars matrum uirginibus nupturis admixta. </p>
             </div>
 
@@ -3456,7 +3457,7 @@
                <p> (QVAE CVIQVE DOMVS SACRIQVE) FACVLTAS unusquisque pro uiribus suis uota faciebat. </p>
             </div>
 
-            <div type="schol" n="247-248">
+            <div type="schol" n="247">
                <p> NEC MINVS AVDITI (SI MENS ACCEPTA MERENTVR / TVRE DEOS) sensus: nec minus auditi sunt illi qui ture deos placabant illis qui hostias immolarant. Victimarum enim loco sola etiam bona conscientia diis litatur. Sicut Persius:</p>
                <lg>
                   <l>'compositum ius fasque animi sanctusque recessos</l>
@@ -3468,21 +3469,21 @@
                <p> LACHESIS unam pro omnibus posuit. </p>
             </div>
 
-            <div type="schol" n="252-253">
+            <div type="schol" n="252">
                <p> PALLADA MONYCHIIS (CVI NON ARGIVA PER VRBES /POSTHABITA EST LARISSA IVGIS) Pallas, quae non minus diligit Larissam quam Monychiam. Larissa autem oppidum est Adrasti in quo nunc nuptiae fiunt, non illa Thessaliae unde Achilles dicitur natus. </p>
             </div>
 
-            <div type="schol" n="255">
+            <div type="schol" n="255a">
                <p> LIBARE uel consecrare uel aliquid templis appendere. Vergilius:</p> 
                <l>'sacrum tibi pascere crinem'</l> 
                <p>id est nutrire. </p>
             </div>
 
-            <div type="schol" n="255-256">
+            <div type="schol" n="255a">
                <p> PRIMOSQVE SOLEBANT / EXCVSARE TOROS id est: in templo Mineruae solebant uirgines nupturae placare deam quae sit fautrix uirginitatis et excusare quod necessitate et lege naturali nubere cogebantur. </p>
             </div>
 
-            <div type="schol" n="257-260">
+            <div type="schol" n="257">
                <p> (SVMMI DELAPSVS CVLMINE TEMPLI) / ARCADOS EVHIPPI SPOLIVM (CADIT AEREVS ORBIS / PRAEMISSASQVE FACES FESTVM NVBENTIBVS IGNEM/ OBRVIT) Euhippus, rex <supplied>
                      <gap/>
                   </supplied> Argiuorum, mirae felicitatis fuit. Cuius clipeum qui<del>a</del> apud Argos nobiliter rem gessisset accipiebat, ut illo per urbem incedens honestaretur. Vnde prouerbium apud illos tale est, cum alicuius ignauiam irriderent, ut Callimachus ait:</p> 
@@ -3500,7 +3501,7 @@
                <p> MOX AVDISSE NEGANT ut homines suspicionem sedarent, more uulgi potentibus blandientes audisse se negant quae constabat gaudiis obfutura. </p>
             </div>
 
-            <div type="schol" n="265-267">
+            <div type="schol" n="265">
                <p> (NEC MIRVM NAM TVM INFAVSTOS DONANTE MARITO) / ORNATVS ARGIA GERIS (DIRVMQVE MONILE / HARMONIAE) dicit non esse mirandum quod aduersum omen acciderit, siquidem Argia, uxor Polynicis, funestum monile acceperit, quod Thebis ueniens ad Argos extulerat. Et repetit originem huius muneris, quod a Vulcano Veneri fabricatum fuisse dicatur et deinde Harmoniae <supplied>fuerit</supplied>, postremo reginarum omnium quae Thebis uixerunt, quas istius monilis omine dicit infeliciter deperisse. </p>
             </div>
 
@@ -3508,11 +3509,11 @@
                <p> HARMONIAE DOTALE DECVS ut illa puniretur, quae ex adulterio Martis et Veneris nata esset. Huiusmodi enim uenenis infecerat illud monile Vulcanus, ut necesse esset hoc monile gestanti aerumnarum mole opprimi. Hoc enim usa est Harmonia, Agaue, Semele, Iocasta, Argia, ultimo Eriphyla, nam ad Polynicen hoc hereditario iure peruenerat. Quaecumque ergo hoc ornatu usae sunt, graui exitu et aerumnis affectae sunt. SVB LVCE IVGALI id est sub die nuptiarum quo Cadmo nupserat. </p>
             </div>
 
-            <div type="schol" n="273-274">
+            <div type="schol" n="273">
                <p> DOCTI QVAMQVAM M(AIORA) L(ABORANT) / C(YCLOPES) quamquam maiora docti sunt facere, tamen hoc laboriose fecerunt. </p>
             </div>
 
-            <div type="schol" n="274-276">
+            <div type="schol" n="274">
                <p> NOTIQVE OPERVM TELCHINES (AMICA / CERTATIM IVVERE MANV SED PLVRIMVS IPSI / SVDOR) hi tres fratres dicuntur fuisse inuidia liuidi. Qui cum uicinorum agros uiderent prouentu fertiles, natura felices, hos sparsisse dicuntur aquis Stygiis ut redderent infecundos. Qua culpa poenam metuentes solum uerterunt seque ad Cyclopes contulerunt. Est ergo sensus: in hoc plurimus est Vulcano sudor, quamuis et Cyclopes in hoc laborauerint ipsique Telchines. Telchinas ergo inuidos ad hoc monile faciendum concordasse dixit, ut fieret. PLVRIMVS IPSI / SVDOR Vulcano scilicet, ut, qui facienda aliqua imperare consueuerat, personam sumeret fabricantis. Vnde Vergilius:</p>
                <lg>
                   <l>'ensem, quem Dauno ignipotens deus ipse parenti</l>
@@ -3530,15 +3531,15 @@
                <p> (INFAVSTAS) PERCVSSVM ADAMANTA (FIGVRAS) id est characteribus nocentissimis sculptum. </p>
             </div>
 
-            <div type="schol" n="278">
+            <div type="schol" n="278a">
                <p> GORGONEOSQVE ORBES ita exsecrandum monile describit, ut huic pulchritudinem conferat atque terrorem. Nam <hi rend="italic">Gorgoneos ... orbes</hi> ponit instar oculorum, ut ad monstri speciem stupefaceret intuentes magnitudo et pulchritudo gemmarum. </p>
             </div>
 
-            <div type="schol" n="278-279">
+            <div type="schol" n="278b">
                <p> (SICVLAQVE INCVDE RELICTOS) / FVLMINIS EXTREMI CINERES hoc est: qui perfecto fulmine superfuissent, quasi hoc perniciosiores essent. Constat enim hoc monile post fulmina fabricatum de fragmentis. VIRIDVMQVE DRACONVM uel iuuenum uel uenenosorum. </p>
             </div>
 
-            <div type="schol" n="280-281">
+            <div type="schol" n="280">
                <p> HIC FLEBILE GERMEN / HESPERIDVM in Aethiopia speciosissimum pomarium Atlantis fuit, in quo nascebantur mala aurea, quae Hesperides custodiebant Aegle, Erethusa, Hesperethusa, et draco peruigil. — <supplied>
                      <gap/>
                   </supplied> acceperat responsum, ut ea quandoque ex Ioue genitus raperet. — nihilominus tamen fides responsi explicata est, missusque est ab Eurystheo rege Hercules, Iouis filius, qui ea mala abstulit occiso dracone peruigili. Diximus poetam omnia contulisse quae gratiam facerent et timorem. Ideo etiam aurum uult infame fuisse quo monile compositum est, ut iure confirmetur malum fuisse. </p>
@@ -3548,7 +3549,7 @@
                <p> ET DIRVM PHRIXEI VELLERIS AVRVM Phrixus et Helle<del>s</del> insania a Libero abiecti cum in silua errarent, Nebula, mater eorum, dicitur uenisse et arietem uellere aureo insignitum exhibuisse, in quo praedictos filios suos iussit ascendere et in Colchos ad regem Aeetam transire ibique arietem immolare. Qui cum ex praecepto matris ascendissent, illos aries in pelagus detulit. Helle<del>s</del> lapsa nomen ponto dedit. Phrixus matris praecepto parens arietem immolauit pellemque auream Martis templo dicauit, quam Iason, Aesonis filius, cum Argonautis dicitur petisse. Hunc Aeeta rex libens recepit filiamque ei dedit uxorem. Et cum ex ea liberos suscepisset, ueritus est Aeeta, ne se a regno deiceret, quod ei responsum ex prodigiis fuerat <supplied>ut ab</supplied> aduena, Aeoli progenie, mortem caueret, <supplied>et</supplied> Phrixum interfecit. At filii eius ratem ascenderunt, ut ad auum Athamantem transirent. Hos naufragos Aeson excepit. </p>
             </div>
 
-            <div type="schol" n="283-284">
+            <div type="schol" n="283">
                <p> ET QVAE PESSIMA CESTON / (VIS PROBAT) etiam illam uim monili permiscuit quae uis ceston probat id est quae cuius sit potestatis ostendit. <hi rend="italic">Ceston</hi> enim cingulum dicitur Veneris, quo utitur ad honestas nuptias. Et quoniam uirgo Cadmo nupserat Harmonia, ideo hoc iunxit. Nam ad turpes nuptias Venus dicitur non uenire. Ideo 'incestum' dicitur quod sacrato illo Veneris cingulo non fuerit iunctum. </p>
             </div>
 
@@ -3563,15 +3564,15 @@
                   <del>NON HOC</del> PASITHEA (BLANDARVM PRIMA SORORVM) id est una Gratiarum. Sunt autem tres: Pasithea, Aglaie, Euphrosyne, Iouis et Eurynomes filiae, Veneris famulae. </p>
             </div>
 
-            <div type="schol" n="289-291">
+            <div type="schol" n="289">
                <p> PRIMA FIDES OPERI (CADMVM COMITATA IACENTEM / HARMONIA VERSIS IN SIBILA DIRA QVERELIS / ILLYRICOS LONGO SVLCAVIT PECTORE CAMPOS) periculum huius monilis fidem fecit Harmoniae, quae prima experta est. Nam in anguem uersa est cum marito ob hanc causam, quod <supplied>Cadmus</supplied>, Agenoris et Ar<supplied>g</supplied>iopae filius, draconem Martis, qui fontem custodiebat, occidit. Ideo uult hoc contigisse, quia nuptialibus donis hoc monile possederat. </p>
             </div>
 
-            <div type="schol" n="292-293">
+            <div type="schol" n="292">
                <p> IMPROBA MOX SEMELE (VIX DONA NOCENTIA COLLO / INDVIT ET FALLAX INTRAVIT LIMINA IVNO) uult etiam Semelen huius infelicitate monilis exstinctam et magis ornatus inuidia a Iunone quam paelicatus inductam ut a Ioue improbe posceret quod nefas esset corpus sustinere mortale. Optime autem Semelen <hi rend="italic">improbam</hi> dixit, quod uoti fuit immodica, ut Iouem uellet uidere cum fulmine. </p>
             </div>
 
-            <div type="schol" n="294-295">
+            <div type="schol" n="294">
                <p> TEQVE ETIAM INFELIX P(ERHIBENT) I(OCASTA) D(ECORVM) / P(OSSEDISSE) N(EFAS) bene <hi rend="italic">infelix</hi>, quae non imposuit per malorum experimenta finem cupiditati. Nam hoc monile Iocastam etiam post Agauen certum est habuisse. </p>
             </div>
 
@@ -3580,11 +3581,11 @@
                <l>'auri sacra fames'. </l>
             </div>
 
-            <div type="schol" n="299">
+            <div type="schol" n="299a">
                <p> VIDERAT HOC CONIVNX (PERITVRI VATIS) Eriphylen dicit, Amphiarai uatis uxorem. </p>
             </div>
 
-            <div type="schol" n="299-300">
+            <div type="schol" n="299b">
                <p> ET ARAS / ANTE OMNES (EPVLASQVE) quia apud antiquos ante aras numinum celebrabant iura nuptiarum. Et est ordo: ante aras et epulas nuptiarum. </p>
             </div>
 
@@ -3624,7 +3625,7 @@
                <p> NVDVM LATVS (OMNE) ab amicis desertum. Regum enim semper latera stipatorum satellitumque corona claudebat. </p>
             </div>
 
-            <div type="schol" n="313-314">
+            <div type="schol" n="313">
                <p> NAMQVE VNA SOROR (PRODVCERE TRISTIS EXSVLIS AVSA VIAS) Antigonen dicit, quae fratrem sepeliuit. Nam et Ismenen aliam sororem habuit Polynices. PRODVCERE prosequi. Vt Terentius:</p> 
                <l>'comes produxi'. </l>
             </div>
@@ -3639,16 +3640,16 @@
                <l>'inclusitque dolor lacrimas'. </l>
             </div>
 
-            <div type="schol" n="316-318">
+            <div type="schol" n="316">
                <p> TVNC QVOS EXCEDENS HILARIS (QVIS CVLTVS INIQVI / PRAECIPVVS DVCIS ET PROFVGO QVOS IPSE NOTARET / INGEMVISSE SIBI) cogitat, discessu suo qui gauisi sint, qui doluerint. Omnia, inquit, haec in animo reuoluebat, et fratris cultum et quos sibi profugo gemuisse prospexerat. Ergo si aliquibus potuit exilium displicere, reuertentem tanto magis poterunt adiuuare. </p>
             </div>
 
-            <div type="schol" n="320-321">
+            <div type="schol" n="320">
                <p> (QVA NON GRAVIOR MORTALIBVS ADDITA CVRIS) / SPES VBI LONGA VENIT qua nulla grauior mortalibus cura est. Sallustius: 'animo cupienti nihil satis festinare'. Cicero: 'eripis etiam spem, quae sola homines in miseriis consolatur'. Hanc enim curarum omnium constat esse postremam. Graue enim tormentum est spes quae longa exspectatione differtur. Terentius:</p> 
                <l>'spem pretio non emo'. </l>
             </div>
 
-            <div type="schol" n="321-322">
+            <div type="schol" n="321">
                <p> (TALEM SVB PECTORE) NVBEM / (CONSILII) cogitationum multitudinem, quae animum sollicitudinis mole confundit. </p>
             </div>
 
@@ -3656,7 +3657,7 @@
                <p> DIRCEN fontem Thebanum, per quem Boeotiam debemus accipere. <hi rend="italic">Cadmi</hi> autem <hi rend="italic">domos</hi> Thebas dicit. </p>
             </div>
 
-            <div type="schol" n="326-327">
+            <div type="schol" n="326">
                <p> RECEPTO / SANGVINE id est recepta uirtute. Lucanus:</p>
                <lg>
                   <l>'dum sanguis inerat, dum uis materna, peregi</l>
@@ -3668,11 +3669,11 @@
                <p> (PASTVSQVE ET) CAPTA ARMENTA REPOSCIT ab inimico uictore. </p>
             </div>
 
-            <div type="schol" n="332">
+            <div type="schol" n="332a">
                <p> MENTE ACVIT exercuit uel in maiorem rabiem concitauit. FIDA proprium uxoris epitheton. </p>
             </div>
 
-            <div type="schol" n="332-334">
+            <div type="schol" n="332b">
                <p> (VIAS ARCANAQVE CONIVNX) / SENSERAT (VT ... TORIS PRIMO COMPLEXA IACEBAT / AVRORAE PALLORE VIRVM) Argia dispositionem mariti senserat, prima exorta aurora complexa uirum. <hi rend="italic">Pallorem</hi> dixit colorem croceum. Primo enim aurora cum Luciferi candore pallescit, deinde fulgore rosei solis afflatur. </p>
             </div>
 
@@ -3689,11 +3690,11 @@
                <p> (MAGNAS) LATRANTIA PECTORA (CVRAS) ex magnis curis tumultuantia. </p>
             </div>
 
-            <div type="schol" n="339">
+            <div type="schol" n="339a">
                <p> ADMOTA DEPREHENDO MANV lacrimas tantum an pectoris motus et pulsus? </p>
             </div>
 
-            <div type="schol" n="339-340">
+            <div type="schol" n="339b">
                <p> NIL FOEDERE RVPTO / (CONVBIISVE SVPER MOVEOR VIDVAQVE IVVENTA) oratorie. Cur enim metuit, si se dicit posse contemnere? Vergilius:</p> 
                <l>'nil super imperio moueor'.</l> 
                <p>Figura <supplied>
@@ -3705,21 +3706,21 @@
                <p>CONVBIIS<del>VE SVPER</del> synaeresis. </p>
             </div>
 
-            <div type="schol" n="341-342">
+            <div type="schol" n="341">
                <p> ETSI CRVDVS AMOR (NECDVM POST FLAMMEA TOTI / INTEPVERE TORI) <supplied>
                      <hi rend="italic">crudus</hi>
                   </supplied> recens, immaturus necdum temporis longinquitate firmatus. Ergo talis ordo est: <hi rend="italic">etsi necdum intepuere tori</hi>. Sensus: etsi necdum post nuptias calefactus <del>est</del> torus mariti <del>nec</del> temporis prolixioris accessibus deferuescit. Adeo pauci dies sunt, ex quo sunt nuptiae celebratae. </p>
             </div>
 
-            <div type="schol" n="342-343">
+            <div type="schol" n="342">
                <p> (TVA ME PROPERABO FATERI) / ANGIT AMATE SALVS sic ait, ut uincat, quia propter suum commodum nil suadet, sed asserit se a<supplied>n</supplied>gere causam mariti, ut hoc totum, quod ad cautelam mariti proficit, sibi putet quaeri. INERMIS aut facultatibus, quae desunt, inermis aut non tu inermis, sed armatorum multitudine destitutus. </p>
             </div>
 
-            <div type="schol" n="344-345">
+            <div type="schol" n="344">
                <p> (POTERISQVE TVIS DECEDERE THEBIS) / SI NEGET ergo si negauerit, subsequens est ut fratris insidiis pereas. </p>
             </div>
 
-            <div type="schol" n="345-346">
+            <div type="schol" n="345">
                <p> ATQVE ILLVM (SOLLERS DEPRENDERE SEMPER / FAMA DVCES TVMIDVM NARRAT) sensus: atque illum fama tumidum narrat, quae solet ducum indicare mores. Ordo autem est: atque illum tumidum narrat fama, quae sollers est reges deprendere. Fama enim ista studia semper illustrat, et semper, qua maiore dissimulatione, celebrantur. </p>
             </div>
 
@@ -3731,7 +3732,7 @@
                <p> EXTA MINANTIA DIVOS quae deos minantur iratos. </p>
             </div>
 
-            <div type="schol" n="350-351">
+            <div type="schol" n="350">
                <p> (NVNQVAM MIHI FALSA PER VMBRAS) / IVNO VENIT quae Argis praesidet, nec potest fallere quos defendit. Et Homerus dicit somn<del>i</del>um <del>de</del> experimento esse ut maritus <supplied>de</supplied>terreatur. </p>
             </div>
 
@@ -3747,19 +3748,19 @@
                <p> TEMPESTIVA opportuna, quasi tempori conuenientia. LACRIMASQVE REPRESSIT incertum est cuius, suas an coniugis: si suas, ne fleret, si uxoris, ut iam non fleret. </p>
             </div>
 
-            <div type="schol" n="356-357">
+            <div type="schol" n="356">
                <p> (SOLVE METVS ANIMO DABITVR MIHI CREDE) MERENTVM / CONSILIIS (TRANQVILLA DIES) eorum consiliis, qui merentur imperia gubernare, dabitur mihi regnum: desiste, inquit, de maerore meo esse sollicita. Bene sic coepit, quia uxor hoc se solum timere dixerat, quod pro ipso faceret. </p>
             </div>
 
-            <div type="schol" n="357-358">
+            <div type="schol" n="357">
                <p> TE FORTIOR ANNIS / (NONDVM CVRA DECET) ordo: te non decet cura, quae tuis annis est fortior. </p>
             </div>
 
-            <div type="schol" n="358-359">
+            <div type="schol" n="358">
                <p> SCIAT HAEC SATVRNIVS (OLIM / FATA PARENS) quod futurum sit, Iuppiter nouerit. </p>
             </div>
 
-            <div type="schol" n="359-360">
+            <div type="schol" n="359">
                <p> OCVLOSQVE POLO DIMITTERE (SI QVOS / IVSTITIA ET RECTVM TERRIS DEFENDERE CVRAT) sensus: haec ad Iustitiam cura pertineat, si tamen respicit terras. Id est: futura nostra sciant fata <supplied>et Iuppiter</supplied> et Iustitia, si reuera respicit terras aut homines curat. </p>
             </div>
 
@@ -3767,15 +3768,15 @@
                <p> FORS ADERIT LVX ILLA TIBI bonus ordo, ut metum coniugis in fine felicitatis promissionibus solaretur. </p>
             </div>
 
-            <div type="schol" n="364-366">
+            <div type="schol" n="364">
                <p> (TYDEA) ... / ... / ... (SOCERVMQVE) AFFATVR TRISTIS ADRASTVM ordo: Tydea et Adrastum affatur tristis. Cetera <foreign xml:lang="grc">διὰ μέσου</foreign> inserta sunt. </p>
             </div>
 
-            <div type="schol" n="367">
+            <div type="schol" n="367a">
                <p> FIT MORA CONSILIO id est: diu habito tractatu cunctati sunt ut multum cogitantibus placeret una sententia, id est: utrum bello an legatis regnum peteret Polynices? </p>
             </div>
 
-            <div type="schol" n="367-369">
+            <div type="schol" n="367b">
                <p> (CVM MVLTA MOVENTIBVS V)NA / (IA)M POTIOR CVNCTIS (SEDIT SENTENTIA FRATRIS / PERTEMPTARE FIDEM) id est: omnibus melior sententia placuit, Eteoclis fidem legatione temptare. </p>
             </div>
 
@@ -3783,7 +3784,7 @@
                <p> EA MVNERA legationis officium. </p>
             </div>
 
-            <div type="schol" n="373-374">
+            <div type="schol" n="373">
                <p> TVTIQVE REGRESSVS / LEGATO quod legatum nefas esset interfici. Sacrosancta enim sunt legationis officia, ut <supplied>inquit</supplied> Cicero, ut <hi rend="italic">etiam inter hostium tela</hi> incolumis uersaretur. </p>
             </div>
 
@@ -3791,11 +3792,11 @@
                <p> (ITER) SILVIS AC LITORE (DVRVM) id est siluis quae erant in litore, aut quia iter difficile est per siluas et litora. </p>
             </div>
 
-            <div type="schol" n="376-377">
+            <div type="schol" n="376">
                <p> (QVA LERNAEA PALVS AMBVSTAQVE SONTIBVS ALTE) / INTEPET HYDRA VADIS hic enim in Lerna palude Hydram Hercules igni perdomuit damnis capitum et uulneribus pullulantem. <hi rend="italic">Intepuit</hi> ideo quia, cum ferro uinci non posset, uulneribus est ignis admotus. Tepet ergo adhuc quasi flamma uictrici. </p>
             </div>
 
-            <div type="schol" n="377-378">
+            <div type="schol" n="377">
                <p> ET QVA VIX CARMINE RARO / (LONGA SONAT NEMEE NONDVM PASTORIBVS AVSIS) sensus: et quamuis Nemeaeum leonem constet Herculis uirtute prostratum, tamen prioris periculi metu<supplied>s</supplied> interrumpit pastorum timidas cantilenas. </p>
             </div>
 
@@ -3803,11 +3804,11 @@
                <p> QVA LATVS EOOS (EPHYRES QVOD VERGIT AD EVROS) Corinthi latus emensus est. Et orientem dixit <hi rend="italic">Eoos</hi> , occidentem <hi rend="italic">Euros</hi>.</p>
             </div>
 
-            <div type="schol" n="380">
+            <div type="schol" n="380a">
                <p> SISYPHIIQVE SEDENT PORTVS cum inter duo maria montem positum Sisyphus crudeli latrocinio occupasset — hac enim poena mortalium pascebatur, ut homines praegrauans ingenti saxo necaret — tandem ab accolis deorum lege punitus apud inferos saxi quod uoluit poenas exsoluit pondere. Portus Corinthus ex utraque parte duos habet, Sisypheum et Lechaeum, quos nunc poeta commemorat. </p>
             </div>
 
-            <div type="schol" n="380-381">
+            <div type="schol" n="380b">
                <p> IRATAQVE TERRAE / (CVRVA PALAEMONIO SECLVDITVR VNDA LECHAEO) Isthmon significat, ubi se Ino cum Palaemone praecipitauit. <hi rend="italic">Lechaeum</hi> uero promuntorium Corinthiorum. </p>
             </div>
 
@@ -3830,7 +3831,7 @@
                <p> QVERITVRQVE FIDEM (TAM SERO REPOSCI) oratorie Eteocles in suum fratrem transtulit crimen, quod tunc demum Polynices deposcat imperium. Dolet ergo, quod cessantibus legatis tam sero frater uicissitudinis fidem reposcat, quod iam dudum negare potuisset, uel quod tardius ei perpetrandi parricidii detur occasio. </p>
             </div>
 
-            <div type="schol" n="&lt;391&gt;">
+            <div type="schol" n="391">
                <p> 
                   <supplied>RVDIS FANDI</supplied> militaribus armis imbutus ordinem ac modum orationis ignorat. </p>
             </div>
@@ -3839,7 +3840,7 @@
                <p> IVSTIS MISCENS TAMEN ASPERA COEPIT non blanda locutus est, quae possent persuadere, sed aspera, quae magis ad iram accenderent. Et ostendit Tydeum uirum fortem militiae magis quam eloquentiae operam tribuisse. </p>
             </div>
 
-            <div type="schol" n="393-394">
+            <div type="schol" n="393">
                <p> SI TIBI PLANA FIDES (ET DICTI CVRA MANERET / FOEDERIS) quia, ut supra edoctum est, hoc iurauerant fratres, ut annis singulis imperium gubernarent. Ergo queritur, quod contra legem aut sacramentum germano negaret regnum. </p>
             </div>
 
@@ -3851,7 +3852,7 @@
                <p> PACTAE TANDEM S(VCCEDERET) A(VLAE) hoc est inter uos partitae, quam ex pacto debitam accipere iam debebat. </p>
             </div>
 
-            <div type="schol" n="399-400">
+            <div type="schol" n="399">
                <p> SED QVIA DVLCIS AMOR REGNI (BLANDVMQVE POTESTAS / POSCERIS) id est: sed quia omnibus dulce est regnum, ultro rogaris. Non dixit 'quod Polynices cupiditate regnandi coactus est te rogare', ne uideretur illi maledicere, sed dicit hoc uitium generale esse. Aut certe illud exsequitur 'ignoscimus tibi, quod cupiditate regnandi minime imperium exuisti, nam hoc uitium commune est omnium'. Generalia enim uitia ueniam facillime promerentur. Vt Lucanus:</p> 
                <l>'quicquid multis peccatur, inultum est'.</l>
             </div>
@@ -3881,19 +3882,19 @@
                <p> TENVEM (... ANNVM) in quo tenuis fuit et inops. </p>
             </div>
 
-            <div type="schol" n="408-409">
+            <div type="schol" n="408">
                <p> MONEO (REGNORVM GAVDIA TEMET / DEDOCEAS PATIENSQVE FVGAE MEREARE REVERTI) iucunda conclusio. Moneo, inquit, ut regnorum gaudia sponte dediscas et, dum pateris te aula recedere, propter hanc ipsam patientiam dignus esse dicaris qui recipias dignitatem. Qui enim sponte non reddit, cum ui perdiderit, qua audebit fronte repetere? (PATIENSQVE FVGAE) MEREARE REVERTI id est: ut sis exemplo fratri<del>s</del> et tu profugus <del>et</del> inde <supplied>mere</supplied>aris ad regnum redire. </p>
             </div>
 
-            <div type="schol" n="410-411">
+            <div type="schol" n="410">
                <p> (AST ILLI TACITO SVB PECTORE DVDVM) / IGNEA CORDA FREMVNT more peccantum, qui audire uera non possunt. </p>
             </div>
 
-            <div type="schol" n="412-414">
+            <div type="schol" n="412">
                <p> CVI SVBTER INANES / (LONGA SITIS LATEBRAS TOTVMQVE AGITATA PER ARTVS / CONVOCAT IN FAVCES ET SQVAMEA COLLA VENENVM) id est: quasi serpens diu sub concauis terrarum latebris perpessa sitim atrocius gerebat uenenum. (TOTVMQVE AGITATA PER ARTVS) / CONVOCAT IN FAVCES (... VENENVM) uirus ex omnibus artubus colligit in fauces et <hi rend="italic">in fauces</hi> proprie, quia et hic contrario eiecturus est uenena uerborum. </p>
             </div>
 
-            <div type="schol" n="415-420">
+            <div type="schol" n="415">
                <p> COGNITA SI DVBIIS (FRATRIS MIHI IVRGIA SIGNIS / ANTE FORENT NEC CLARA ODIORVM ARCANA PATERENT / SVFFICERET VEL SOLA FIDES QVA TORVVS ET ILLVM MENTE GERENS ... / ... / PRAEFVRIS) sensus: si mihi essent iurgia fratris incognita, orationis tuae prosecutione, qualis erga me esset futurus, agnoscerem. NEC CLARA ODIORVM (ARCANA PATERENT) quod aperte ostendit suum odium contra me. <del>SVFFICERET VEL SOLA FIDES id est: nisi fratris in me odia et orationis tuae furorem agnoscerem, ad reddenda, quae reposcis, potui fide compelli.</del> 
                   <del>QVA<del>M</del> TORVVS</del> quoniam deest iusta defensio, loquendi tantum inuenitur occasio. Vt in Terentio ualidae propositioni lenonis quia respondere adolescens non potuit, minatus est caedem. Leno enim dixerat: </p>
                <lg>
@@ -3908,7 +3909,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="418-420">
+            <div type="schol" n="418">
                <p> (CEV SAEPTA NOVVS IAM MOENIA) LAXET / (FOSSOR ET HOSTILES INIMICENT CLASSICA TVRMAS / PRAEFVRIS) <supplied>
                      <hi rend="italic">laxet</hi>
                   </supplied> commoueat, diruat. Talem se gerit, quasi iam teneat urbis statum et euertat. FOSSOR <hi rend="italic">fossores</hi> dicuntur in exercitu cuniculatores, qui cuniculos faciunt per quos ingressi milites murorum fundamenta conuellunt. Dicit ergo Tydei orationem illi tempori conuenire quo ista fiunt. Ideo ait <hi rend="italic">praefuris</hi> id est ante furis, cum adhuc quae dixerat non agantur. Hucusque ergo principii tenditur sensus: si quid de iurgiis fratris odiisque dubitarem, <hi rend="italic">sufficeret</hi> mihi <hi rend="italic">fides</hi>, <hi rend="italic">qua praefuris</hi> 
@@ -3919,17 +3920,17 @@
                <p> AVT REFVGO PALLENTES SOLE GELONOS <hi rend="italic">refugo</hi> deuio, quia dicuntur Scythae, quos nunc Gelonos appellat, non habere aeris temperamenta, quia longe a sole submoti sunt. Hi sub septentrione degunt, ad quos sol uix peruenit: ideo <hi rend="italic">pallentes</hi>.</p>
             </div>
 
-            <div type="schol" n="422-423">
+            <div type="schol" n="422">
                <p> (PARCIOR ELOQVIO) ET MEDII REVERENTIOR AEQVI / (INCIPERES) <supplied>
                      <hi rend="italic">medii ... aequi</hi>
                   </supplied> nihil enim magis <hi rend="italic">medium</hi> quam iustitia est. Considerata ergo reuerentia iustitiae parcior esses alloquio. </p>
             </div>
 
-            <div type="schol" n="423-424">
+            <div type="schol" n="423">
                <p> NEC TE FVRIBVNDAE (CRIMINE MENTIS / ARGVERIM) id est non te arguo propter crimina mentis tuae. Agnosco enim fratris esse, quaecumque tua prosecutione complecteris. </p>
             </div>
 
-            <div type="schol" n="425-426">
+            <div type="schol" n="425">
                <p> (NEC SCEPTRA FIDE NEC) PACE SEQVESTRA / (POSCITIS ET PROPIOR CAPVLO MANVS) <supplied>
                      <hi rend="italic">pace sequestra</hi>
                   </supplied> id est media. ET PROPIOR CAPVLO MANVS hoc dicendo significauit ad bellum potius esse uicinos, cum regna magis debuerint fide reposcere. Vnde quidam in principio hoc accipiunt non absurde: 'sufficeret uel sola fides'. </p>
@@ -3943,23 +3944,23 @@
                <p> QVAE SORS IVSTA MIHI <hi rend="italic">iusta</hi>, quia maior natu erat. Et ideo dicit se priorem regnare debuisse quippe natu maiorem. Licet placitum fuisse dixerimus ut uicissim imperium gubernarent, tamen sorte perfectum est ut aliquis primus acciperet potestatem. Sed oratorie Eteocles, quoniam scit in sorte esse casum, non iudicium, stringit ad hoc, ut merito accidisse uideatur, non fortuito. Ideo ait <hi rend="italic">iusta</hi>.</p>
             </div>
 
-            <div type="schol" n="430-431">
+            <div type="schol" n="430">
                <p> TE PENES (INACHIAE DOTALIS REGIA DONO / CONIVGIS) ordo: te penes est regia Inachiae dono coniugis. </p>
             </div>
 
-            <div type="schol" n="431-432">
+            <div type="schol" n="431">
                <p> DANAAE (... / ... CVMVLENTVR OPES) <supplied>
                      <hi rend="italic">opes</hi>
                   </supplied> quas Argi<del>u</del>a possideat. Hoc autem ideo dictum ut doceat fratrem habere quod repetit. (QVID ENIM MAIORIBVS ACTIS) / INVIDEAM nolo enim uerbis maioribus cumulare, ne uidear inuidere. </p>
             </div>
 
-            <div type="schol" n="433">
+            <div type="schol" n="433a">
                <p> LERNAMQVE REGAS Amymone, Danai filia, dum studiose in silua iaculo exerceretur, imprudens Satyrum percussit. Et eam cum Satyrus uiolare uellet, illa Neptuni implorauit auxilium. Quod cum Neptunus uidisset, fugato Satyro ipse eam compressit. Ex quo coitu natus est Nauplius, pater Palamedis. Vnde Vergilius prosapiem repetens ait:</p> 
                <l>'Belidae nomen Palamedis'.</l> 
                <p>Neptunus uero cuspide dicitur locum in quo Amymonen compresserat percussisse. Vnde cum aqua flueret, Lernaeus fons dictus est et fluuius Amymone. </p>
             </div>
 
-            <div type="schol" n="433-434">
+            <div type="schol" n="433b">
                <p> HORRIDA DIRCES / (PASCVA) memor poeta superiorum. Nam ait:</p>
                <lg>
                   <l>'dumque uter angustae squalentia iugera Dirces</l>
@@ -3967,7 +3968,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="435-436">
+            <div type="schol" n="435">
                <p> NON INDIGNATI (MISERVM DIXISSE PARENTVM / OEDIPODEN) oratorie disputat, quasi Polynices indignetur felicitate elatus. Sensus ergo: et licet miserum Oedipum non tamen indignor patrem uocare. </p>
             </div>
 
@@ -3985,11 +3986,11 @@
                <p> HVNC ... LAREM exiguum et pauperem. </p>
             </div>
 
-            <div type="schol" n="440-442">
+            <div type="schol" n="440">
                <p> (QVAM ...) OFFENDAT <del>ET</del> SOCER ILLE SENEX quam superbam et indignaturam talem socerum dicit. </p>
             </div>
 
-            <div type="schol" n="442-443">
+            <div type="schol" n="442">
                <p> IAM PECTORA VVLGI (ADSVEVERE IVGO) tertia causa ualidior, quare non reddat imperium, in fine est collocata non sine aliqua specie ueritatis: certatur magnae commendationis scaena. Dicit enim perfidum se uelle dici, dummodo suis ciuibus prosit. </p>
             </div>
 
@@ -3997,16 +3998,16 @@
                <p> PLEBISQVE PATRVMQVE more Romano locutus est, ut primo plebem diceret, post patres. </p>
             </div>
 
-            <div type="schol" n="&lt;445&gt;">
+            <div type="schol" n="445">
                <p> 
                   <supplied>DVBIO PIGEAT PARERE TYRANNO</supplied> successori imperium seruire non pati<supplied>a</supplied>tur. Et in primo ideo querelam populi induxit posse <supplied>se</supplied> ambos perdere. </p>
             </div>
 
-            <div type="schol" n="446">
+            <div type="schol" n="446a">
                <p> REGNVM BREVE id est breuis administrator. </p>
             </div>
 
-            <div type="schol" n="446-447">
+            <div type="schol" n="446b">
                <p> QVANTVS / HORROR (ET ATTONITI NOSTRO IN DISCRIMINE CIVES) cum de me agitur. Quasi Thebani timere coepissent, si Polynici redderetur imperium. </p>
             </div>
 
@@ -4014,15 +4015,15 @@
                <p> (HOSNE EGO) QVIS CERTA EST (SVB TE DVCE) POENA RELINQVAM id est: hos tibi ego ad supplicium tradam, si tamen fueris adeptus imperium, quibus certa est poena meritorum? Merentur enim supplicia, quod mihi paruerint. </p>
             </div>
 
-            <div type="schol" n="449-451">
+            <div type="schol" n="449">
                <p> FAC VELLE (NEC IPSI / ... PATRES / REDDERE REGNA SINENT) fac me regnum ad fratrem uelle transducere, ciues non sinent. </p>
             </div>
 
-            <div type="schol" n="452-453">
+            <div type="schol" n="452">
                <p> (REDDES) / INGEMINAT REDDES Tydeus tantum hac inuidia orationis egit, ut, licet legatus esset, iuste tamen mereretur occidi. </p>
             </div>
 
-            <div type="schol" n="453-456">
+            <div type="schol" n="453">
                <p> NON SI TE FERREVS AGGER / (AMBIAT AVT TRIPLICES ALIO TIBI CARMINE MVROS / AMPHION AVDITVS AGAT NIL TELA NEC IGNES / OBSTITERINT) nec tibi blandiaris, quod sis firmissimo muro uallatus. Quicquid enim obuium fuerit, superabitur nostra uirtute. <supplied>AMPHION</supplied> Amphion, Iouis et Antiopae filius, lyrae carminibus ad Thebanos aedificandum muros dicitur saxa duxisse. </p>
             </div>
 
@@ -4030,23 +4031,23 @@
                <p> (CAPTIVO MORIBVNDVS HVMVM) DIADEMATE PVLSES oratorie, ut infelicior poena sit mori cum dignitate quam fraude possedit. </p>
             </div>
 
-            <div type="schol" n="458-460">
+            <div type="schol" n="458">
                <p> AST HORVM MISERET (QVOS SANGVINE VILES / CONIVGIBVS NATIBVSQVE INFANDA AD PROELIA RAPTOS / PROICIS EXCIDIO) <supplied>
                      <hi rend="italic">horum</hi>
                   </supplied> ciuium scilicet tuorum. Conciliauerat sibi Eteocles omnium animos militum, quos rursus Tydeus omnes infensos regi facit, dum dicit ipsum causam esse bellorum. QVOS SANGVINE VILES ad mortem faciles. Vt Vergilius:</p> 
                <l>'nos animae uiles'. </l>
             </div>
 
-            <div type="schol" n="462-464">
+            <div type="schol" n="462">
                <p> (NEC CRIMINA GENTIS / MIRA EQVIDEM DVCO SIC PRIMVS) SANGVINIS AVCTOR / (INCESTIQVE PATRVM THALAMI) primum auctorem generis Oedipum dicit. Nam cuius atrocitatem deprehendimus, maiorum uituperationem ad exaggerandum inuehimus. Vt Vergilius:</p> 
                <l>'Laomedontiadae, bellumne inferre paratis?'</l>
             </div>
 
-            <div type="schol" n="464-465">
+            <div type="schol" n="464">
                <p> SED FALLIT ORIGO / (OEDIPODIS TV SOLVS ERAS) ex dissimilitudine et bonitate morum Polynices Oedipi filius non putatur. </p>
             </div>
 
-            <div type="schol" n="465-466">
+            <div type="schol" n="465">
                <p> HAEC PRAEMIA MORVM / (AC SCELERIS) id est poenas et captiuitatem tuorum. </p>
             </div>
 
@@ -4058,7 +4059,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="467-468">
+            <div type="schol" n="467">
                <p> (HAEC AVDAX ETIAMNVM IN LIMINE) RETRO / VOCIFERANS sensus: haec, cum egrederetur, dicebat, respectans in limine. </p>
             </div>
 
@@ -4086,11 +4087,11 @@
                <p> CALYDONIVS HEROS propria ratio Tydeo. <hi rend="italic">Calydonius</hi> propter patriam, mores, et tegimentum. </p>
             </div>
 
-            <div type="schol" n="482-483">
+            <div type="schol" n="482">
                <p> NEC PIGER INGENIO (SCELERVM FRAVDISQVE NEFANDAE / RECTOR EGET) id est qui semper sollers fuit et peritus scelerum. Quia inuidiose aggressus fuerat Eteoclen Tydeus legatus missus a Polynice, inde iam cogitat, quemadmodum insidias praeparet. </p>
             </div>
 
-            <div type="schol" n="486-487">
+            <div type="schol" n="486">
                <p> ET SANCTVM (POPVLIS PER SAECVLA NOMEN / LEGATVM) definitio legati. Et cum exclamatione pronuntiandum. Vt sensum exaggerationis adiuuaret, <hi rend="italic">sanctum</hi> legationis <hi rend="italic">nomen</hi> adiecit. </p>
             </div>
 
@@ -4098,13 +4099,13 @@
                <p> QVID REGNIS NON VILE <del>PVTAT</del> indignatio poetae auxesin fecit. Dicit enim: quid non uile ducit regnandi cupiditas? </p>
             </div>
 
-            <div type="schol" n="489-490">
+            <div type="schol" n="489">
                <p> (O CAECA NOCENTVM / CONSILIA) O SEMPER TIMIDVM SCELVS <supplied>
                      <hi rend="italic">caeca</hi>
                   </supplied> quia insidiis agitur et hoc ideo <hi rend="italic">timidum</hi>. Antequam fiat, de potentia aduersantis, <hi rend="italic">timidum</hi> post, de conscientia, iuxta Tullium dicentem: 'ut nihil timeant, qui nihil commiserint, et poenam semper ante oculos uersari putent, qui peccauerint'. TIMIDVM SCELVS quod nisi a timentibus non committitur. Sed utrum hoc ad Eteoclen refert, qui sceleratus est, quia Tydeum timet, an ad illos quinquaginta, quos ideo parauerat, quia timebat? Denique hoc sequitur: </p>
             </div>
 
-            <div type="schol" n="490-491">
+            <div type="schol" n="490">
                <p> EXIT IN VNVM / PLEBS FERRO (IVRATA CAPVT) ut sit catalogus. EXIT IN VNVM quia scelus commissuri pauci timebant, idcirco plures armauerat; <hi rend="italic">plebs</hi> autem dixit, ut inuidiam numero hoc nomine compararet. At contra unius Tydei caput <hi rend="italic">plebs ... iurata</hi> consurgit. </p>
             </div>
 
@@ -4112,7 +4113,7 @@
                <p> MACTE ANIMI (TANTIS DIGNVS QVI CREDERIS ARMIS) laus Tydei, cuius uirtus non unius insidiantis dexteram poscit. </p>
             </div>
 
-            <div type="schol" n="496">
+            <div type="schol" n="496a">
                <p> FERT VIA PER DVMOS (PROPIOR ... CALLE LATENTI) hoc est: ducit <supplied>uia</supplied> compendiosior latente calle. Vt Vergilius:</p>
                <lg>
                   <l>'olli per dumos, qua proxima meta uiarum,</l>
@@ -4121,7 +4122,7 @@
                <p>Topographia. </p>
             </div>
 
-            <div type="schol" n="496-497">
+            <div type="schol" n="496b">
                <p> QVA CALLE LATENTI / (PRAECELERANT DENSAEQVE LEGVNT COMPENDIA SILVAE) docet per compendium insidiatores praecessisse. </p>
             </div>
 
@@ -4145,11 +4146,11 @@
                <p> HIC FERA QVONDAM Sphinga<del>m</del> dicit, quae in hoc aliquando insederat saxo. </p>
             </div>
 
-            <div type="schol" n="506">
+            <div type="schol" n="506a">
                <p> ERECTA GENAS erectas genas habens. </p>
             </div>
 
-            <div type="schol" n="506-507">
+            <div type="schol" n="506b">
                <p> SVFFVSAQVE TABO / LVMINA eorum cruore, quos occiderat, orbes oculorum habens suffusos. </p>
             </div>
 
@@ -4158,18 +4159,18 @@
                <l>'concretos sanguine crines'. </l>
             </div>
 
-            <div type="schol" n="511">
+            <div type="schol" n="511a">
                <p> INEXPLICITIS inexplicabilibus siue obscuris. </p>
             </div>
 
-            <div type="schol" n="&lt;511-512&gt;">
+            <div type="schol" n="511b">
                <p> 
                   <supplied>AVT COMMINVS IRE VIATOR / AVDEAT ET DIRAE COMMERCIA IVNGERE LINGVAE</supplied> uicibus habens confabulationem. Vt Vergilius:</p> 
                <l>'uarioque uiam sermone leuabant'.</l> 
                <p>COMMERCIA aenigmatis illius, quod Sphinx proposuit. <hi rend="italic">Commercium</hi> autem proprie est mutare inuicem aut emere uel uendere. Hic nunc iucunde deriuauit <hi rend="italic">commercium</hi>, ut diceret audire uoces et reddere. </p>
             </div>
 
-            <div type="schol" n="513-515">
+            <div type="schol" n="513">
                <p> (NEC MORA) QVIN ACVENS (EXSERTOS PROTINVS VNGVES / LIVENTISQVE MANVS FRACTOSQVE IN VVLNERA DENTES / TERRIBILI APPLAVSV CIRCVM HOSPITA SVRGERET ORA) <supplied>
                      <hi rend="italic">nec mora</hi>
                   </supplied> si non soluisset propositam quaestionem. LIVENTISQVE MANVS peremptorum scilicet cruore perfusas. TERRIBILI APPLAVSV alarum sonitu. Vt Vergilius:</p>
@@ -4241,15 +4242,15 @@
                <p> OLENII TEGMEN SVIS Olenos Aetoliae regio est, in qua sus Calydonius dicitur interemptus, cuius exuuiis Tydeus nunc tegitur et armatur. </p>
             </div>
 
-            <div type="schol" n="542-543">
+            <div type="schol" n="542">
                <p> SVPER LAEVOS HVMEROS (VICINA CRVORI / EFFVGIT) id est: super sinistri humeri partem hasta imminens paene uulnus inuenit. </p>
             </div>
 
             <div type="schol" n="543">
                <p> VIDVO ... LIGNO cuspide: ab ea parte quae ferro caret ac per hoc infirma. Metaphora a muliere: ut quae auxilio mariti caret infirma est, ita lignum quod non habet ferrum unde uulnus infligat infirmum est. </p>
-            </div>
+            <lg/></div>
 
-            <div type="schol" n="545-546">
+            <div type="schol" n="545">
                <p> (PALLENTIAQVE) IRA (ORA) <supplied>
                      <hi rend="italic">pallentia</hi>
                   </supplied> furore, non metu. </p>
@@ -4267,15 +4268,15 @@
                <p> HOS DEIRE IVGIS anastrophe: hos de iugis ire. </p>
             </div>
 
-            <div type="schol" n="553-554">
+            <div type="schol" n="553">
                <p> VT CLAVSAS INDAGINE PROFERT / IN MEDIVM (VOX PRIMA FERAS) haec comparatio ad superiora referenda est. Dicit enim sic illos aut de iugis prodisse aut creuisse de uallibus, quemadmodum de retibus ferae quas in medium uox uenantum et clamor expellit. Tunc enim licet scire quam multae sint, cum terrore clamoris coactae fuerint non latere. Est ergo ordo: sic illos excursare e latebris uidet ut clausas indagine feras uox prima in medium profert. <hi rend="italic">Indago</hi> autem est, cum siluam uenantum corona uallat ut ferae euadere non possint. </p>
             </div>
 
-            <div type="schol" n="554-555">
+            <div type="schol" n="554">
                <p> QVAE SOLA MEDENDI / TVRBATA RATIONE VIA EST id est quae sola uia salutis est: in hostes incidentem ardua petere. </p>
             </div>
 
-            <div type="schol" n="556-557">
+            <div type="schol" n="556">
                <p> ET ABSCISIS (INFRINGENS CAVTIBVS VNCAS / EXSVPERAT IVGA DVRA MANVS) ordo est: et abscisis cautibus infringens uncas manus iuga dura exsuperat. </p>
             </div>
 
@@ -4283,7 +4284,7 @@
                <p> VNDE PROCVL TERGO METVS (ET VIA PRONA NOCENDI) qui locus esset facilior ad nocendum et a periculo defenderet terga pugnantis. Hoc est: de longe esset timor, ne a tergo circumueniretur. In quo saxo stans interim post se hostes timere non poterat. </p>
             </div>
 
-            <div type="schol" n="559-560">
+            <div type="schol" n="559">
                <p> QVOD VIX PLENA CERVICE (GEMENTES / VERTERE HVMO MVRISQVE VALENT INFERRE IVVENCI) bene et <hi rend="italic">iuuenci</hi> et <hi rend="italic">plena ceruice</hi>. Bona auxesis: ut aetati robur adiungeret. </p>
             </div>
 
@@ -4295,7 +4296,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="563-564">
+            <div type="schol" n="563">
                <p> QVALIS IN ADVERSOS LAPITHAS (EREXIT INANEM / MAGNANIMVS CRATERA PHOLVS) Lapithae, gens Thessaliae omnium uirium sublimis patientia, cum ceteris diis immortalibus annua sacra conficerent, in ipsa religione genus sacrilegii commissum est. Cum enim Pirithoi, regis sui, nuptiae celebrarentur et sacrificia diis omnibus facerent, Martis solius aras incultas reliquerunt; siue ignorantia seu contemptu numinis, habetur incertum. Quae res manifesto punita est exitu. Mars namque fecit ut aduersus Centauros bellarent, a quibus uicti sunt. Ciuitas damno intellexit religionis uirtutem. Vnde Vergilius:</p>
                <lg>
                   <l>'Mars perdere gentem</l>
@@ -4303,26 +4304,26 @@
                </lg>
             </div>
 
-            <div type="schol" n="564-565">
+            <div type="schol" n="564">
                <p> STVPET OBVIA LETO / (TVRBA) iam a comparatione discessit et ad factum Tydei redit. Potest enim ambiguitas circumuenire lectorem. </p>
             </div>
 
-            <div type="schol" n="&lt;570-571&gt;">
+            <div type="schol" n="570">
                <p> 
                   <supplied>NEQVE ENIM TEMNENDA IACEBANT / FVNERA</supplied> in honorem occidentis laudantur occisi. TEMNENDA aphaeresis pro <hi rend="italic">contemnenda</hi>.</p>
             </div>
 
-            <div type="schol" n="573">
+            <div type="schol" n="573a">
                <p> TERRIGENAS CONFISVS AVOS qui gloriaretur auos se promeruisse terrigenas, de Cadmi sationibus originem ducens, qui mutuis uulneribus perierunt. </p>
             </div>
 
-            <div type="schol" n="573-574">
+            <div type="schol" n="573b">
                <p> (NEC VERTERE CVIQVAM / FRENA) SECVNDVS (HALYS) <supplied>
                      <hi rend="italic">secundus</hi>
                   </supplied> inferior, id est equitandi arte peritus. </p>
             </div>
 
-            <div type="schol" n="575-576">
+            <div type="schol" n="575">
                <p> PENTHEVMQVE TRAHENS (NONDVM TE PHAEDIMVS AEQVO / BACCHE GENVS) <supplied>
                      <hi rend="italic">Pentheumque trahens ... genus</hi>
                   </supplied> id est a Pentheo originem generis trahens.</p>
@@ -4338,15 +4339,15 @@
                <p> ORBEM scutum obuolutum. Bene subdidit <hi rend="italic">orbem</hi>. Sunt enim scuta oblongae facturae. </p>
             </div>
 
-            <div type="schol" n="583-584">
+            <div type="schol" n="583">
                <p> (TERGOQVE ET VERTICE) TEGMINA NOTA / (SAEPTVS) id est: terga sua et caput muniit apri Calydonii tegmine. </p>
             </div>
 
-            <div type="schol" n="586">
+            <div type="schol" n="586a">
                <p> OGYGIDAE Thebani, ab Ogygio terrigena. </p>
             </div>
 
-            <div type="schol" n="586-588">
+            <div type="schol" n="586b">
                <p> (TRAHIT OCIVS) ENSEM / BISTONIVM TYDEVS (MAVORTIA MVNERA MAGNI / OENEOS) unde Tydeo Bistonius ensis, nisi quia Oeneus Martis est filius? Primum quia uicina est Aetolia Thraciae, aut quia Mars apud Bistonas colitur. <hi rend="italic">Ensem</hi> uero <hi rend="italic">Bistonium</hi> Thracium dixit, quia Bistonia gens Thraciae est. </p>
             </div>
 
@@ -4362,7 +4363,7 @@
                <p> ANGVSTVS TELIS optime dixit <hi rend="italic">angustus</hi>, id est qui aditum uulneribus non daret. INEXPVGNABILIS quia uni in multos facilis iactus est, multis in unum difficilis. Sallustius in Iugurthino: 'pauci in pluribus minus frustrabantur'. </p>
             </div>
 
-            <div type="schol" n="595-596">
+            <div type="schol" n="595a">
                <p> NON ALITER ... / (ARMATVM IMMENSVS BRIAREVS STETIT AETHERA CONTRA) Briareum bello Gigantum constat cum Ioue sensisse. Sed hic <hi rend="italic">contra</hi> sic posuit, quemadmodum Vergilius:</p> 
                <l>'Iouis cum fulmina contra'</l> 
                <p>et ut Terentius:</p> 
@@ -4371,11 +4372,11 @@
                <l>'Aegaeon qualis, centum cui bracchia dicunt'. </l>
             </div>
 
-            <div type="schol" n="595">
+            <div type="schol" n="595b">
                <p> PHLEGRAE Phlegra regio est Macedoniae, in qua Terra Gigantes procreauit. </p>
             </div>
 
-            <div type="schol" n="598-599">
+            <div type="schol" n="598">
                <p> 
                   <del>INDE</del> PELETHRONIAM (... PINVM / MARTIS) <supplied>
                      <hi rend="italic">Pelethroniam</hi>
@@ -4389,7 +4390,7 @@
                <l>'et nudus membra P(yracmon)'. </l>
             </div>
 
-            <div type="schol" n="600-601">
+            <div type="schol" n="600">
                <p> (TOTO) NEQVIQVAM (OBSESSVS OLYMPO / TOT QVERITVR CESSARE MANVS) aut nequiquam obsessus aut nequiquam queritur multitudini manuum suarum hostes deesse, cum fuerit uictus. </p>
             </div>
 
@@ -4397,7 +4398,7 @@
                <p> HVC ILLVC CLIPEVM (OBIECTANS) circumspectat omnes partes, ne ab hostibus circumuentus occumbat. </p>
             </div>
 
-            <div type="schol" n="604-605">
+            <div type="schol" n="604">
                <p> (SPICVLA DEVELLENS CLIPEO QVAE PLVRIMA TOTO / FIXA TREMVNT) ARMANTQVE VIRVM nam ipsa in hostes retorquet. <supplied>CLIPEO</supplied> quo ali<supplied>en</supplied>orum telorum impetus retunditur, cum in tela impingit. Lucanus:</p> 
                <l>'totaeque uiro dant tela ruinae'. </l>
             </div>
@@ -4414,7 +4415,7 @@
                <p> PROCIDIT IMPVLSV (NIMIIS CONATIBVS INFANS) dicit illum furore genitum, non dolore. Dum enim Dryope, mater eius, praegnans furore bacchatur, reluctantem taurum cornibus traxit. Dicit ergo hunc non nascendi ordine procreatum, sed conatu nimio utero matris expulsum. </p>
             </div>
 
-            <div type="schol" n="620-621">
+            <div type="schol" n="620">
                <p> VNVSNE VIRI (TOT CAEDIBVS VNVS / IBIT OVANS ARGOS) Vergilius:</p>
                <lg>
                   <l>'unus homo et uestris, o ciues, undique saeptus</l>
@@ -4430,39 +4431,39 @@
                <p> TEVMESIA CORNVS Thebana. Teumeson mons est Thebanorum. Ideo Tydeus Thebana hasta, quia spoliis hostium armatus exstiterat. </p>
             </div>
 
-            <div type="schol" n="625-626">
+            <div type="schol" n="625">
                <p> ATQVE ILLI VOCE REPLETA / (INTERCEPTA NATAT PRORVPTO IN SANGVINE LINGVA) ordo: atque illi uoce intercepta prorupto in sanguine natat repleta lingua. </p>
             </div>
 
-            <div type="schol" n="629-630">
+            <div type="schol" n="629">
                <p> (VOS QVOQVE THESPIADAE) CVR INFITIATVS HONORA / ARCVERIM FAMA cur uos <hi rend="italic">arcuerim</hi> id est priuauerim? HONORA ... FAMA id est honesta, honorifica. </p>
             </div>
 
-            <div type="schol" n="631-632">
+            <div type="schol" n="631">
                <p> (NIL) INDOLE CLARIVS ILLA / (NEC PIETATE FVIT) <hi rend="italic">indolem</hi> corporis dixit, <hi rend="italic">pietatem</hi> animi. </p>
             </div>
 
-            <div type="schol" n="633-634">
+            <div type="schol" n="633">
                <p> SINGVLTIBVS ARTVM / (... THORACA) angustum. Singultibus enim angustatur latus. </p>
             </div>
 
-            <div type="schol" n="634">
+            <div type="schol" n="634a">
                <p> EXHAVRIT concauum facit id est uacuat. </p>
             </div>
 
-            <div type="schol" n="634-635">
+            <div type="schol" n="634b">
                <p> NEC VINCLA COERCENT / (VNDANTEM FLETV GALEAM) inundatio lacrimarum galeae uincula rumpebat. </p>
             </div>
 
-            <div type="schol" n="635-638">
+            <div type="schol" n="635">
                <p> CVM MVLTA GEMENTI / (PONE GRAVIS CVRVAS PERFRINGIT LANCEA COSTAS / EXIT ET IN FRATREM COGNATAQVE PECTORA TELO / CONSERIT) cum multa gemeret, a tergo percussus est et hostili telo corpori fratris affixus. CONSERIT coniungit. </p>
             </div>
 
-            <div type="schol" n="638-639">
+            <div type="schol" n="638">
                <p> ILLE OCVLOS (ETIAMNVM IN LVCE NATANTES / SISTIT ET ASPECTA GERMANI MORTE RESOLVIT) qui prior fuerat uulneratus, <supplied>oculos</supplied> aperuit, ut in utraque morte fratrum ambo lugerent se inuicem morientes. </p>
             </div>
 
-            <div type="schol" n="642-643">
+            <div type="schol" n="642">
                <p> (MISERABILE) VOTVM / MORTIS uotum iniquae mortis, quia et uno telo <del>et</del> gemini et eodem momento periere. </p>
             </div>
 
@@ -4470,11 +4471,11 @@
                <p> (PROTINVS) IDEM VLTRO coepit iam ipse ultro hostes insequi, a quibus ante appetebatur. </p>
             </div>
 
-            <div type="schol" n="645-646">
+            <div type="schol" n="645">
                <p> (TREPIDIS) VESTIGIA RETRO / (PASSIBVS VRGENTEM) sua retro uestigia urgebat fugiendo imminente Tydeo. </p>
             </div>
 
-            <div type="schol" n="646-647">
+            <div type="schol" n="646">
                <p> INIQVA / (... HVMO) quae fuerat sanguine madefacta. Hic autem <hi rend="italic">iniqua</hi> proprie 'inaequali' dixit. </p>
             </div>
 
@@ -4513,7 +4514,7 @@
                <p> QVID TIMIDE SEQVERIS COMPENDIA VITAE iucunde consolatur et terret. Namque hoc pollicetur nullum, si bella uenerint, euasurum. In hac autem parte si consideres, prouisum tibi est quod nunc moreris, ne grauiori supplicio reserueris. </p>
             </div>
 
-            <div type="schol" n="659">
+            <div type="schol" n="659a">
                <p> BELLA MANENT Lucanus:</p>
                <lg>
                   <l>'non hoc ciuilia bella,</l>
@@ -4521,11 +4522,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="659-660">
+            <div type="schol" n="659b">
                <p> (CRASSVM SANGVINE TELVM) / IAM REDIT corpore iam reuulsum telum. Neque enim poterat gladium uagina recondere nisi hoste iam perempto. </p>
             </div>
 
-            <div type="schol" n="661-663">
+            <div type="schol" n="661">
                <p> (NON HAEC) TRIETERICA (VOBIS / NOX PATRIO DE MORE VENIT NON ORGIA CADMI / CERNITIS) dixerat enim ea nocte Tydeum Thebas intrasse qua Libero patri sacra celebrantur. <hi rend="italic">Trieterica</hi> ergo et <hi rend="italic">orgia</hi> Liberi sacra sunt, quae exacto triennio mos est celebrari, sicut Olympiaci Iouis sacrum redit intermisso quinquennio. </p>
             </div>
 
@@ -4539,11 +4540,11 @@
                <l>'pellibus in morem cincti'. </l>
             </div>
 
-            <div type="schol" n="665">
+            <div type="schol" n="665a">
                <p> IMBELLEM AD SONITVM tympani et saltationis Baccharum imbellis. MARIBVSQVE INCOGNITA VERIS in comparatione Thebanorum <hi rend="italic">ueris maribus</hi> dicit. </p>
             </div>
 
-            <div type="schol" n="665-666">
+            <div type="schol" n="665b">
                <p> INCOGNITA ... / ... PROELIA luxuriosae saltationis. Quasi hi qui aduersum se pugnauerunt sacrorum consuetudine fuerint effeminati. </p>
             </div>
 
@@ -4569,7 +4570,7 @@
                <l>'perdiderat uultum rabies'. </l>
             </div>
 
-            <div type="schol" n="673-674">
+            <div type="schol" n="673">
                <p> (CRVENTIS) / RORIBVS cruentis aspersionibus. Vt Lucanus:</p> 
                <l>'sanguineis stillauit roribus arbor'. </l>
             </div>
@@ -4579,14 +4580,14 @@
                <l>'Massylique ruunt equites'. </l>
             </div>
 
-            <div type="schol" n="677-678">
+            <div type="schol" n="677">
                <p> ET TABE GRAVATAE / (IVBAE) <hi rend="italic">tabes</hi> dicitur recentis cadaueris foetor — Lucanus:</p> 
                <l>'longusque in carcere foetor'</l> 
                <p>— et humor, qui destillans cadaueribus corrumpit terram. Vnde Vergilius:</p> 
                <l>'et terram tabo maculant'. </l>
             </div>
 
-            <div type="schol" n="682-683">
+            <div type="schol" n="682">
                <p> (ILLE ETIAM THEBAS SPOLIIS) ET SANGVINE PLENVS / (ISSET) sensus hic de Homero uenit, ut tunc demum castris Dolonis Diomedes excedat, cum esset admonitus a Minerua. Nam Vergilius hunc sensum in Nisi et Euryali personis seruauit:</p> 
                <l>'acceleremus, ait, nam lux inimica propinquat'. </l>
             </div>
@@ -4595,11 +4596,11 @@
                <p> (MVLTAQVE OPERIS) CALIGINE PLENVM id est nimia felicitate mentis obcaecatum. <hi rend="italic">Caliginem</hi> dixit: quae non prospiciebat futura pericula. </p>
             </div>
 
-            <div type="schol" n="687-688">
+            <div type="schol" n="687">
                <p> (ABSENTES CVI DVDVM) VINCERE THEBAS/ (ADNVIMVS) nam in istis quinquaginta, quod omnes lectissimae uirtutis fuerant, absentes uictae sunt Thebae. </p>
             </div>
 
-            <div type="schol" n="688-689">
+            <div type="schol" n="688">
                <p> (NIMIVMQVE SECVNDIS) / PARCE DEIS nam qui immoderate sua felicitate utitur, fauentes sibi deos fatigat. Elatus enim animus rebus secundis utilia minime respicit. Vergilius:</p> 
                <l>'et seruare <supplied>modum</supplied> rebus lassata secundis'.</l> 
                <p>HVIC VNA FIDES (OPTANDA LABORI) ut tantae uirtutis gloriam solus consecutus fuisse uidearis. </p>
@@ -4609,7 +4610,7 @@
                <p> AEROS genitiuus Graecus est ut 'Memnon, Memnonos'. </p>
             </div>
 
-            <div type="schol" n="694-695">
+            <div type="schol" n="694">
                <p> NEC VERITVS (PROHIBERE DVCEM SED FATA MONENTEM / PRIVAVERE FIDE) hoc dicit: nec ueritus est hic augur prohibere ducem, id est Eteoclen, ne morituros tot mitteret, sed instantia morituris fata fidem augurii derogauerunt. Vt Vergilius:</p>
                <lg>
                   <l>'tunc etiam fatis aperit Cassandra futuris</l>
@@ -4634,7 +4635,7 @@
                <p> TALES IN BELLA VENIMVS et in Romana historia hoc Porsennae Mucius dixisse fertur, cum eius dextera focis imposita diceret suae patientiae similes uiros atque uirtutis a senatu plures in eius exitium destinatos. </p>
             </div>
 
-            <div type="schol" n="710-712">
+            <div type="schol" n="710">
                <p> HVIC LEVES GALEAS (PERFOSSAQVE VVLNERE CREBRO / INSERIT ARMA FERENS HVIC TRVNCOS ICTIBVS ENSES / SVBLIGAT ET TRACTAS MEMBRIS SPIRANTIBVS HASTAS) in hoc consecrando Vergilium secutus est. Nam ille, dum Marti offerret exuuias, ait:</p>
                <lg>
                   <l>'aptat rorantes sanguine cristas</l>
@@ -4656,13 +4657,13 @@
                   </supplied> crudelior fit. Zeu<supplied>g</supplied>ma. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718">
                <p> (NEC MAGIS ARDENTES MAVORS) HASTATA(QVE PVGNAE IMPVLERIT BELLONA TVBAS) <supplied>
                      <hi rend="italic">hastata</hi>
                   </supplied> hastis armata siue hastifera, id est: magis tu bellicosa quam Mars aut Bellona. IMPVLERIT pro 'impellit'. Mutauit modum. </p>
             </div>
 
-            <div type="schol" n="720-721">
+            <div type="schol" n="720">
                <p> SEV PANDIONIO ... / (MONTE) Pandionium montem dicit a Pandione, filio Ericthonii. Tereus, Martis filius, Thrax <supplied>
                      <gap/>
                   </supplied>
@@ -4697,7 +4698,7 @@
                <p>Nam Meleager Martis <supplied>fuit</supplied> filius. PLEVRON Aetoliae ciuitas prope Calydonem, Marti consecrata. Alii regionem Calydoniorum dicunt. <del>PLEVRON MARTIA quia ibi maxime Mars colitur</del>.</p>
             </div>
 
-            <div type="schol" n="728-731">
+            <div type="schol" n="728">
                <p> AVREA (TVNC MEDIIS VRBIS TIBI TEMPLA DICABO / COLLIBVS IONIAS QVA DESPECTARE PROCELLAS / DVLCE SIT ET FLAVO TOLLENS VBI VERTICE PONTVM / TVRBIDVS OBIECTAS ACHELOVS ECHINADAS EXIT) cum in media urbe tibi aedem dicauero, in tantum templi altitudo tolletur ut et Ionium mare et Echinadas insulas Acheloumque despicias. Harum insularum Lucanus meminit:</p>
                <lg>
                   <l>'et tuus, Oeneu,</l>
@@ -4711,19 +4712,19 @@
                   <del>HIC EGO</del> MAIORVM PVGNAS maiorum sui generis scilicet. </p>
             </div>
 
-            <div type="schol" n="733-734">
+            <div type="schol" n="733">
                <p> (FIGAMQVE SVPERBIS) / ARMA THOLIS Vergilius:</p> 
                <l>'suspendiue tholo'.</l> 
                <p>
                   <hi rend="italic">Tholus</hi> est in media templi camera locus in quo uouentium primitiae aut exuuiae figebantur. </p>
             </div>
 
-            <div type="schol" n="737">
+            <div type="schol" n="737a">
                <p> ACTAEAS (FACES) Athenienses, quia Athenarum iuxta litus sita sunt secreta nemorum loca. Vt Vergilius:</p> 
                <l>'in sola secreta Troades acta'. </l>
             </div>
 
-            <div type="schol" n="737-738">
+            <div type="schol" n="737b">
                <p> ET AB ARBORE CASTA / (NECTENT PVRPVREAS NIVEO DISCRIMINE VITTAS) <del>oliua siue lauro. Pro inuentore id quod inuentum est. Nam casta non est olea, sed Minerua. Aliter:</del> castam arborem dixit, quae post quinquennium Athenis Mineruae offerebatur <supplied>ob libera</supplied> tam pestilentia ciuitatem, quam <foreign xml:lang="grc">εἰρεσιώνην</foreign> nominant, in qua omnium frugum pomorumque primitias obligabant, ut Cratinus ait. Hanc igitur castam arborem dicit in qua purpureis nexibus omnia supra dicta pendebant, quae tamen interiectis duobus pedibus candida fila discriminant. </p>
             </div>
 
@@ -4731,20 +4732,20 @@
                <p> (ARCANVM) NVNQVAM INSPECTVRA PVDOREM <hi rend="italic">arcanum ... pudorem</hi> dicit <del>aut</del> eius simulacrum uerum, id Palladium, quod illicitum erat cernere. Quo quidam quondam uiso priuatus est uisu <del>aut uirginitatem eius</del>. ergo, si sic est, <hi rend="italic">inspectura</hi> pro 'rimatura' uel 'inquisitura' accipitur. </p>
             </div>
 
-            <div type="schol" n="741-742">
+            <div type="schol" n="741">
                <p> TV BELLIS TV PACE FERES (DE MORE FREQVENTES / PRIMITIAS OPERVM) <del>bellorum potens, quod proprium est ei</del>. NON INDIGNANTE DIANA semper tibi de primitiis sacrificabo, nec mihi, sicut solet, Diana indignabitur. Occulte historiam tangit, ubi Diana contempta in sacrificio immisit aprum qui Calydoniam regionem uastaret. </p>
             </div>
 
          </div>
 
-         <div type="lib" n="III">
+         <div type="lib" n="3">
             <head>LIBER III</head>
 
             <div type="pr" n="pr">
                <p>Conquestio Eteoclis de tarditate quinquaginta missorum. Maeonis aduentus et caedis indicium. Indignatio regis. Mors Maeonis et eius a rege interdicta sepultura. Profectio lugentium matrum ad locum caedis et cadauerum funeratio. De Thebanis malis conquestio et regis iniustitia. Iouis imperium Marti ut Thebana bella suscipiat. Veneris querela apud Martem de Thebanis. Martis responsio pro Thebanis. Regressio Tydei uulnerati et eius hortatio ad bellum. Polynicis allocutio pro iniuria Tydei <supplied>et</supplied> affectiones obliquae. Curatio Tydei. Descriptio solis occidentis et orientis noctis. Descriptio Martis bellum mouentis. Captatio auguriorum ab Amphiarao et Melampode in monte Aphesan<supplied>te</supplied> et omnium signorum descriptio. Allocutio Capanei iniuriosa contra Amphiaraum et religionem. Argiae apud patrem allocutio et belli postulatio. Patris responsio permulcentis.</p>
             </div>
 
-            <div type="schol" n="1-4">
+            <div type="schol" n="1">
                <p> (AT NON AONIAE MODERATOR) PERFIDVS (AVLAE / NOCTE SVB ANCIPITI QVAMVIS VMENTIBVS ASTRIS / LONGVS AD AVRORAM SVPERET LABOR OTIA SOMNI / ACCIPIT) <supplied>
                      <hi rend="italic">perfidus</hi>
                   </supplied> aut quia regnum negauit aut quia contra ius gentium legato parauit insidias. Docet enim poeta malorum conscientiam esse peruigilem, quippe Eteocles, quamuis adhuc stellis labor supersit ut ascenso axe perueniatur ad lucem, tamen otia somni non accepit. Ouidius in libro secundo, ubi describit Inuidiam:</p>
@@ -4760,7 +4761,7 @@
                <p>(NOCTE SVB) ANCIPITI uel propter noctem ancipitem, cum ipse anceps esset, uel <hi rend="italic">ancipiti</hi> media. Notanda figura anacoluthon. Secundum Sallustium: 'qua nocte ipse fiebat anceps'. </p>
             </div>
 
-            <div type="schol" n="4-5">
+            <div type="schol" n="4">
                <p> (INVIGILANT ANIMO) SCELERISQVE PARATI / (SVPPLICIVM EXERCENT CVRAE) prima enim sceleris nostri poena est cogitatio. Vt Iuuenalis:</p>
                <lg>
                   <l>'prima haec est ultio, quod se</l>
@@ -4781,7 +4782,7 @@
                <p> NVM REGIO DIVERSA VIAE proponit sibi quod fieri potuit aliter quam ipse mandauerat. Ideo autem laudandus Tydeus, quia quod fecit nec metuens potuerit suspicari. </p>
             </div>
 
-            <div type="schol" n="10-11">
+            <div type="schol" n="10">
                <p> AN SCELERIS DATA F(AMA) P(ER) V(RBES) / (FINITIMAS) <supplied>
                      <hi rend="italic">sceleris</hi>
                   </supplied> id est uiolatae legationis sanctimoniae, uel quod religiosum officium legati peteretur insidiis. Tertium quod suspicatur tale est: dicit quippe a finitimis ciuitatibus Tydeo aduersus insidiantes esse subuentum. </p>
@@ -4791,7 +4792,7 @@
                <p> ET CHROMIS ET DORYLAS Dorylas saxo periit inter illos quos uno ictu dicit esse prostratos. Chromis inter sacra uulnere prostratus occubuit. </p>
             </div>
 
-            <div type="schol" n="17-18">
+            <div type="schol" n="17">
                <p> HEV SEGNES (QVORVM LABOR HAERET IN VNO / SI CONSERTA MANVS) uere segnes, si conflixerunt et ab uno uincuntur. </p>
             </div>
 
@@ -4810,13 +4811,13 @@
                <p>Sensus: frustra nauigare compulit Olenii astri purior gradus. <supplied>OLENII</supplied> Arcadii, quod ibi fuerit capra quae Iouem nutriuit, Amalthea. </p>
             </div>
 
-            <div type="schol" n="26-27">
+            <div type="schol" n="26">
                <p> (OMNIA MVNDI) CLAVSTRA TONANT <supplied>
                      <hi rend="italic">claustra</hi>
                   </supplied> cardines dixit <del>quia uoluuntur</del>. Vt: 'intonuere poli'. </p>
             </div>
 
-            <div type="schol" n="&lt;27&gt;">
+            <div type="schol" n="27">
                <p> 
                   <supplied>MVLTVSQVE POLOS INCLINAT ORION</supplied> et quasi conuersum polum facit pondere congregatarum niuium. INCLINAT ORION Iuppiter et Neptunus, cum ad Oenopionem regem in hospitium uenissent et ab eo liberaliter recepti fuissent, optionem dederunt ut, siquid uellet, ab eis exposceret. Ille liberos sine coniuge postulauit. Cui Neptunus et Iuppiter imperauerunt, ut tauri corium, quem eis immolauerat, terrae infoderet. Illi in eo urinam fecere, unde natus est Orion. Qui cum Dianae stuprum inferret, illa Terrae ope scorpionem uindicem sumpsit, quem occisum Iuppiter in caelum transtulit. Simili modo et Diana uindicem suum inter sidera collocauit. — mensis ergo Ianuarii tempus poeta describit, quo Orion in occasu est constitutus. </p>
             </div>
@@ -4829,11 +4830,11 @@
                <p> (SEROS) MAERENTIBVS INCREPAT (ORTVS) aut sollicitis, quibus maerore nox geminari uidetur, aut maerentibus dictis. </p>
             </div>
 
-            <div type="schol" n="34-35">
+            <div type="schol" n="34">
                <p> (VBI PRIMVM MAXIMA TETHYS / IMPVLIT EOO CVNCTANTEM) HYPERIONA PONTO cum primum <supplied>o</supplied>c<supplied>e</supplied>ano sol exit. Ex Hyperione autem Graeci fabularum scriptores stulte natos esse finxerunt uenerabiles deos, Solem et Lunam, pariter et Auroram, sperantes ueluti stolidi homines quia fallaciis super horum numinum natiuitate posset fides offerri ab his qui <supplied>non</supplied> nouerunt nec mundum nec diem sine Sole Lunaque esse potuisse a primordiis rerum nec tanta lumina utero fuisse gestata. Hyperiona ergo non, ut Graeci fingunt, Titanis filium accipiendum, sed simplicitate Latina explicandum est ambiguum Graecitatis: Hyperiona dicunt 'super omnia saecula'. </p>
             </div>
 
-            <div type="schol" n="36-37">
+            <div type="schol" n="36">
                <p> IMA FLAGELLATIS (... / PONDERIBVS TREPIDAVIT HVMVS) dicunt physici quod suis fixa ponderibus in aere librata pendeat tellus. Et omne graue cum pendet, si motum habeat, flagellatur. Ergo terra cum in medio fuerat aere librata, motum passa est, suis flagellata ponderibus. </p>
             </div>
 
@@ -4845,15 +4846,15 @@
                <p> ET PROPE SVNT CAVSAE quibus prodigia ista contigere. </p>
             </div>
 
-            <div type="schol" n="41-42">
+            <div type="schol" n="41">
                <p> (TRISTIS MORTE NEGATA) / HAEMONIDES hic est quem Tydeus, ut uictoriae suae testis esset, non est dignatus occidere. </p>
             </div>
 
-            <div type="schol" n="42-43">
+            <div type="schol" n="42a">
                <p> DVBIVSQVE NOTARI / (SIGNA DABAT MAGNAE LONGE MANIFESTA RVINAE) tempus diei significauit et noctis, quo difficile hominis uultus ad perfectum potuisset agnosci. Sensus: quamuis per obscurum nuntius agnosci non posset, quid tamen nuntiaturus esset, manifestis agnouerant signis. </p>
             </div>
 
-            <div type="schol" n="[&lt;42-44&gt;]">
+            <div type="schol" n="42b">
                <p> 
                   <del>
                      <supplied>NECDVM ORA PATENT DVBIVSQVE NOTARI / SIGNA DABAT MAGNAE LONGE MANIFESTA RVINAE / PLANCTVQVE ET GEMITV</supplied> id est: quis esset adhuc ignorabatur et tamen quid nuntiaret habitus et gestus eius prodiderat.</del>
@@ -4872,7 +4873,7 @@
                <p> (AMISSOS LONGO CIET ORDINE) TAVROS comparatione<del>m</del> hero<supplied>es</supplied> tauros dixit, <del>aut</del> quia solent tauros lupi uincere. </p>
             </div>
 
-            <div type="schol" n="55-57">
+            <div type="schol" n="55">
                <p> TOLLVNT / CLAMOREM (QVALIS BELLO SVPREMVS APERTIS / VRBIBVS AVT PELAGO IAM DESCENDENTE CARINA) tantum clamorem tulerunt, quantus fit in ciuitate ab hostibus capta aut naufragio iam carinam mergente. </p>
             </div>
 
@@ -4887,12 +4888,12 @@
                <l>'namque uolans <supplied>rubra</supplied> fuluus Iouis ales in aethra'. </l>
             </div>
 
-            <div type="schol" n="67-68">
+            <div type="schol" n="67">
                <p> (PLACITOQVE) IGNARA MOVERI / ATROPOS quae ab his, quae semel mortalibus statuit, moueri non possit. Vt Vergilius:</p> 
                <l>'Fortuna omnipotens et ineluctabile F(atum)'. </l>
             </div>
 
-            <div type="schol" n="69-71">
+            <div type="schol" n="69">
                <p> PRODIGA VITAE / PECTORA (ET EXTREMAM NIHIL HORRESCENTIA MORTEM / ASPICIAS) <supplied>
                      <hi rend="italic">prodiga</hi>
                   </supplied> quemadmodum fortunarum prodigus dicitur, qui patrimonium decoquit, ita et uitae prodigus, qui non terretur exitio, sed uitam prodigere uult id est effundere. Pectora autem dixit nihil horrescentia. ASPICIAS utar, inquit, libertate, qua non utitur, nisi qui mori paratus est. Vt Vergilius:</p> 
@@ -4900,7 +4901,7 @@
                <p>Et hoc clamore pronuntiandum. Hic enim uerbis satisfacit dolori suo peritura libertas. </p>
             </div>
 
-            <div type="schol" n="&lt;72&gt;">
+            <div type="schol" n="72">
                <p> 
                   <supplied>LEGES</supplied> aut ius legationis aut iura pietatis aut legationis leges. </p>
             </div>
@@ -4909,7 +4910,7 @@
                <p> GLISCIS hic 'cupis' significat. Id est: cupiditatis tuae crescit incendium. </p>
             </div>
 
-            <div type="schol" n="75-77">
+            <div type="schol" n="75">
                <p> TE DIRO HORRORE VOLANTES / Q(VINQVAGINTA) A(NIMAE) (CIRCVM NOCTESQVE DIESQVE / ADSILIENT) integer se oculis tuis ingeret numerus occisorum. Et dicendo <hi rend="italic">quinquaginta animae</hi> se quoque optima uirtute iunxit occisis. VOLANTES quasi circa ora tua uolabunt <del>et ingerent se oculis tuis</del>. Sapientes dicunt nocentium esse poenas, si quasdam figuras cum uiderint, timeant. Vt Vergilius:</p> 
                <l>'omnibus umbra locis adero',</l> 
                <p>et ut ostenderet hoc sceleratorum esse supplicium, adiecit:</p> 
@@ -4920,15 +4921,15 @@
                <p> ET NON CVNCTATOR INIQVI qui iniusta omnia poterat sine dubitatione complere. </p>
             </div>
 
-            <div type="schol" n="80-81">
+            <div type="schol" n="80">
                <p> (IRE MANVQVE) / PROTVRBARE (PARANT) ne conuiciaretur regi aut se certe iuste percuteret. </p>
             </div>
 
-            <div type="schol" n="82-83">
+            <div type="schol" n="82">
                <p> ET NVNC TRVCIS ORA TYRANNI / (NVNC FERRVM ASPECTANS) quasi utrumque aspiciens, quid esset fugiendum, quid dulcius uideretur, ferrum aut tyrannus. </p>
             </div>
 
-            <div type="schol" n="84-85">
+            <div type="schol" n="84">
                <p> IMPERDITA TYDEO / PECTORA id est quae Tydeus noluisset occidere. Vt:</p> 
                <l>'et uos, o Grais imperdita corpora, Teucri'. </l>
             </div>
@@ -4942,11 +4943,11 @@
                <l>'incipit effari mediaque in uoce resistit'. </l>
             </div>
 
-            <div type="schol" n="88-89">
+            <div type="schol" n="88">
                <p> DOLORI / PVGNAT contra dolorem repugnat, ne putaretur sentire cum moritur. </p>
             </div>
 
-            <div type="schol" n="92-93">
+            <div type="schol" n="92">
                <p> TVRBATAQVE MVSSANT / (CONCILIA) bene <hi rend="italic">mussant</hi>, quia nulla loquendi libertas est sub tyranno. Vt Vergilius:</p>
                <lg>
                   <l>'cuncti se scire fatentur,</l>
@@ -4962,13 +4963,13 @@
                <p> (NON LONGVM REDVCEM) LAETATI non diu gauisi quod rediit, quia se statim peremit. </p>
             </div>
 
-            <div type="schol" n="97-98">
+            <div type="schol" n="97">
                <p> PACEMQVE SEPVLCRI / (IMPIVS IGNARIS NEQVIQVAM MANIBVS ARCET) quia dixit inquietam illis fore animam, qui ferro pereunt aut insepulti remanent. NEQVIQVAM bene <hi rend="italic">nequiquam</hi>, quia secundum Epicurum nihil mortui sentire uidentur. Vnde Vergilius:</p> 
                <l>'facilis iactura sepulcri'.</l> 
                <p>Quorundam enim opinio est animas cum corporibus interire, ut Lucretius. Iuxta hos homini sepultura nihil prodest. </p>
             </div>
 
-            <div type="schol" n="99-100">
+            <div type="schol" n="99">
                <p> (NEC VMQVAM / ...) PASSVRE SITVM obliuionis mala minime patieris. Vnde Vergilius:</p>
                <lg>
                   <l>'si quid mea carmina possunt,</l>
@@ -4976,7 +4977,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="100-102">
+            <div type="schol" n="100">
                <p> (QVI COMMINVS AVSVS / VADERE CONTEMPTVM REGES QVAQVE AMPLA VENIRET / LIBERTAS) SANCIRE VIAM uiam dedisti, per quam contemnendo regiam potestatem ad libertatis possimus insignia peruenire. </p>
             </div>
 
@@ -4984,27 +4985,27 @@
                <p> LAVRO ... SVA propter Daphnen, cuius arborem aeternum uiuere uoluit pro perpetuitate amoris sui. </p>
             </div>
 
-            <div type="schol" n="106-107">
+            <div type="schol" n="106">
                <p> ET NEMORVM DODONA PARENS (CIRRHAEAQVE VIRGO / AVDEBIT TACITO SVSPENDERE PHOEBO) in Chaonia regione, quae pars est Epiri, Dodonaei Iouis templum esse dicitur notum numinis reuerentia, ubi duae columbae fuisse dicuntur sedentes super duas quercus et responsa dantes, exprimentes in mutis animalibus quod homo adorare uellet. Et postea una earum transuolauit <supplied>ad</supplied> Delphos, quae ciuitas in regione Boeotiae est iuxta Parnassum montem eiusdem regionis, ibique Delphici Apollinis oraculo opinionem parauit. Altera Hammonis Iouis templum in Africa tenuit. <del>Dodonaeum igitur fuit oraculum Iouis in Epiro, ubi de quercu columba hominibus responsa dabat.</del> SVSPENDERE sollicitos facere. Vt Vergilius:</p> 
                <l>'suspensum numine ducit'.</l> 
                <p>Sensus: otia habebunt oracula te mortuo, hoc est: propter tuum interitum conticescent. </p>
             </div>
 
-            <div type="schol" n="109-110">
+            <div type="schol" n="109">
                <p> ELYSIAS (I CARPE PLAGAS VBI MANIBVS AXIS / INVIVS OGYGIIS) hunc solum de Thebanis dicit Elysios promeruisse campos, ceterum pro meritis scelerum nullam ad Elysios campos animam Thebanam peruenire. </p>
             </div>
 
-            <div type="schol" n="112-113">
+            <div type="schol" n="112">
                <p> (IACENTEM) / ET NEMVS ET TRISTIS VOLVCRVM REVERENTIA SERVAT aut quae mortuo exhibetur reuerentia, aut quod ore prohibebantur attingere. </p>
             </div>
 
-            <div type="schol" n="116-117">
+            <div type="schol" n="116">
                <p> QVISQVE SVAS (AVIDI AD LACRIMAS MISERABILE CVRRVNT / CERTAMEN) ad suas quisque lacrimas, id est quas de suis habituri sunt. Et est <supplied>
                      <hi rend="italic">currunt</hi>
                   </supplied> uerbum sine praepositione. Vt Sallustius: 'radicem montis accessit'. </p>
             </div>
 
-            <div type="schol" n="117-118">
+            <div type="schol" n="117">
                <p> (QVOS DENSA GRADV COMITANTVR EVNTES / MILIA) SOLANDI STVDIO quorum licet nemo fuisset occisus, tamen solandi gratia sequebantur. </p>
             </div>
 
@@ -5041,11 +5042,11 @@
                <p> (SQVALENTEM) SVBLATA COMAM squalentem comam sublatam habens. </p>
             </div>
 
-            <div type="schol" n="137">
+            <div type="schol" n="137a">
                <p> TERROR INEST LACRIMIS id est: prae dolore luctus coeperat esse terrori. Sexus oblita quippe uirorum fortium mater durauerat. </p>
             </div>
 
-            <div type="schol" n="137-139">
+            <div type="schol" n="137b">
                <p> (PER ET ARMA ET CORPORA PASSIM / CANITIEM IMPEXAM DIRA TELLVRE) VOLVTANS / (QVAERIT INOPS NATOS) pathos: dolores a facto. </p>
             </div>
 
@@ -5079,11 +5080,11 @@
                <p> LACRIMISQVE OCVLI (PATVERE PROFVSIS) obducuntur enim oculorum uisus humore lacrimarum. Qui, ubi profusus fuerit, reddit aspectum. </p>
             </div>
 
-            <div type="schol" n="152">
+            <div type="schol" n="152a">
                <p> TVOR pro 'intueor'. </p>
             </div>
 
-            <div type="schol" n="152-153">
+            <div type="schol" n="152b">
                <p> (VOS) EXTREMO IN FINE LIGAVIT / (INGENIVM CRVDELE NECIS) memor poeta superioris descriptionis. Ait enim:</p>
                <lg>
                   <l>'exit et in fratrem cognataque pectora ferro</l>
@@ -5099,7 +5100,7 @@
                <p> (OGYGIAS TITVLIS) ANTEIRE PARENTES Nioben specialiter tangit. </p>
             </div>
 
-            <div type="schol" n="157-159">
+            <div type="schol" n="157">
                <p> (AT QVANTO MELIVS) DEXTRAQVE IN SORTE (IVGATAE / QVIS STERILES THALAMI NVLLOQVE VLVLATA DOLORE / RESPEXIT LVCINA DOMVM) <supplied>
                      <hi rend="italic">dextra</hi>
                   </supplied> prospera. QVIS STERILES THALAMI quibus thalami infecundi. NVLLOQVE VLVLATA (DOLORE) / ... LVCINA <del>dea</del> id est non inuocata parturientibus prae dolore. Vt Terentius:</p> 
@@ -5107,7 +5108,7 @@
                <p>Quanto melius, inquit, cum illis agitur quae propter sterilitatem suam non subiacent orbitati. </p>
             </div>
 
-            <div type="schol" n="159-160">
+            <div type="schol" n="159">
                <p> (MIHI QVIPPE MALORVM) / CAVSA LABOR mire dixit ut liberos cum labore genuisse uideatur, quos cernit exstinctos. Laboraui ergo ut infelix fierem. IN LVCE PATENTI publice, honesto interitu. Quia nocte occubuerunt nec luce pugnantes, ubi uirtus potuisset uideri. <del>Alii: querela quod inglorii nocte perierunt.</del>
                </p>
             </div>
@@ -5116,7 +5117,7 @@
                <p> AETERNAQVE (GENTIBVS) quae essent apud omnes gentes memorabilia. </p>
             </div>
 
-            <div type="schol" n="&lt;163&gt;">
+            <div type="schol" n="163">
                <p> 
                   <supplied>MORTEM OBSCVRAM</supplied> quia inter paucos nec in magno proelio concidistis aut quia nocte perempti fuistis. </p>
             </div>
@@ -5125,7 +5126,7 @@
                <p> ET SINE LAVDE quia non inter cuneos hostium nobilis est datus interitus. </p>
             </div>
 
-            <div type="schol" n="167-168">
+            <div type="schol" n="167">
                <p> INDISCRETIQVE (SVPREMIS / IGNIBVS) una uobis traditur sepultura, quos nec in morte fata discriminant. </p>
             </div>
 
@@ -5142,7 +5143,7 @@
                <l>'et pactae coniugis o(stro)'. </l>
             </div>
 
-            <div type="schol" n="176-178">
+            <div type="schol" n="176">
                <p> (IBI) GRANDIOR AEVO / (ANTE ROGOS DVM QVISQVE SVO NEQVIT IGNE REVELLI / CONCILIVM INFAVSTVM DICTIS MVLCEBAT ALETES) quo in loco Aletes aeuo grandior lugentibus ante rogos suos gemitus solabatur. </p>
             </div>
 
@@ -5157,11 +5158,11 @@
                <l>'sic quoque mutatis requiescent fetibus arua'. </l>
             </div>
 
-            <div type="schol" n="185">
+            <div type="schol" n="185a">
                <p> CONSEDIT corruit, consumpta est. </p>
             </div>
 
-            <div type="schol" n="185-187">
+            <div type="schol" n="185b">
                <p> NEQVE FVNEREA (CVM LAVDE POTITVS / INFELIX ATHAMAS TREPIDO DE MONTE VENIRET / SEMIANIMEM HEV LAETO REFERENS CLAMORE LEARCHVM) putabat se occiso filio Learcho Athamas gloriam consecuturum, quem prae furore feram putauit. Gloriabatur ergo insana mente uenationis euentu. DE MONTE de quo se Leucothea cum Palaemone praecipitauit in fluctus. </p>
             </div>
 
@@ -5169,7 +5170,7 @@
                <p> HIC GEMITVS THEBIS talis qualis nunc est quinquaginta hominum clade peremptis. </p>
             </div>
 
-            <div type="schol" n="189-190">
+            <div type="schol" n="189">
                <p> FVROREM / VICIT resipuit ad hoc solum, ut agnosceret orbitatem. </p>
             </div>
 
@@ -5177,7 +5178,7 @@
                <p> EXPAVIT quia adhuc causam nesciebat. </p>
             </div>
 
-            <div type="schol" n="191-193">
+            <div type="schol" n="191">
                <p> VNA DIES (SIMILIS FATO SPECIEQVE MALORVM / AEQVA FVIT QVA MAGNILOQVOS LVIT IMPIA FLATVS / TANTALIS) prope est ut haec infelicitas consolatione careat, si nihil unquam tale contigit. Ideo subdidit exemplum. Quia, ut Ouidius ait, Niobe Latonam coli uetabat in se cupiens transferre honorem numinis, quod illam in utroque sexu liberorum se iactabat fetibus anteire. <hi rend="italic">Tantalis</hi> autem Niobe, quia Tantali fuit filia. Filii Niobae hi: Archemorus, Antagoras, Tantalus, Phaedimus, Sipylos, Xenarchus, Epinicos, item filiae: Astycratia, Pelopia, Ch<del>e</del>loris, Cleodoxe, Ogime, Pthia, Neaera. </p>
             </div>
 
@@ -5205,20 +5206,20 @@
                <p> BINA PER INGENTES (STIPABANT FVNERA PORTAS) Thebae a ueteribus heptapylae sunt nominatae quia septem portis ambiebantur. Vt ostenderet Niobe<supplied>n</supplied> quattuordecim habuisse filios, ait: bina funera per singulas portas efferebant. Vt et hinc daretur intellegi Thebanam ciuitatem septem portarum exitu decoratam. </p>
             </div>
 
-            <div type="schol" n="201-203">
+            <div type="schol" n="201">
                <p> (NEC QVOD TIBI DELIA CASTOS / PROLAPSVM FONTES SPECVLA TEMERARE PROFANA / HEV DOMINVM INSANI NIHIL AGNOVERE) MOLOSSI Actaeonem dicit, qui mutatus in ceruum putatur quod Dianam nudam aspexerat, et a suis dicitur canibus laniatus. </p>
             </div>
 
-            <div type="schol" n="204-205">
+            <div type="schol" n="204">
                <p> (VERSO QVOD SANGVINE FLVXIT) / IN SVBITOS REGINA LACVS Dircen significat, quam Amphion et Zethus, Antiopae et Iouis filii, tauro uinxerunt, de cuius sanguine fons natus est eius nomine decoratus. </p>
             </div>
 
-            <div type="schol" n="205-206">
+            <div type="schol" n="205">
                <p> SIC DVRA SORORVM / (PENSA DABANT VISVMQVE IOVI) ideo, inquit, illa non fleo, quia patientius fertur, quod fato accidit. Nunc ergo quinquaginta isti regis uitio ceciderunt. Sic Cicero in Philippicis: 'multa autem impendere uidentur praeter naturam etiam praeterque fatum'. Ideoque poeta describit illud fatorum fuisse, hoc non. De qua re magna quaestio est. Sed si philosophiae inuestigemus arcana — si haec tamen talia credamus euenisse — reperire possumus hoc magis fato factum quam per Eteoclis insidias contigit. Quid enim deorum iracundiis extra fatum? Licet enim diis, qui ipsa fata senserunt, facere quod uelint, qui humanum genus hoc uinculo ligauerunt, non suas uoluntates atque licentias. Attamen si utrumque perpendas, et hoc et illud de fato euenisse cognoscis. Nam ut quinquaginta morerentur, per regis perfidiam contigit, et illa quae <supplied>de</supplied> regibus facta narrauit, de Dirce, de Niobe, de Pentheo, de Agaue, de Actaeone, etiam decretum fuisse poteramus agnoscere. Omne enim, quodcumque, fato moritur. Vt Vergilius:</p> 
                <l>'stat sua cuique dies'. </l>
             </div>
 
-            <div type="schol" n="&lt;207&gt;">
+            <div type="schol" n="207">
                <p> 
                   <supplied>PATRIAE TOT CVLMINA CIVIS</supplied> tamquam quae tegerent aut ornarent. </p>
             </div>
@@ -5239,7 +5240,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="220-221">
+            <div type="schol" n="220">
                <p> (FVRENTES) / BISTONAS ET GETICAS (... VRBES) gentes Thraciae crudelissimae, ob quam causam Mars esse de Thracia dicitur. Vt Vergilius:</p> 
                <l>'Gradiuumque patrem, Geticis qui praesidet aruis'. </l>
             </div>
@@ -5248,7 +5249,7 @@
                <p> FVLMINE CRISTATVM (GALEAE IVBAR) quod exibat de crista galeae infinitum luminis habens, eratque galea in morem fulminis cristis ornata. </p>
             </div>
 
-            <div type="schol" n="223-224">
+            <div type="schol" n="223">
                <p> (ARMAQVE IN AVRO) / TRISTIA quae quamquam essent aurea, tamen tristitia non carerent, ut esset terror in proelio. </p>
             </div>
 
@@ -5292,11 +5293,11 @@
                <p> NIGRAE infernae, quia bellorum. </p>
             </div>
 
-            <div type="schol" n="242">
+            <div type="schol" n="242a">
                <p> COLVS pensa. Notandum plurali numero declinatas. </p>
             </div>
 
-            <div type="schol" n="242-243">
+            <div type="schol" n="242b">
                <p> (MANET HAEC) AB ORIGINE MVNDI / (FIXA DIES BELLO) secundum illos qui dicunt nascente mundo praefinita esse hominum fata. </p>
             </div>
 
@@ -5318,16 +5319,16 @@
                <l>'di cuius iurare timent et fallere numen'. </l>
             </div>
 
-            <div type="schol" n="&lt;249-250&gt;">
+            <div type="schol" n="249">
                <p> 
                   <supplied>VERSASQVE SOLO SVPER INACHIA TECTA / EFFVNDAM TVRRES)</supplied> ut consoletur omnes, minatur Argiuis. Constat enim timorem periculi accipere solacium, si hoc non solus quicumque patiatur. </p>
             </div>
 
-            <div type="schol" n="250-251">
+            <div type="schol" n="250">
                <p> (STAGNA IN CAERVLA) VERRAM / (IMBRE SVPERIECTO) aut in mare traham aut diluuio conteram. </p>
             </div>
 
-            <div type="schol" n="253-254">
+            <div type="schol" n="253">
                <p> MORTALIA CREDAS / (PECTORA SIC CVNCTI VOCEM ANIMOSQVE TENEBANT) sic praecepto Iouis cuncta sunt territa numina ut crederentur esse mortalia. </p>
             </div>
 
@@ -5359,7 +5360,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="265-266">
+            <div type="schol" n="265">
                <p> (TVNC PECTORA SVMMO) / ACCLINATA IVGO (VVLTVMQVE OBLIQVA MADENTEM) <supplied>acclinata</supplied> incumbens. Venus super iugum uultum madentem lacrimis obliquum tenens, ut hoc habitu Martem in amorem suum magis magisque succenderet. </p>
             </div>
 
@@ -5379,7 +5380,7 @@
                <p> (HOC MIHI) LEMNIACAE DE TE MERVERE CATENAE quibus in Lemno deprensa cum Marte uincta fuit. Quamquam Veneris et Vulcani notissima fabula sit, breuiter tamen exinde pauca perstringam. Postquam filiabus Solis Venus amores immisit et singulae exitiali morbo detentae interiere, Vulcanus Mineruae consilio monile astu perfecit, nam consciam facti Mineruam indicant oculi Gorgonae, quos dicit poeta in illo monili gemmis insertos. Fecit ergo monile pulcherrimum infausti ominis, quod dedit Harmoniae cum Cadmo nuberet, cuius malo omine in dracones cum marito conuersa est. Deinde hoc monile Semele gestauit, quae fulminibus Iouis absumpta est. Inde habuit Ino, quae, a marito Athamante occiso per furorem uno ex filiis Learcho, cum alio, id est Palaemone, se praecipitauit in mare ut mariti insequentis uitaret insaniam. Post habuit Agaue et ipsa filium furore percussit. Hae omnes filiae Cadmi et Harmoniae fuerunt. Habuit et Iocasta, quae per errorem filio nupsit. Habuit et Argia, sed Eriphylae dedit, ut mariti proderet latebras. </p>
             </div>
 
-            <div type="schol" n="279-280">
+            <div type="schol" n="279">
                <p> (GAVDEAT ORNATVSQVE NOVOS IPSIQVE LABORET) / ARMA TIBI ut:</p> 
                <l>'Marti currumque rotasque uolucris'. </l>
             </div>
@@ -5421,22 +5422,22 @@
                </lg>
             </div>
 
-            <div type="schol" n="302">
+            <div type="schol" n="302a">
                <p> EXCIDĔRVNT propter metrum, ut:</p> 
                <l>'longa decem tulerunt fastidia menses'. </l>
             </div>
 
-            <div type="schol" n="302-303">
+            <div type="schol" n="302b">
                <p> PRIVS IN PATRVI (DEVS INFERA MERGAR / STAGNA ET PALLENTES AGAR EXARMATVS AD VMBRAS) prius perdam condicionem huius potestatis, quam aliquando mei sanguinis obliuiscar. </p>
             </div>
 
-            <div type="schol" n="[303]">
+            <div type="schol" n="303">
                <p> 
                   <del>EXARMATVS id est: prius perdam immortalitatem, quam mei generis obliuiscar.</del>
                </p>
             </div>
 
-            <div type="schol" n="304-305">
+            <div type="schol" n="304">
                <p> (SED NVNC FATORVM MONITVS MENTEMQVE) SVPREMI / (IVSSVS OBIRE PATRIS) <supplied>
                      <hi rend="italic">supremi</hi>
                   </supplied> summi. Vt Terentius:</p> 
@@ -5444,11 +5445,11 @@
                <p>Iureiurando confirmauerat se omnium meminisse, et superest ut queratur contra Thebanos aliquid moliri. Per uenialem statum excusat. Dicit enim se facere, sed coactum. </p>
             </div>
 
-            <div type="schol" n="305-306">
+            <div type="schol" n="305">
                <p> NEQVE ENIM VVLCANIA (TALI / IMPERIO MANVS APTA LEGI) nunquam enim ad haec potest mitti Vulcanus. Et opportune imbecillitatem obicit mariti, ut amorem Veneris in se transferret. </p>
             </div>
 
-            <div type="schol" n="310-311">
+            <div type="schol" n="310">
                <p> (SED NE MIHI CORDE SVPREMOS) / CONCIPE CARA METVS id est: nolo timeas excidia Thebanorum, qui non uincentur ita ut penitus pereant. </p>
             </div>
 
@@ -5456,11 +5457,11 @@
                <p> APERTO id est caelo.</p>
             </div>
 
-            <div type="schol" n="318">
+            <div type="schol" n="318a">
                <p> IRA IOVIS id est fulmen. </p>
             </div>
 
-            <div type="schol" n="318-319">
+            <div type="schol" n="318b">
                <p> SI QVANDO (NIVALEM / OTHRYN ET ARCTOAE GELIDVM CAPVT INSTITIT OSSAE) quoniam hi montes tam finguntur altissimi ut inter nubes potius delitescant. </p>
             </div>
 
@@ -5473,7 +5474,7 @@
                <p> TRISVLCA pro quadrisulca, quia fulmen ex quattuor consistit: aqua, igne, nube, uento. </p>
             </div>
 
-            <div type="schol" n="322-323">
+            <div type="schol" n="322">
                <p> (TERRITAT ... AVT DITIBVS AGRIS) / SIGNA DARE (AVT PONTO MISEROS INVOLVERE NAVTAS) ut signum det aut perituras esse fruges aut nauigantibus imminere naufragia. DITIBVS locupletibus, id est fertilibus. </p>
             </div>
 
@@ -5489,7 +5490,7 @@
                <p> STANT (FVLTI PVLVERE CRINES) horridi sunt, aut certe pleni sunt puluere. </p>
             </div>
 
-            <div type="schol" n="328-329">
+            <div type="schol" n="328">
                <p> (ORAQVE) RETRO / (SORBET ANHELA SITIS) maciem indicat, quasi retro eius facies ducta sit. </p>
             </div>
 
@@ -5497,17 +5498,17 @@
                <p> (TVNC QVOQVE LASSA TVMET VIRTVS MVLTVMQVE) SVPERBIT ideo dixit superbire <unclear>uirtutem, sicut animum uirtutemque</unclear> transcendat. </p>
             </div>
 
-            <div type="schol" n="&lt;334&gt;">
+            <div type="schol" n="334">
                <p> 
                   <supplied>PECTORE DESPECTO</supplied> quasi ad gloriam suae uirtutis despectet superato hoste pectus habere confossum, quem laus uictoriae et uicti gemitus consolantur. VACVA (... HARENA) quod in ea solus iacet. </p>
             </div>
 
-            <div type="schol" n="&lt;335&gt;">
+            <div type="schol" n="335">
                <p> 
                   <supplied>CRVDOSQVE VETAT SENTIRE DOLORES</supplied> omne quippe gaudium quod nimium est nostri nos facit immemores. </p>
             </div>
 
-            <div type="schol" n="336-338">
+            <div type="schol" n="336">
                <p> (MEDIAS ETIAM NON DESTITIT VRBES / QVICQVID ET) ASOPON (VETERESQVE INTERIACET ARGOS / INFLAMMARE ODIIS) <supplied>
                      <hi rend="italic">Asopos</hi>
                   </supplied> fluuius est Boeotiae. Dicit autem omne spatium quod inter Asopon et Argos interiacet in bellum Tydei inflammationibus excitatum. </p>
@@ -5519,11 +5520,11 @@
                   </supplied> Tydei relatione<supplied>m</supplied>.</p>
             </div>
 
-            <div type="schol" n="345-346">
+            <div type="schol" n="345">
                <p> (ET) FORTE VERENDVS / (CONCILIO PATER IPSE DVCES COGEBAT ADRASTVS) oeconomia opportuna. Quippe hoc actum est occasione concilii ne reuertenti Tydeo publicus deesset auditor. </p>
             </div>
 
-            <div type="schol" n="350-351">
+            <div type="schol" n="350">
                <p> (NVSQVAM PIETAS NON GENTIBVS) AEQVVM / FAS (AVT CVRA IOVIS) quia scelerati hac spe peccant, dum non sperant deos criminum uindices fore. Vnde Vergilius:</p> 
                <l>'contemptorque deum Mezentius'.</l> 
                <p>Nam sunt philosophi qui, cum uideant naturae mala necessitate res contrarias ac pessimas mundo parari, dicunt curam humanarum rerum penitus <supplied>deos</supplied> non habere. Vnde Vergilius Epicurum secutus ait:</p>
@@ -5537,14 +5538,14 @@
                <l>'Iuppiter, hospitibus nam te dare iura locuntur'. </l>
             </div>
 
-            <div type="schol" n="352">
+            <div type="schol" n="252a">
                <p> SAVROMATAS AVIDOS <hi rend="italic">Sauromatae</hi> populi sunt Scythiae ultra Pontum <del>sunt</del> uicini<del>s</del> sedibus Amazonarum, ad quos non peruenit potestas Romanorum. Vnde Iuuenalis:</p> 
                <l>'ultra Sauromatas fugere hinc libet'.</l> 
                <p>
                   <hi rend="italic">Sauromatas</hi> ergo Sarmatas dicit, genus hominum ad omne scelus paratissimum. </p>
             </div>
 
-            <div type="schol" n="352-353">
+            <div type="schol" n="352b">
                <p> (SERVATOREMQVE CRVENTVM) / BEBRYCII NEMORIS Pollux cum Argonautis ad Bebryciam appulsus est, cum eum Amycus Bebryciorum rex ad caestuum prouocasset certamen. Amycus autem hanc consuetudinem semper habuit, ut insidiaretur in Bebrycio nemore, ubi, si quis forte aduena deuolutus fuisset, ab eo caestibus prouocatus occumberet. Hunc Pollux eodem certamine superatum dicitur occidisse. Hic autem Amycus Neptuni et Melopes filius fuit, quem Pollucem diximus prostrauisse. Cuius mortem uindicaturi ciues cum Polluci instarent, Argonautae asserturi commilitonem suum in aciem processerunt uictoriamque Bebryciorum <del>con</del>tulerunt. Bebrycia autem Bithynia est. Vt Vergilius ad Daretis augendum uirtutis meritum dixit:</p>
                <lg>
                   <l>'qui se</l>
@@ -5560,7 +5561,7 @@
                <p> NOCTE DOLOQVE VIRI (NVDVM IGNARVMQVE LOCORVM) quantae occasiones periculorum fuerint, Tydeus exponit: nox, dolus, <supplied>nudus</supplied> ipse, inscius loci. </p>
             </div>
 
-            <div type="schol" n="&lt;359&gt;">
+            <div type="schol" n="359">
                <p> 
                   <supplied>NEQVIQVAM</supplied> et tam<supplied>en</supplied> aperto uicimus. </p>
             </div>
@@ -5569,7 +5570,7 @@
                <p> VACVAM uiris fortibus exhaustam. </p>
             </div>
 
-            <div type="schol" n="369-370">
+            <div type="schol" n="369">
                <p> (HOSNE MIHI REDITVS GERMANE) PARABAS / (IN ME HAEC TELA DABAS) ut huiusmodi mihi parares insidias, aut certe qualis Tydeus reuersus est, talis et ego ad Argos redirem. </p>
             </div>
 
@@ -5590,7 +5591,7 @@
                <p> (QVAM DVRVM NATIS ...) <del>QVAM TRISTE</del> REVELLI scio, inquit, quemadmodum durum sit a liberis distrahi <del>ituris ad bellum</del>.</p>
             </div>
 
-            <div type="schol" n="&lt;376&gt;">
+            <div type="schol" n="376">
                <p> 
                   <supplied>NON ME VLLIVS DOMVS ANXIA CVLPET</supplied> nolo domorum habere maledicta, si quae forte fuerint uiduatae necessitate bellorum. </p>
             </div>
@@ -5605,22 +5606,22 @@
                   <supplied>MATRES</supplied> id est quarum filii me sequantur ad bella. </p>
             </div>
 
-            <div type="schol" n="378">
+            <div type="schol" n="378a">
                <p> IBO<del>QVE</del> LIBENS Cum dicit <hi rend="italic">ibo</hi>, facit ut solus ire non debeat. </p>
             </div>
 
-            <div type="schol" n="378-379">
+            <div type="schol" n="378b">
                <p> (LICET OPTIMA CONIVNX) / AVDITVS(QVE ITERVM REVOCET SOCER) <supplied>
                      <hi rend="italic">auditus</hi>
                   </supplied> a me scilicet. Vt obtemperans primum non isse, sic hoc dicit, ut intellegamus Polynicen ad Thebas ante ire uoluisse. Sed prohibitum se ab Adrasto queritur, ut prius legatio mitteretur. Artificiosa ergo conquestio est, quae sic agitur ut in ultionem sui etiam nolentes ire compellat. </p>
             </div>
 
-            <div type="schol" n="383-386">
+            <div type="schol" n="383">
                <p> OMNIBVS VLTRO / (NON IVVENVM MODO SED GELIDIS ET INERTIBVS AEVO / PECTORIBVS MENS VNA SVBIT VIDVARE PENATES / FINITIMAS ADHIBERE MANVS IAMQVE IRE) defectu orationis totius aperuit uoluntatem. Nam dum astute repudiabat auxilia, id egit ut mereretur. <hi rend="italic">Vltro</hi> bene, quia <del>ille</del> ingeniose noluerat putans illos ultro uelle. Aut <hi rend="italic">ultro</hi> 'ultra' accipimus. Vt Vergilius:</p> 
                <l>'et miserescimus ultro'. </l>
             </div>
 
-            <div type="schol" n="386-387">
+            <div type="schol" n="386">
                <p> SED ALTVS / CONSILIIS (PATER) profundus pater consilio siue prouidus. Vt Vergilius:</p>
                <lg>
                   <l>'arces, quibus altus Apollo</l>
@@ -5628,11 +5629,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="388-389">
+            <div type="schol" n="388">
                <p> ISTA QVIDEM SVPERIS (... MEDENDA / LINQVITE QVAESO) more Romano orationem de bello habiturus primum sibi deos facit esse propitios. </p>
             </div>
 
-            <div type="schol" n="&lt;398&gt;">
+            <div type="schol" n="398">
                <p> 
                   <supplied>EPIDAVRIVS ...IDMON</supplied> Epidaurus ciuitas in Graecia, unde Aesculapius fuisse dicitur, medicinae artis inuentor. Et bene perito medico illius ciuitatis tribuit gloriam, a qua inuentor artis ipsius dicitur sumpsisse principium. </p>
             </div>
@@ -5645,11 +5646,11 @@
                <p> PRINCIPIA IRARVM (QVAEQVE ORSVS VTERQVE VICISSIM) id est orationis suae libertatem, uel quae huic ab Eteocle responsa fuerint. </p>
             </div>
 
-            <div type="schol" n="403-404">
+            <div type="schol" n="403">
                <p> (QVI CONTRA QVANTIQVE DVCES) VBI MAXIMVS ILLI / SVDOR quos fortiores reppererit, apud quos tota uirtute pugnauerit. </p>
             </div>
 
-            <div type="schol" n="&lt;404&gt;">
+            <div type="schol" n="404">
                <p> 
                   <supplied>INDICIO SERVATVM MAEONA TRISTI</supplied> quemadmodum unum seruasset Maeon<del>id</del>em qui indicia Thebanis acceptae cladis exponeret. </p>
             </div>
@@ -5686,7 +5687,7 @@
                <p>Si<supplied>c</supplied> ergo cum oritur dies, nox ruit, cum occidit, nox surgit, alterno ut surgant, alterno ut cadant. </p>
             </div>
 
-            <div type="schol" n="418-419">
+            <div type="schol" n="418">
                <p> (NAM TYDEA LARGVS HABEBAT / PERFVSVM MAGNA VIRTVTIS) IMAGINE (SOMNVS) occupant eum labores egregii. In somnis enim uidebat ea quae gesserat. </p>
             </div>
 
@@ -5695,12 +5696,12 @@
                <l>'Hecate lassata Therapnis'. </l>
             </div>
 
-            <div type="schol" n="424-425">
+            <div type="schol" n="424">
                <p> (COMVNT FVROR IRAQVE CRISTAS / FRENA MINISTRAT EQVIS) PAVOR ARMIGER omnes ergo terrores circa Martis currum fuisse poeta describit. Vt Vergilius:</p> 
                <l>'Iraeque Insidiaeque, dei comitatus, aguntur'. </l>
             </div>
 
-            <div type="schol" n="&lt;425-426&gt;">
+            <div type="schol" n="425">
                <p> 
                   <supplied>VIGIL OMNI / FAMA SONO VANOS RERVM SVCCINCTA TVMVLTVS</supplied> ut, quicquid sonuisset, populis esset horrendum. </p>
             </div>
@@ -5739,7 +5740,7 @@
                <p> MVLTA SVPER BELLO GENERISQVE TVMENTIBVS bene <hi rend="italic">generis</hi>. Nam et Tydeus in uindictam sui bellum desiderat et Polynices ut recuperaret imperium. Ergo bellum desiderant unus uictor, alter incensus. Ideo <hi rend="italic">tumentibus</hi> id est anhelantibus bellum. </p>
             </div>
 
-            <div type="schol" n="450-451">
+            <div type="schol" n="450">
                <p> (VATVM MENTES AC PROVIDA VERI) / SACRA MOVERE DEVM temptare audire, auguria belli per uates cognoscere. Lucanus:</p> 
                <l>'finemque expromere rerum'.</l> 
                <p>Proprie enim <hi rend="italic">moueri</hi> sacra dicuntur, ubi coeperint incohari. Vt Lucanus:</p> 
@@ -5751,7 +5752,7 @@
                <l>'Amythaoniusque Melampus'. </l>
             </div>
 
-            <div type="schol" n="&lt;454-455&gt;">
+            <div type="schol" n="454">
                <p> 
                   <supplied>DVBIVM CVI PRONVS APOLLO / ORAQVE CIRRHAEA SATIARIT LARGIVS VNDA</supplied> id est: dedit uaticinandi scientiam. Et est sensus: dubium erat, utrum Amphiarao an Melampo pronus Apollo magis esset, uel cuius ora potius satiasset unda Cirrhaea, quia uterque nobilis, uterque diuinandi peritus. </p>
             </div>
@@ -5797,16 +5798,16 @@
                <p> ADDERE CONSILIVM <hi rend="italic">addere</hi> bene dixit. Non est enim ipsius, quod mouetur. </p>
             </div>
 
-            <div type="schol" n="474-475">
+            <div type="schol" n="474">
                <p> (NON) CIRRHA DEVM (PROMISERIT ANTRO / CERTIVS) Cirrha prope Parnassum est, quo in loco Apollo futura praedicit. </p>
             </div>
 
-            <div type="schol" n="475-476">
+            <div type="schol" n="475">
                <p> (FRONDES LVCIS QVAS FAMA MOLOSSIS) / CHAONIAS SONVISSE TIBI Epiroticas quercus dicit, in quibus sedentes columbae sciscitatoribus futura dicebant. Vt Vergilius:</p> 
                <l>'atque habitae Grais oracula quercus'. </l>
             </div>
 
-            <div type="schol" n="476-477">
+            <div type="schol" n="476">
                <p> ARIDVS HAMMON / INVIDEAT <del>Iuuenalis:</del>
                </p>
                <lg>
@@ -5820,11 +5821,11 @@
                <p>— Liber, cum ex India ueniens in deserta et in extrema parte Libyae teneretur ac siti laboraret exercitus, rogasse dicitur Iouem ut se patrem probaret. Vnde ex arena subito aries apparuit, quo duce Liber aquam inuenit. Petit Iouem ut arietem in astra transferret. In eo autem loco in quo aqua fluxit templum constituit, quod Iouis Hammonis dicitur. Simulacrum autem eius adiectis cornibus arietinis confictum est. De quo templo postea data esse dicuntur oracula. Hic <unclear>Zoamachon</unclear> opinione Metrodori Peri<supplied>e</supplied>getici condidit ab Aethiopia usque in Libyam tria opinata templa: <unclear>triannus</unclear> solis in Aethiopia hoc est ter fulgentis quantum per ceteram terram ardet; in climate ultimo Libyae, quod Sagittario clauditur signo, <del>esse</del> Hammonis templum Iouis intra Aethiopas <supplied>id est</supplied> Indos — sunt enim et qui PseudoAethiope<supplied>s</supplied> uocantur. — et Libyas ultimos <del>esse</del> prope Alexandriam. </p>
             </div>
 
-            <div type="schol" n="478">
+            <div type="schol" n="478a">
                <p> NILIACVMQVE PECVS Apin dicit, taurum lunatum Isidis, qui Aegyptiis motu corporis sui et quibusdam signis futura praedicit <del>qui e Memphide nascitur</del>.</p>
             </div>
 
-            <div type="schol" n="478-479">
+            <div type="schol" n="478b">
                <p> (PATRIOQVE AEQVALIS HONORI) / BRANCHVS <del>Branchi meminit Terentianus de metris:</del>
                </p>
                <lg>
@@ -5848,15 +5849,15 @@
                </p>
             </div>
 
-            <div type="schol" n="479-480">
+            <div type="schol" n="479">
                <p> (VNDOSAE QVI RVSTICVS ACCOLA PISAE) / PANA LYCAONIA (NOCTVRNVM EXAVDIT IN VMBRA) Pan apud Pisas rusticos numine suo replere solet, datque oracula qui impletur deo. Ergo neque ille aequari potest tibi, o Iuppiter, qui in nocturna umbra audit Pana, id est: quasi per ipsum numen loquitur hominibus. — diuersa loca commemorat et quis deus quo in loco futura praedixerit. </p>
             </div>
 
-            <div type="schol" n="481-482">
+            <div type="schol" n="481a">
                <p> DITIOR ILLE ANIMI (CVI TV DICTAEE SECVNDAS / IMPVLERIS MANIFESTVS AVES) laus <del>uero</del> augurii est, quae per reliquarum artium diminutionem extollitur. </p>
             </div>
 
-            <div type="schol" n="481-483">
+            <div type="schol" n="481b">
                <p> (CVI TV DICTAEE SECVNDAS / IMPVLERIS MANIFESTVS AVES) MIRVM VNDE (SED OLIM / HIC HONOR ALITIBVS) in errorem inducitur ista admiratio cum inuocatione. Nam quasi Vergilium, sed non recto ordine, sequitur. Ait enim:</p>
                <lg>
                   <l>'haud equidem credo, quia sit diuinitus illis</l>
@@ -5867,16 +5868,16 @@
                <p>(MIRVM VNDE SED OLIM) HIC HONOR ALITIBVS rationem redditurus est unde concessum sit auibus futura praedicere. Quod Vergilius quasi philosophus explicat Epicureus, hic quasi Platonicus. </p>
             </div>
 
-            <div type="schol" n="&lt;483-484&gt;">
+            <div type="schol" n="483">
                <p> 
                   <supplied>SVPERAE SEV CONDITOR AVLAE / SIC DEDIT EFFVSVM CHAOS IN NOVA SEMINA TEXENS</supplied> prima opinio est ab Hesiodo: futura praedicere quia supernus orbis conditor, cum chaos figuraret in semina, hanc illis potestatem concessit. <hi rend="italic">In noua</hi> autem <hi rend="italic">semina</hi>, ut generatim omnia procrearent, quae corpora, ut Epicurei uolunt, textu inani fiunt atomorum. </p>
             </div>
 
-            <div type="schol" n="485-486">
+            <div type="schol" n="485">
                <p> (SEV QVIA) MVTATAE (NOSTRAQVE) AB ORIGINE VERSIS / CORPORIBVS hoc philosophice. Aiunt enim <foreign xml:lang="grc">μετεμψύχωσιν</foreign> fieri animarum in corpora. Vt lectum est in Horatio: 'nec te Pythagorae fallunt arcana renati'. Primo enim anima ipsius in Euphorbi <supplied>corpus</supplied> migrasse dicitur Troiano proelio, dum de clipeo ageretur 'Danai de poste refixo', secundo in Pythagorae, tertio in pauonis, quarto in Homeri, quinto in Ennii poetae, ergo animas in qualiuis corpore eandem tenere sapientiam. Haec autem secunda opinio est. </p>
             </div>
 
-            <div type="schol" n="486-488">
+            <div type="schol" n="486">
                <p> SEV PVRIOR AXIS / (AMOTVMQVE NEFAS ET RARVM INSISTERE TERRIS / VERA DOCENT) tertia opinio dicit aues ideo futura praedicere quia in aere sunt et purissime uiuunt, exinde quia raro terris insidunt, quae sunt nefastae. Ergo aues uera dicere illa res facit: <hi rend="italic">axis purior</hi>.</p>
             </div>
 
@@ -5894,11 +5895,11 @@
                <l>'ante sinistra caua monuisset ab ilice cornix'. </l>
             </div>
 
-            <div type="schol" n="495">
+            <div type="schol" n="495a">
                <p> (SI PROHIBES) HINC NECTE MORAS hoc est: ne ad Thebanos ire cogamur incassum. </p>
             </div>
 
-            <div type="schol" n="495-496">
+            <div type="schol" n="495b">
                <p> DEXTRISQVE ... / ALITIBVS quia de caelo uenientibus a dextra parte auibus auguria mala sunt. </p>
             </div>
 
@@ -5906,19 +5907,19 @@
                <p> (IMMENSI FRVITVR) CALIGINE MVNDI quicquid hominibus non patet, solus uidebat. </p>
             </div>
 
-            <div type="schol" n="&lt;499-500&gt;">
+            <div type="schol" n="499">
                <p> 
                   <supplied>POSTQVAM RITE DIV PARTITI SIDERA CVNCTIS / PERLEGERE ANIMIS OCVLISQVE SEQVACIBVS AVRAS</supplied> intentionem incredibilem describit, nam obtutu <supplied>in</supplied> uno fixi oculi non dubitatione caligant? </p>
             </div>
 
-            <div type="schol" n="502-503">
+            <div type="schol" n="502">
                <p> NONNE SVB EXCELSO (SPIRANTIS LIMITE CAELI / AMPHIARAE VIDES CVRSVS) ordo: nonne uides, Amphiarae, sub excelso limite caeli spirantes cursus? Aut uentorum dixit aut stellarum. CVRSVS id est uolatus. <supplied>Vergilius</supplied>:</p> 
                <l>'quo cursu deserta petiuerit'.</l> 
                <p>
                   <hi rend="italic">Serenos</hi> autem 'prosperos' dixit. </p>
             </div>
 
-            <div type="schol" n="504-505">
+            <div type="schol" n="504">
                <p> LIQVIDO (... MEATV / PENDEAT) id est or<supplied>di</supplied>nato uolatu pendeat. </p>
             </div>
 
@@ -5938,12 +5939,12 @@
                <p> (FLAVAEQVE SONANS) AVIS VNCA MINERVAE huius alitis talis est fabula: Nycteus, Aethiopum rex, felix, si nunquam pater fuisset, habuit filiam Nycti<supplied>menen</supplied> nomine. Quae cum scelerato amore patrem diligeret, amorem suum nutrici confessa est infandumque petiuit auxilium. Ea, cum mentita esset domino suo Nycteo a quadam illum extranea diligi uirgine, impetrauit ut filiae suae imprudens uteretur amplexibus. Sero illi cognitum facinus statuit uindicare. Quapropter agnitam inter ipsos amplexus filiam cum uoluisset exstinguere, illa Mineruae implorauit auxilium. Cuius protectione periculo est erepta uersaque in auem, quae ex conscientia commissi facinoris diei fugit aspectum et Mineruae tutelae dicata est. Alii dicunt filiam Proeti fuisse patris<supplied>que</supplied> uim timentem aufugisse, quam Minerua mutauit in noctuam. </p>
             </div>
 
-            <div type="schol" n="508">
+            <div type="schol" n="508a">
                <p> NON VENIT AVGVRIO MELIOR QVI VVLTVR id est uultur, qui solet bona omina augurantibus facere. Cuius auis auspicio fundata dicitur Roma. Quod Lucanus praeteriens tetigit dicens:</p> 
                <l>'uulturis ut primum laeuo fundata uolatu'. </l>
             </div>
 
-            <div type="schol" n="&lt;508-509&gt;">
+            <div type="schol" n="508b">
                <p> 
                   <supplied>ALTIS / DESVPER ACCIPITRES EXSVLTAVERE RAPINIS</supplied> praeliban<supplied>te</supplied>s dira, ui qu<del>i</del>a eorum fruge<del>m</del> id est cruentis epulis <supplied>
                      <gap/>
@@ -5951,16 +5952,16 @@
                </p>
             </div>
 
-            <div type="schol" n="511-512">
+            <div type="schol" n="511">
                <p> ET FERALIA BVBO / (DAMNA CANENS) cum filiam suam Ceres raptam a Dite comperisset, conquesta a Ioue impetrauit ut ei filia redderetur, ita tamen, si nihil apud inferos gustauisset. Et cum in eo fuisset ut matrem filia sequeretur, Ascalaphus, qui apud inferos erat, dixit Proserpinam e pomario Ditis e malo punico gustasse tria grana. Indignata Ceres conuertit Ascalaphum in bubonem. De Proserpina uero ficta sic fabula est. Ceterum tenore philosophiae diuina anima esse signatur, quae, incidens naturae cogitationes et nefarie polluens, necessitate haesit tenta infernali hoc mundo. Buboni autem tale studium non tam fabula quam natura praescripsit. Quam sit ferale bubonis augurium, testis est poeta Vergilius:</p> 
                <l>'solaque culminibus ferali <supplied>carmine bubo</supplied>'. </l>
             </div>
 
-            <div type="schol" n="516-519">
+            <div type="schol" n="516">
                <p> (EQVIDEM) VARII PATER OMINA PHOEBI / (SAEPE TVLI IAM TVM PRIMA CVM PVBE VIRENTEM / SEMIDEOS INTER PINVS ME THESSALA REGES / DVCERET) saepe, inquit, tuli uaria Phoebi omina, ex quo me inter reges semideos pinus duxit Thessala. Dicit autem: ex illo tempore, quo cum Argonautis uectus sum. <hi rend="italic">Semideos ... reges</hi> ait, quia filii <supplied>deum et</supplied> regum omnes fuerunt qui in illa naui impositi sunt. <hi rend="italic">Thessala</hi> autem <hi rend="italic">pinus</hi> Argo, quae in Pelio monte Thessaliae fabricata est. Peliae igitur, Neptuni filio, a sortibus praeceptum erat: cum Neptuno sacrificaret et aliquis nudo pede superuenisset, tunc ei mortem appropinquare. Is ergo cum annua sacra faceret Neptuno, Iason, Aesonis filius, cum uenisset ad flumen, in limo unum ei calciamentum adhaesit. Ille, ut celerius ueniret, neglexit. Cum superuenisset sacrificio, Pelias aspexit et memor sortium iussit eum arietis pellem inauratam a Colchis petere a rege Aeeta. Qui conuocata Graecorum nobilium iuuentute Colchos profectus est. </p>
             </div>
 
-            <div type="schol" n="520-521">
+            <div type="schol" n="520">
                <p> (NEC ME VENTVRA LOCVTO / SAEPIVS IN DVBIIS) AVDITVS IASONE MOPSVS Mopsus, Apollinis et Mantus filius, amicitia Iasoni fida coniunctus, diuinandi peritus. Ait ergo nunc Melampus: non plus me auditus est Mopsus imminentibus cladibus, cum ego futura praedicerem. In tantum enim magnus fuit Mopsus in augurandi peritia ut post mortem ei templa dicata sint, a quorum adytis saepe homines responsa accipiunt. </p>
             </div>
 
@@ -5983,7 +5984,7 @@
                <p> HAC RERE <supplied>IN</supplied> IMAGINE THEBAS in hac imagine finge Thebas esse. </p>
             </div>
 
-            <div type="schol" n="&lt;529-530&gt;">
+            <div type="schol" n="529">
                <p> 
                   <supplied>NAM SESE IMMOTI GYRO ATQVE IN PACE SILENTES / CEV MVRIS VALLOQVE TENENT</supplied> reddit causas, cur pro Thebis accipi debeant cygni: quia, ut Thebani muris, illi se gyro uallabant. </p>
             </div>
@@ -6000,7 +6001,7 @@
                <p> NIVEI GREGIS cygnorum scilicet. </p>
             </div>
 
-            <div type="schol" n="536-537">
+            <div type="schol" n="536">
                <p> (CERNIS INEXPERTO RORANTES SANGVINE VENTOS) / ET PLVMIS STILLARE DIEM quia excussae in congressu plumae mixtae sanguine ex aere cadunt. Vt Vergilius:</p> 
                <l>'tunc cruor euulsae labuntur ab aethere pennae'. </l>
             </div>
@@ -6013,45 +6014,45 @@
                </l>
             </div>
 
-            <div type="schol" n="540-541">
+            <div type="schol" n="540">
                <p> ILLVM VESTIGIA ADORTVM / (MAIORVM VOLVCRVM TENERAE DEPONITIS ALAE) Parthenopaeum significat, qui puerili aetate maiora uiribus suis temptando confossus est. </p>
             </div>
 
-            <div type="schol" n="542">
+            <div type="schol" n="542a">
                <p> HIC HOSTI IMPLICITVS (PARITER RVIT) Polynicen significat, qui fratri morienti implicitus fuit. </p>
             </div>
 
-            <div type="schol" n="542-543">
+            <div type="schol" n="542b">
                <p> HVNC FVGA RETRO / (VOLVIT AGENS SOCIAE LINQVENTEM FATA CATERVAE) Adrastum dicit, quia solus euasit. Vt Vergilius:</p> 
                <l>'et Adrasti pallentis imago'</l> 
                <p>id est timore fugientis. </p>
             </div>
 
-            <div type="schol" n="544">
+            <div type="schol" n="544a">
                <p> HIC NIMBO GLOMERATVS OBIT Hippomedontem significat fluminis periturum esse uertigine. </p>
             </div>
 
-            <div type="schol" n="544-545">
+            <div type="schol" n="544b">
                <p> HIC PRAEPETE VIVA / (PASCITVR IMMORIENS) Tydeum dicit, qui interfectoris sui Melanippi oblato sibi capite cerebrum eius, dum moreretur, absorbuit. </p>
             </div>
 
-            <div type="schol" n="546-547">
+            <div type="schol" n="546">
                <p> QVID FVRTIM INLACRIMAS (ILLVM VENERANDE MELAMPV / QVI CADIT AGNOSCO) Amphiaraus Melampo dicit: 'quid fles, quia uides me moriturum? Augurium cadentis cygni mihi finem uitae portendere ego cognosco'. Notandum quia uocatiuum <hi rend="italic">Melampu</hi> dixit. </p>
             </div>
 
-            <div type="schol" n="549">
+            <div type="schol" n="549a">
                <p> TERROR HABET VATES qui non tantum uidisse se crederent, sed fuisse perpessos. </p>
             </div>
 
-            <div type="schol" n="549-550">
+            <div type="schol" n="549b">
                <p> PIGET (IRRVPISSE VOLANTVM / CONCILIA) piget eos exauditos fuisse, quos utique pigere debuisset, si eos auguria fefellissent. Sed quia mala compererant, <hi rend="italic">piget irrupisse uolantum concilia</hi>.</p>
             </div>
 
-            <div type="schol" n="551">
+            <div type="schol" n="551a">
                <p> AVDITIQVE (ODERE DEOS) declamatio e contrario. </p>
             </div>
 
-            <div type="schol" n="551-553">
+            <div type="schol" n="551b">
                <p> VNDE ISTE PER ORBEM / (PRIMVS VENTVRI MISERIS ANIMANTIBVS AEGER / CREVIT AMOR) <foreign xml:lang="grc">διαπόρησις</foreign> poetica. Quaerit enim, unde prius hominibus studium augurandi uel uaticinandi uenerit. Vt Lucanus:</p>
                <lg>
                   <l>'cur hanc tibi, rector Olympi,</l>
@@ -6071,11 +6072,11 @@
                <p> ASTRORVMQVE VICES <unclear>matheseos</unclear>, ubi sit luna uel quo signo, uel quae astra significent. NVMERATAQVE SEMINA LVNAE si <hi rend="italic">semina</hi>, propter spumam magicae artis, si <hi rend="italic">semita</hi>, propter obliquum circulum quo cursus exercet. <hi rend="italic">Numerata</hi> autem, quia per numerum dierum flammarum suarum augmenta detrimentaque recipit. </p>
             </div>
 
-            <div type="schol" n="559">
+            <div type="schol" n="559a">
                <p> THESSALICVMQVE NEFAS artem magicam dicit, qua cadauera cogit futura praedicere. </p>
             </div>
 
-            <div type="schol" n="559-561">
+            <div type="schol" n="559b">
                <p> AT NON PRIOR AVREVS ILLE / (SANGVIS AVVM SCOPVLISQVE SATAE VEL ROBORE GENTES / MENTIBVS HIS VSAE) <supplied>
                      <hi rend="italic">scopulisque satae uel robore gentes</hi>
                   </supplied> non ut antiqui aureo saeculo fuerunt. Sicut Vergilius:</p> 
@@ -6094,7 +6095,7 @@
                </l>
             </div>
 
-            <div type="schol" n="562-563">
+            <div type="schol" n="562">
                <p> QVID CRASTINA VOLVERET AETAS / (SCIRE NEFAS HOMINI) Horatius:</p> 
                <l>'quid sit futurum cras, fuge quaerere'. </l>
             </div>
@@ -6109,7 +6110,7 @@
                <p>id est persolues. </p>
             </div>
 
-            <div type="schol" n="568-569">
+            <div type="schol" n="568">
                <p> (IAM BELLA TVBAEQVE / COMMINVS ABSENTESQVE FREMVNT) SVB PECTORE THEBAE quae futura sunt aliis, sunt praesentia sacerdoti. </p>
             </div>
 
@@ -6121,7 +6122,7 @@
                </l>
             </div>
 
-            <div type="schol" n="575-577">
+            <div type="schol" n="575">
                <p> (ET IAM SVPREMA TONANTIS / IVSSA FREMVNT AGROSQVE VIRIS) ANNOSAQVE VASTANT / (OPPIDA) id est: quae iussa sunt, implere festinant cupiditate pugnandi. </p>
             </div>
 
@@ -6130,7 +6131,7 @@
                <l>'et scabros nigrae morsu rubiginis enses'. </l>
             </div>
 
-            <div type="schol" n="&lt;587-588&gt;">
+            <div type="schol" n="587">
                <p> 
                   <supplied>ALII CORTYNIA LENTANT / CORNVA</supplied> Vergilius:</p>
                <lg>
@@ -6144,11 +6145,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="588-589">
+            <div type="schol" n="588">
                <p> (IAM FALCES AVIDIS ET ARATRA CAMINIS / RASTRAQVE ET INCVRVI SAEVVM) RVBVERE LIGONES naturam ignis expressit, quae facit ferrum rubescere. </p>
             </div>
 
-            <div type="schol" n="590-591">
+            <div type="schol" n="590">
                <p> (CAEDERE NEC VALIDAS) SANCTIS A STIRPIBVS H(ASTAS) / (NEC PVDOR) non pudebat illos de sacris lucis praefixisse lanceis hastilia. Vt Vergilius:</p>
                <lg>
                   <l>'sed stirpem Teucri nullo discrimine sacrum</l>
@@ -6157,12 +6158,12 @@
                </lg>
             </div>
 
-            <div type="schol" n="594-597">
+            <div type="schol" n="594">
                <p> (VBI TEMPTAT / ENCELADVS MVTARE LATVS SVPER IGNEVS ANTRIS / MONS TONANT EXVNDANT APICES FLVCTVSQVE PELORVS) / CONTRAHIT tanta saxa de uertice ab Encelado uolui dicit ut mare fieri possit angustum quod Italiam a Sicilia separat. Vt Lucanus:</p> 
                <l>'ne rupti repetant confinia montes'. </l>
             </div>
 
-            <div type="schol" n="&lt;602&gt;">
+            <div type="schol" n="602">
                <p> 
                   <supplied>DIV TVTO SVPERVM CONTEMPTOR</supplied> qui idcirco diu tutus fuerit quod ei supremus dies seruabatur in Thebas. </p>
             </div>
@@ -6186,7 +6187,7 @@
                <p>PHOLOES mons Thessaliae. </p>
             </div>
 
-            <div type="schol" n="&lt;605&gt;">
+            <div type="schol" n="605">
                <p> 
                   <supplied>INTER ET AETNAEOS AEQVVS CONSVRGERE FRATRES</supplied> talis ergo erat quales Gigantes aliquando fuerunt. Magnitudinem eius <del>ex</del> Gigantibus comparauit id est Cyclopibus, <supplied>eos</supplied> de locis quibus fuerunt notans. Vt Vergilius:</p>
                <lg>
@@ -6209,7 +6210,7 @@
                <l>'horrendas canit ambages antroque remugit'.</l>
             </div>
 
-            <div type="schol" n="615-616">
+            <div type="schol" n="615">
                <p> (VIRTVS) MIHI NVMEN ET ENSIS / (QVEM TENEO) totum Vergiliane de Capaneo ponit. Ait enim ille:</p> 
                <l>'dextra mihi deus et telum, quod missile libro'. </l>
             </div>
@@ -6218,15 +6219,15 @@
                <p> (VOLVCRVM) QVAE TANTA POTESTAS quae illi praestatur ut futura cognoscat. </p>
             </div>
 
-            <div type="schol" n="620">
+            <div type="schol" n="620a">
                <p> OECLIDES Amphiaraum, Oeclei filium, dicit. </p>
             </div>
 
-            <div type="schol" n="620-623">
+            <div type="schol" n="620b">
                <p> (ALIO CVRARVM AGITANTE TVMVLTV) / NON EQVIDEM EFFRENO (IVVENIS CLAMORE PROFANI / DICTORVMQVE METV LICET HIC INSANA MINETVR / ELICIOR TENEBRIS) non me timor aut terror furiosi iuuenis de secreto agit ad publicum, sed amor ciuium et cura rei publicae. Ordo talis: non elicior tenebris dictorum metu et iuuenis profani effreno clamore commotus. </p>
             </div>
 
-            <div type="schol" n="623-624">
+            <div type="schol" n="623">
                <p> ALIO MIHI DEBITA FATO / (SVMMA DIES) iam coepit pericula sua promere ab exitu suo incohans, quoniam hiatu terrae se cognouerat periturum. </p>
             </div>
 
@@ -6242,7 +6243,7 @@
                <p> (NVLLA) OMINA CVRAE non timori sunt uobis deorum responsa, quia improspera sunt?</p>
             </div>
 
-            <div type="schol" n="633-634">
+            <div type="schol" n="633">
                <p> QVID ME PERSEI (SECRETA AD CVLMINA MONTIS / IRE GRADV TREPIDO) Aphesantem significat montem, in quo auguria captauerant. De hoc enim Perseus primum uolauit, quando ad caput Gorgonae auferendum profectus est. Dicit ergo nunc Amphiaraus: si hoc facturi eratis, quod furor suadet, cur me augurandi causa sollicite misistis ad montem? </p>
             </div>
 
@@ -6275,7 +6276,7 @@
                <p> IBIMVS id est in bellum. Mire et hoc uult futurorum necessitate compleri, ne quid furori suo Capaneus assignet. </p>
             </div>
 
-            <div type="schol" n="648-649">
+            <div type="schol" n="648">
                <p> (TVVS O FVROR AVGVR) ET VNI / ISTA TIBI ista quae praedicis tibi soli contingant. Vt Vergilius:</p>
                <lg>
                   <l>'capiti cane talia, demens,</l>
@@ -6283,7 +6284,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="650-651">
+            <div type="schol" n="650">
                <p> ET TVA NON VNQVAM (TYRRHENVS TEMPORA CIRCVM / CLANGOR EAT) proueniat, inquit, tibi ut aures tuas nunquam tubarum sonitus irrumpat clangor. </p>
             </div>
 
@@ -6291,15 +6292,15 @@
                <p> (I SIDONIOS) LEGATVS AD HOSTES repete regnum Polynicis. </p>
             </div>
 
-            <div type="schol" n="657">
+            <div type="schol" n="657a">
                <p> HAEC <del>PACEM</del> ... SERTA quae Amphiaraus gerebat in capite. </p>
             </div>
 
-            <div type="schol" n="657-659">
+            <div type="schol" n="657b">
                <p> (TVA PRORSVS INANI / VERBA POLO CAVSAS) ABSTRVSAQVE MOMINA RERVM / (ELICIVNT) ut sacrilegus dicit, quia quaecumque eueniunt mundi uertigine, non numinum dispositionibus, fiunt. ELICIVNT reuera quicquid loqueris fatum est, aut tuo arbitrio fata disponis. </p>
             </div>
 
-            <div type="schol" n="659-660">
+            <div type="schol" n="659">
                <p> MISERET SVPERVM (SI CARMINA CVRAE / HVMANAEQVE PRECES) totum hoc secundum Epicurum dicit poeta. Ait enim Lucretius:</p>
                <lg>
                   <l>'omnis enim diuum per se natura necesse est</l>
@@ -6343,11 +6344,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="669">
+            <div type="schol" n="669a">
                <p> INSANIRE MANV furere manibus, bellare, non ut tu uaticinationibus furis. </p>
             </div>
 
-            <div type="schol" n="669-670">
+            <div type="schol" n="669b">
                <p> (RVRSVS) FRAGOR (INTONAT INGENS / HORTANTVM) populi clamor hortantis, ut Capanei sententiam sequerentur. Sic Lucanus:</p>
                <lg>
                   <l>'elatasque alte, quaecumque ad bella uocaret,</l>
@@ -6355,7 +6356,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="671-672">
+            <div type="schol" n="671">
                <p> (VT RAPIDVS TORRENS ANIMOS CVI VERNA MINISTRANT) / FLAMINA (ET EXVTI CONCRETO FRIGORE MONTES) nam Fauonii flatu solutae niues addunt fluminibus incrementa. Vt Lucanus:</p>
                <lg>
                   <l>'at Genusum nunc sole niues, nunc imbre solutae</l>
@@ -6364,7 +6365,7 @@
                <p>CONCRETO FRIGORE definitio niuis: quid est nix? — concretum frigus. </p>
             </div>
 
-            <div type="schol" n="678-679">
+            <div type="schol" n="678">
                <p> (AT GEMITVS ARGIA VIRI) NON AMPLIVS AEQVO / CORDE FERENS id est: ulterius aequo corde mariti gemitus ferre non potuit Argia, caritatis affectione deuincta. </p>
             </div>
 
@@ -6372,7 +6373,7 @@
                <p> ET FLETV SIGNATA GENAS nam quaedam uia apparet lacrimarum in plangentis facie et <supplied>in</supplied> maestorum uultibus orbitam suam tristitia dereli<supplied>n</supplied>quit. </p>
             </div>
 
-            <div type="schol" n="682-683">
+            <div type="schol" n="682">
                <p> PARVVMQVE SVB VBERE C(ARO) / (THESSANDRVM PORTABAT AVO) Vergilius:</p>
                <lg>
                   <l>'paruumque nepotem</l>
@@ -6387,12 +6388,12 @@
                <p> IAM NOCTE (SVPREMA) id est in fine constituta, cum explicatur <hi rend="italic">ante nouos ortus</hi> id est ante aduentum diei. </p>
             </div>
 
-            <div type="schol" n="684-685">
+            <div type="schol" n="684">
                <p> (VBI SOLA SVPERSTITE PLAVSTRO / ARCTOS) AD OCEANVM (FVGIENTIBVS INVIDET ASTRIS) quia Arctos Oceano non mergitur positione cursus sphaerae circularis. <foreign xml:lang="grc">οἴη δ' ἄμμορός ἐστι λοετρῶν Ὠκεανοῖο</foreign>. Sed fabulas quae in Septentrionem sunt fictae a Graecis contra ueri propositum disseramus. Callisto, Lycaonis Arcadiae regis filiam, in comitatu Dianae Iuppiter cum uidisset, in amorem eius incidit nactusque a reliquis segregatam nymphis, in Dianam mutatus seductamque compressit et grauidam fecit. Cuius cum crimen crescens uterus proderet, indignata Diana comitatu suo eam reppulit. Quae exactis decem mensibus enixa est paruulum, qui Arcas cognominatus est. Indignata Iuno, quod paelex sua ex Ioue etiam mater esset, Callisto uertit in ursam. Cuius filius Arcas cum esset in adultam perductus aetatem, imprudens in matrem incidit ursamque credens misso telo eam perimere uoluit. Non sustinuit Iuppiter ignorantem parricidium perpetrare statimque eos inter sidera rettulit. Ille Arcturus et alio nomine Arctophylax uocatur, illa <foreign xml:lang="grc">ἄρκτος μείζων</foreign>, Latine 'Septentrio Maior' appellatur. Quod signum loco non mouetur neque mergitur. Tethys enim, uxor Oceani, nutrix Iunonis fuit, quae propter affectum nutritae eam prohibet in Oceanum cadere. Vnde Vergilius:</p> 
                <l>'Arctos Oceani metuentes aequore tingui'. </l>
             </div>
 
-            <div type="schol" n="687-689">
+            <div type="schol" n="687">
                <p> (CVR TVA CVM LACRIMIS MAESTO SINE CONIVGE SVPPLEX) / LIMINA NOCTE PETAM (CESSEM LICET IPSA PROFARI / SCIS GENITOR) intellegis, pater, causa<del>m</del> esse mariti uxoris lacrimas, etsi <hi rend="italic">lingua</hi> mei <hi rend="italic">animi</hi> non sit <hi rend="italic">interpres</hi>.</p>
             </div>
 
@@ -6400,7 +6401,7 @@
                <p> (IVRA...) GENIALIA coniugalia. Viris enim <hi rend="italic">genius</hi> conuenit, mulieribus <hi rend="italic">Iuno</hi>: sed bene uxor super coniugis iurauerit partes. </p>
             </div>
 
-            <div type="schol" n="693-694">
+            <div type="schol" n="683">
                <p> (NON SI MIHI) TIGRIDIS HORROR / (AEQVOREAEQVE SVPER RIGEANT PRAECORDIA CAVTES) totum Vergiliane amantis expressit affectum. Dido enim, ut Aeneae exprobraret duritiam cordis, ait:</p>
                <lg>
                   <l>'sed duris genuit te Caucasus horrens</l>
@@ -6408,7 +6409,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="697-698">
+            <div type="schol" n="697">
                <p> (ATQVE HANC PATER) ASPICE PROLEM / (EXSVLIS HVIC OLIM GENERIS PVDOR) Thessandrum dicit, qui patie<del>ba</del>tur pudoris ignominiam si dicatur exsulis filius. Vergilius:</p>
                <lg>
                   <l>'idem ego, nate, tuum uiolaui crimine nomen,</l>
@@ -6420,7 +6421,7 @@
                <p> QVEM DIXIT APOLLO id est quem oracula tibi generum per portenta dixerant. </p>
             </div>
 
-            <div type="schol" n="701-703">
+            <div type="schol" n="701">
                <p> NON EGOMET (TACITOS VENERIS FVRATA CALORES / CVLPATAMVE FACEM TVA IVSSA VERENDA TVOSQVE / DILEXI MONITVS) id est: non cum furtiuo amore et culpabili Polynicen dilexi, sed, ut exsul<supplied>i nuber</supplied>em, tuis praeceptis parui et, ut maritum amarem, tuis monitis parui. </p>
             </div>
 
@@ -6437,29 +6438,29 @@
                <p> (VT TIMEAM DOLEAMQVE) ROGO peto ut concedas quod proficiscente marito dolebo, quod pugnante timebo. </p>
             </div>
 
-            <div type="schol" n="714-716">
+            <div type="schol" n="714">
                <p> SED MIHI MVLTA DEI (... / ... MVLTA METVS REGNIQVE VOLVBILE PONDVS / SVBICIVNT ANIMO) ordo: sed mihi multa dei <supplied>metus</supplied> regnique pondus subiciunt animo. </p>
             </div>
 
-            <div type="schol" n="716-717">
+            <div type="schol" n="716">
                <p> (VENIET QVI DEBITVS ISTIS) / NATA MODVS eleganter religiosus pater sollicitae filiae belli pollicetur effectum. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718">
                <p> (NEV SINT DISPENDIA IVSTAE) / DVRA MORAE neu damnum putes utiles moras. Ipsa enim tarditate bello proficitur. Vt Lucanus:</p> 
                <l>'saepe mora melior'.</l>
             </div>
 
          </div>
 
-         <div type="lib" n="IV">
+         <div type="lib" n="4">
             <head>LIBER IV</head>
 
             <div type="pr" n="pr">
                <p>Continet hic liber Bellonam iacientem hastam ad initium belli et persuadentem pugnam, sacrificium Iouis et in ipso omen aduersum, ad bellum euntium planctum suorum. Dehinc catalogus de his qui uenerunt in auxilium Adrasti, et singulorum nomina ducum. Prima descriptio Adrasti, secunda Polynicis generi eius, tertia Tydei eiusdem generi, quarta Hippomedontis, quinta Capanei, sexta Amphiarai descriptio euntis ad bellum prodente coniuge et accipiente ornatus ab Argia, septima Parthenopaei euntis ad bellum inscia matre. Matris aduentus et allocutio eius dissuadentis eum a pugna. Dehinc a Thebis praeparatio Eteoclis contra fratrem. Aduersa monstra. Furoris correptio Iocastae decurrentis in monte et allocutio eius uaticinantis futura. Extractio umbrae Laii et eius umbrae uaticinatio futuri mali. Iter Graeci exercitus euntis Thebas. Liberi patris descriptio cum omni choro et eius allocutio pro Thebis, cum exercitum Graeciae uideret Thebas petere. Preces eius apud Nymphas ut cuncta siccarent et euntibus Graecis siti exhaustis potum fontis negarent. Nympharum uiscera in terram redacta. Remotio Argiuorum. Sitis descriptio. Adrasti allocutio ad Hypsipylen, nutricem Archemori, filii Lycurgi. Hypsipyles responsio et demonstratio fontis Langiae. Descriptio exercitus ad aquam festinantis.</p>
             </div>
 
-            <div type="schol" n="1-2">
+            <div type="schol" n="1">
                <p> TERTIVS (HORRENTEM ZEPHYRIS LAXAVERAT ANNVM) / PHOEBVS id est tertius annus ex emisso pacto fratrum. Primus enim fuit, quo imperauit Eteocles, secundus, quo conuentus est a Tydeo ut redderet regnum — qui annus itu ac reditu Tydei consumptus est — tertius, a quo incipitur bellum. HORRENTEM ... ANNVM hieme asperum uel horridum frigore. <hi rend="italic">Annum</hi> ergo pro parte anni, per quem 'hiemem' poeta significat. ZEPHYRIS LAXAVERAT eleganter, quia hieme liquentia solidantur. Vt Vergilius:</p>
                <lg>
                   <l>'nam frigore mella</l>
@@ -6471,11 +6472,11 @@
                <l>'et Zephyro putris se gleba resoluit'. </l>
             </div>
 
-            <div type="schol" n="2-3">
+            <div type="schol" n="2">
                <p> (ANGVSTVM COGEBAT) LIMITE VERNO / (LONGIVS IRE DIEM) tempore utique uerno, quo imminutis noctibus dies sumit augmentum. </p>
             </div>
 
-            <div type="schol" n="3-4">
+            <div type="schol" n="3">
                <p> (CVM) FRACTA IMPVLSAQVE FATIS / (CONSILIA) quia contra consilium Adrasti indictum est bellum. <supplied>FRACTA IMPVLSAQVE FATIS</supplied> uoluntate Fatorum <hi rend="italic">fracta</hi> id est disrupta et ab ancipiti cogitatione abscissa et destinata ad indictionem belli. Ideo subiunxit <hi rend="italic">impulsaque Fatis</hi>. Iam enim disrupta facile ad bellandum Fatis impelli potuerunt. </p>
             </div>
 
@@ -6483,11 +6484,11 @@
                <p> (TANDEM) MISERI (DATA COPIA BELLI) utrisque — scilicet fratribus — infeliciter exstitit causa bellandi, quos pactos infelicior habuit imperandi condicio. </p>
             </div>
 
-            <div type="schol" n="5-6">
+            <div type="schol" n="5">
                <p> PRIMA (MANV RVTILAM DE VERTICE LARISSAEO / OSTENDIT) BELLONA (FACEM) aut quae prima bellum coeperit ante Martem, aut <hi rend="italic">prima</hi> domina proeliorum. RVTILAM splendentem. DE VERTICE LARISSAEO de arce ciuitatis Argiuae. </p>
             </div>
 
-            <div type="schol" n="6-7">
+            <div type="schol" n="6">
                <p> TRABALEM / HASTAM ingentem. Congrue inde hastam dixit emissam, unde bellum ueniebat ad Thebas. </p>
             </div>
 
@@ -6497,7 +6498,7 @@
                   </supplied> nomen Thebani fontis a reginae uocabulo nuncupatum. Et modo poetice dixit, neque enim poterat hasta <hi rend="italic">de uertice Larissaeo</hi> usque ad Thebas ire. </p>
             </div>
 
-            <div type="schol" n="9-10">
+            <div type="schol" n="9">
                <p> (FERROQVE AVROQVE) CORVSCIS / ... VIRIS splendidis Argiuorum ducibus id est ferri <supplied>aurique</supplied> nitore fulgentibus. </p>
             </div>
 
@@ -6509,15 +6510,15 @@
                <p> DICTA DIES ADERAT aposiopesis. Subaudimus uero 'coetibus' aut 'sacrificiis' aut quibuslibet rebus. <supplied>DICTA</supplied> supra dicta. </p>
             </div>
 
-            <div type="schol" n="14-15">
+            <div type="schol" n="14">
                <p> (NVLLISQVE SECVNDVS IN EXTIS / PALLET ET ARMATIS) SIMVLAT SPERARE (SACERDOS) cum metu futuri mali sacerdos ipse palleret, populis tamen propitios deos esse fingebat, ne animus uirorum fortium minueretur. Quia, ne armati aduersum omen accipiant, prospera pro terribilibus nuntiat. </p>
             </div>
 
-            <div type="schol" n="19">
+            <div type="schol" n="19a">
                <p> TRISTE nomen pro aduerbio, ut si dicatur 'tristiter'. </p>
             </div>
 
-            <div type="schol" n="19-20">
+            <div type="schol" n="19b">
                <p> (CVNCTIS DEPENDET AB ARMIS) / SVSPIRANDA DOMVS <hi rend="italic">domus</hi> pro 'familia', <hi rend="italic">suspiranda</hi> pro 'desiderabili' posuit. Id est: omnes armati domus suae dulcedine tangebantur. </p>
             </div>
 
@@ -6537,13 +6538,13 @@
                <p> (NOTA PVPPIM) DE RVPE SALVTANT uale illis dicunt et ut bene nauigent optant. Est ergo 'salutare' etiam abeuntibus uale dicere. NOTA cum ab ea domum rediens salutaretur. </p>
             </div>
 
-            <div type="schol" n="32-33">
+            <div type="schol" n="32">
                <p> NVNC MIHI FAMA PRIOR (MVNDIQVE ARCANA VETVSTAS / CVI MEMINISSE DVCVM VITASQVE EXTENDERE CVRAE) ideo ista numina inuocantur, quia nullum bellum Thebano antiquius fuit. Vt Lucanus:</p> 
                <l>'hinc aeui ueteris <supplied>custos</supplied>, famosa uetustas'.</l> 
                <p>Hic ergo inuocatio est Famae ac Vetustatis: o Fama, cui cura est meminisse uirorum fortium uitas, ne obliuione sopiantur. </p>
             </div>
 
-            <div type="schol" n="34-35">
+            <div type="schol" n="34">
                <p> TVQVE O NEMORIS (REGINA SONORI / CALLIOPE) <hi rend="italic">nemoris</hi> Pindi uel Parnassi, unde uox funditur Pieridum. </p>
             </div>
 
@@ -6551,7 +6552,7 @@
                <p> SVBLATA MOLIRE LYRA heroicum iam ardorem innectens <supplied>non</supplied> remissa lyra commemora<del>ta</del>.</p>
             </div>
 
-            <div type="schol" n="37-38">
+            <div type="schol" n="37">
                <p> (NEQVE ENIM ALTIOR VLLI) / MENS HAVSTO DE FONTE VENIT quia illic tu donas eloquia.</p>
             </div>
 
@@ -6559,11 +6560,11 @@
                <p> PONDERE CVRARVM magnitudine sollicitudinum. <supplied>PROPIORQVE ABEVNTIBVS ANNIS</supplied> circa finem uitae iam positus. </p>
             </div>
 
-            <div type="schol" n="40">
+            <div type="schol" n="40a">
                <p> VIX SPONTE uel quod senectutis tardaretur incommodo uel quod ad bellum ire cogebatur inuitus. </p>
             </div>
 
-            <div type="schol" n="40-41">
+            <div type="schol" n="40b">
                <p> (INCEDIT ...) CONTENTVS FERRO (CINGI LATVS) gladio tantummodo incedebat praecinctus aut propter senectutem, ne armis grauaretur, aut propter potestatem, quae munimini eius poterat sola sufficere. </p>
             </div>
 
@@ -6585,7 +6586,7 @@
                <l>'findor, ut Arcadiae pecuaria rudere dicas'. </l>
             </div>
 
-            <div type="schol" n="46-47">
+            <div type="schol" n="46">
                <p> (QVAEQVE PAVET LONGA SPVMANTEM VALLE) CHARADRON / (NERIS) <supplied>
                      <hi rend="italic">Neris</hi>
                   </supplied> ciuitas Peloponnensis quae Charadro fluuio iracunde teritur. </p>
@@ -6617,7 +6618,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="51-52">
+            <div type="schol" n="51">
                <p> (QVOS PIGRA VADO) STAGILLA TACENTI / (LAMBIT) id est quos Stagilla palus lambit. </p>
             </div>
 
@@ -6625,12 +6626,12 @@
                <p> (ANFRACTV RIPARVM INCVRVVS) ELISSOS flumen Achaicae regionis. Hunc Graeci ita uocant, tractum nomen a flexibus. </p>
             </div>
 
-            <div type="schol" n="&lt;53-55&gt;">
+            <div type="schol" n="53">
                <p> 
                   <supplied>STYGIAS LVSTRARE SEVERIS / EVMENIDAS PERHIBETVR AQVIS HVC MERGERE SVETAE / ORA ET ANHELANTES POTO PHLEGETHONTE CERASTAS</supplied> qui fertur ex Cocyto fluuio inferorum undarum augmenta percipere, uel in isto dicuntur Furiae fessas siti animare serpentes. </p>
             </div>
 
-            <div type="schol" n="56-57">
+            <div type="schol" n="56">
                <p> SEV TECTA MYCENIS / (IMPIA) propter fratrum discordias et parricidiales epulas et fugam Solis. Vnde Vergilius:</p> 
                <l>'nec tam auersus equos Tyria Sol iungit ab urbe'. </l>
             </div>
@@ -6643,23 +6644,23 @@
                </l>
             </div>
 
-            <div type="schol" n="60">
+            <div type="schol" n="60a">
                <p> CENCHREAEQVE (MANVS) Cenchreae portus est Corinthi. </p>
             </div>
 
-            <div type="schol" n="60-61">
+            <div type="schol" n="60b">
                <p> (VATVM QVA CONSCIVS AMNIS) / GORGONEO PERCVSSVS EQVO equo Pegaso, cuius ungula percussus locus fontem effudit qui Hippocrene<del>s</del> dicitur. Hoc enim fonte qui labra proluerit, poeta fiet. Ideo <hi rend="italic">uatum ... conscium</hi> dicit. Pegasus autem, Neptuni et Medusae Gorgonae filius, uolare solitus, cum uenisset in montem Heliconem, qui est in Boeotia, ungula locum quem percusserat, fontem inde excussit. Hunc dicit seruare uatibus carmina. Vnde Persius:</p> 
                <l>'nec fonte labra prolui caballino'. </l>
             </div>
 
-            <div type="schol" n="61-62">
+            <div type="schol" n="61">
                <p> (QVAQVE OBIACET ALTO) / ISTHMOS (ET A TERRIS MARIA INCLINATA REPELLIT) <supplied>
                      <hi rend="italic">Isthmos</hi>
                   </supplied> terra siue mons qui Aegaeum mare diuidit ab Ionio. Ideo autem dixit <hi rend="italic">maria inclinata repellit</hi>, quod Achaiam, in qua pater regnauit Pelops, duo maria circumdant, adeo ut insulam faciant nisi utrumque pelagus obiectus Isthmos interiaceret. Lucanus:</p> 
                <l>'gracilis mare separat Isthmos'.</l>
             </div>
 
-            <div type="schol" n="64-66">
+            <div type="schol" n="64">
                <p> (PARS) GAESA (MANV PARS ROBORA FLAMMIS / INDVRATA DIV NON VNVS NAMQVE MANIPLIS / MORS) NEQVE SANGVIS (HABENT) <supplied>
                      <hi rend="italic">gaesa</hi>
                   </supplied> tela Gallica. Vt Vergilius:</p>
@@ -6676,20 +6677,20 @@
                <p> (INGENTES) PLAGARVM IN PECTORE NODOS signa praeteritarum uirtutum. Id est cui praestant priora uulnera dignitatem. </p>
             </div>
 
-            <div type="schol" n="74-75">
+            <div type="schol" n="74">
                <p> DIRCAEVS ... / ... GENER Polynices, de fonte Boeotiae sic uocatus, qui ex Dircaeo funere, cuius corpus quod taurus traxit iuxta eum inuentum est, inde nomen accepit. Polynicen ergo <hi rend="italic">Dircaeum</hi> appellat. </p>
             </div>
 
-            <div type="schol" n="&lt;75-76&gt;">
+            <div type="schol" n="75">
                <p> 
                   <supplied>CVI COMMODAT IRAS / CVNCTA COHORS</supplied> ideoque propter quem ab omnibus prodiebatur ad bellum. </p>
             </div>
 
-            <div type="schol" n="77-79">
+            <div type="schol" n="77">
                <p> (SEV QVOS MOVET EXSVL ET HAESIT / TRISTIBVS) AVCTA FIDES (SEV QVIS MVTARE POTENTES / PRAECIPVVM) in quibus haec est fides aucta calamitatibus, quia misericordia commoti sunt, siue quibus praecipuum erat potentes mutare. </p>
             </div>
 
-            <div type="schol" n="80-81">
+            <div type="schol" n="80">
                <p> (DEDERAT NEC NON SOCER IPSE REGENDAS) / AEGION ARENENQVE ciuitates Arcadiae quas regendas Polynici genero quasi dotalis familiae Adrastus dederat, ne exsul regnare desuesceret aut certe ne sentiret exilium. THESEIA TROEZEN Thessaliae ciuitas, quam <hi rend="italic">Theseiam</hi> dixit quod Theseus Troezen<supplied>i</supplied>ae ciuitatis iter obsessum a latronibus liberum praestitisset, uel quia Theseus <supplied>Aegei et</supplied> Aethrae filius in hac urbe natus est. </p>
             </div>
 
@@ -6705,15 +6706,15 @@
                <p> SPHINX ideo dicta est quod quaestionibus ita constringeret homines ut se expedire non possent. Nam Graece <foreign xml:lang="grc">σφίγγειν</foreign> 'constringere' dicitur uel 'uinculum', quod illa propositis suis quasi uinculis colligaret omnium mentes, <del>uel</del> praeter Oedipoden patrem, cuius labor Sphinx est. </p>
             </div>
 
-            <div type="schol" n="91-92">
+            <div type="schol" n="91">
                <p> (HAEC MENTEM OCVLOSQVE REDVCIT / CONIVGIS ET DVLCES AVERTIT) PECTORE THEBAS a cupiditate Thebarum solo coniugis reuocatur affectu. </p>
             </div>
 
-            <div type="schol" n="94-96">
+            <div type="schol" n="94">
                <p> (IAM LAETVS ET) INTEGER ARTVS / (VT PRIMAE STREPVERE TVBAE CEV LVBRICVS ALTA / ANGVIS HVMO VERNI BLANDA AD SPIRAMINA SOLIS) integros artus habens post uulnerum curationem. Dicit ergo Tydeum audito tubarum strepitu nondum curatis uulneribus tamquam integro corpore ad bellum prodiisse, cuius arma uti uerno tempore anguis lubricus splendore radiabant. </p>
             </div>
 
-            <div type="schol" n="97-98">
+            <div type="schol" n="97">
                <p> (LIBER SENIO ET) SQVALENTIBVS ANNIS / (EXVTVS) quia deposita pelle dicuntur serpentes in iuuentutem redire. Herba quaedam dicitur marathros, quam cum comederint, senium deponunt aetatis. </p>
             </div>
 
@@ -6731,11 +6732,11 @@
                <p> (FLETAQVE COGNATIS AVIBVS) MELEAGRIA PLEVRON ciuitas Aetoliae, ut Homerus ait, in qua Meleagri sorores, dum fratrem flerent, in aues uersae sunt quae hodie 'meleagrides' uocantur. Causa enim haec illis fletus fuit, cum Althaea, mater Meleagri, titionem fatalem combureret, dum uindictam Plexippi et Agenoris quaerit, quos Meleager occiderat. Quo facto ipsa post tantum nefas merito laqueo uitam finiuit exosa lucis. Secuta est luctum alia calamitas. Namque Meleagri germanae in tantum fratrem fleuerunt ut deorum misericordia in aues uerterentur. </p>
             </div>
 
-            <div type="schol" n="104-105">
+            <div type="schol" n="104">
                <p> (QVAE IOVE PROVOCET IDEN) / OLENOS Arcadiae ciuitas, in qua Iouem Amalthea capra dicitur nutriisse, quae in cultu<del>m</del> Iouis Idam prouocat, montem Cretae in quo Iuppiter colitur. Contendit autem ut Iouem suum alumnum uindicet. </p>
             </div>
 
-            <div type="schol" n="106-107">
+            <div type="schol" n="106">
                <p> (HERCVLEA) TVRPATVS (GYMNADE VVLTVS / AMNIS) palaestri<supplied>ca</supplied> arte superatus, ut Ouidius ait. Qui autem uerius, hunc dicunt fluuium ante inuium ab Hercule in fossam deductum uires amisisse. Vt Lucanus ait:</p>
                <lg>
                   <l>'et scisso gurgite riuus</l>
@@ -6745,7 +6746,7 @@
                   <supplied>Cornu</supplied>copiam fecisse. </p>
             </div>
 
-            <div type="schol" n="107-109">
+            <div type="schol" n="107">
                <p> (ADHVC IMIS VIX TRVNCAM ATTOLLERE FRONTEM / AVSVS AQVIS GLAVCOQVE CAPVT SVBMERSVS IN ANTRO / MAERET ANHELANTES) AEGRESCVNT (PVLVERE RIPAE) dicitur Achelous duobus alueis fluxisse, cui Hercules unum clausit. Ideoque dicitur cornu truncatus. Hoc etiam sciens poeta <del>aliud agens</del> occulte tetigit dicens: <hi rend="italic">anhelantes aegrescunt puluere ripae</hi>. <hi rend="italic">Maerentem</hi> ergo 'tristem' dixit. </p>
             </div>
 
@@ -6764,18 +6765,18 @@
                <p> MAIOR AT INDE (NOVIS IT DORICVS ORDO SVB ARMIS) transitus ad Hippomedontem. Magna arte et uarietate sermonis primo copia, deinde describitur dux. </p>
             </div>
 
-            <div type="schol" n="[117]">
+            <div type="schol" n="117">
                <p> 
                   <del>LYRCIE fluuius est Aetoliae.</del>
                </p>
             </div>
 
-            <div type="schol" n="119">
+            <div type="schol" n="119a">
                <p> INACHE fluuius est maximus in Graecia, cuius Io filia a Ioue compressa in uaccam mutata est. Vnde Vergilius:</p> 
                <l>'at leuem clipeum sublatis cornibus Io'.</l>
             </div>
 
-            <div type="schol" n="119-120">
+            <div type="schol" n="119b">
                <p> PERSĒA ... / ... HVMO Argiua, ubi Perseus regnauit. <hi rend="italic">Persēa</hi> ergo principale pro deriuatiuo 'Perseia', unde et longam posuit 'se'. </p>
             </div>
 
@@ -6795,12 +6796,12 @@
                </p>
             </div>
 
-            <div type="schol" n="123">
+            <div type="schol" n="123a">
                <p> (RVRA ...) EPIDAVRIA <supplied>Epidaurus</supplied> ciuitas Argiuorum, ubi Aesculapius colitur, equorum fertilitate gratissima. Vnde Vergilius:</p> 
                <l>'domitrixque Epidaurus equorum'. </l>
             </div>
 
-            <div type="schol" n="123-124">
+            <div type="schol" n="123b">
                <p> (DEXTER IACCHO / COLLIS AT) AETNAEAE CERERI (NEGAT) <supplied>
                      <hi rend="italic">Aetnaeae Cereri</hi>
                   </supplied> Siculae Proserpinae. Ostendit supra dictum collem aptum uinetis esse, frugibus infecundum. </p>
@@ -6810,7 +6811,7 @@
                <p> PYLOS NELEIA <hi rend="italic">Pylos</hi> a Neleo, patre Nestoris, nuncupata <hi rend="italic">Neleia</hi>.</p>
             </div>
 
-            <div type="schol" n="126-127">
+            <div type="schol" n="126">
                <p> (NONDVM NOTA PYLOS IVVENISQVE) AETATE SECVNDA / (NESTOR) <supplied>
                      <hi rend="italic">nondum nota Pylos</hi>
                   </supplied> quia nondum militauerat Nestor. Multumque ipsa nouitate declarauit. Nam prima aetas triginta annorum est, secunda sexaginta. Nam Nestorem constat tertia aetate ad bellum uenisse Troianum. Ideo adhuc <hi rend="italic">iuuenem aetate secunda</hi> dixit, quia postmodum militauit. </p>
@@ -6820,12 +6821,12 @@
                <p> LATVS OMNE SVB ARMIS quod latus eius armis tegitur. </p>
             </div>
 
-            <div type="schol" n="&lt;132-133&gt;">
+            <div type="schol" n="132">
                <p> 
                   <supplied>PERFECTAQVE VIVIT IN AVRO / NOX DANAI</supplied> laus operis. <del>NOX</del> non nox uiuit, sed quae gesta sunt nocte. </p>
             </div>
 
-            <div type="schol" n="136-137">
+            <div type="schol" n="136">
                <p> ILLVM PALLADIA (SONIPES NEMEAEVS AB ARCE / DEVEHIT) Hippomedontem dicit, qui <del>ab Athenis id est</del> a Capitolio Mineruae ad bella descendit. (SONIPES ... / ...) ARMA PAVENS id est equus nouus ad bellum. <supplied>VMBRAQVE IMMANE VOLANTI</supplied> uelocitatis insignis. </p>
             </div>
 
@@ -6833,7 +6834,7 @@
                <p> ATTOLLIT PVLVERE CAMPVM quasi ipse campus assurgat. </p>
             </div>
 
-            <div type="schol" n="139-140">
+            <div type="schol" n="139">
                <p> VTROQVE ... / PECTORE eleganter <hi rend="italic">utroque</hi>, hominis et equi, quod bimembres sunt, id est humano et equino. </p>
             </div>
 
@@ -6842,23 +6843,23 @@
                   <del>PAVET</del> OSSA <del>VIAS</del> mons Thessaliae, in quo et Centauri. </p>
             </div>
 
-            <div type="schol" n="142-144">
+            <div type="schol" n="142">
                <p> (NON IPSIS FRATRIBVS HORROR / AFVIT INGENTI DONEC) PENEIA (SALTV) / STAGNA (SVBIT) Peneus Thessaliae fluuius. Quasi tam diu timeant, donec ad amnem ille perueniat.</p>
             </div>
 
-            <div type="schol" n="145-146">
+            <div type="schol" n="145">
                <p> (QVIS NVMERVM FERRI GENTISQVE ET ROBORA DICTV / AEQVARIT) MORTALE SONANS quod pro meritis militum fortitudines <supplied>non</supplied> poterint laudare mortales. </p>
             </div>
 
-            <div type="schol" n="146-147">
+            <div type="schol" n="146">
                <p> (SVVS EXCIT IN ARMA / ANTIQVAM) TIRYNTHA DEVS Iuppiter mutatus in Amphitryonem Alcaei et Astydamiae filium concubuisse cum Alcmena Electryonis filia dicitur in urbe Tirynthia. Vnde natus est Hercules, unde et Tirynthius dicitur. De qua Plautus tragicocomoediam dixit. </p>
             </div>
 
-            <div type="schol" n="147-149">
+            <div type="schol" n="147">
                <p> (NON FORTIBVS ILLA / INFECVNDA VIRIS FAMAQVE IMMANIS ALVMNI) / DEGENERAT (SED LAPSA SITV FORTVNA) non degenerat a fama Herculis: ipsi quidem fortes sunt, sed aeuo mutata est fortuna ciuitatis. </p>
             </div>
 
-            <div type="schol" n="149-150">
+            <div type="schol" n="149">
                <p> (NEQVE ADDVNT) / ROBVR OPES quia non potest fortuna addere uirtutes. Sola enim uirtus neque donatur neque accipitur. Vt Sallustius: 'probitatem, industriam, aliasque artis bonas neque dare neque accipere quispiam potest'. </p>
             </div>
 
@@ -6868,11 +6869,11 @@
                <p>Cyclopes istius ciuitatis moenia condiderunt, sicut asserunt Graeci. </p>
             </div>
 
-            <div type="schol" n="152-153">
+            <div type="schol" n="152">
                <p> (DAT TAMEN HAEC IVVENVM TERCENTVM PECTORA VVLGVS) / INNVMERVM BELLO expositio. Quid sint ter centum pectora? <hi rend="italic">Vulgus innumerum</hi>: quia tam fortes erant ut multorum facta fortia sua uirtute pensarent. </p>
             </div>
 
-            <div type="schol" n="154-156">
+            <div type="schol" n="154">
                <p> (FLAVAE CAPITI TERGOQVE LEONVM) / EXVVIAE (GENTILIS HONOS ET PINEVS ARMAT / STIPES) bene totum a similitudine Herculis. Quemadmodum ille claua, sic isti stipite. </p>
             </div>
 
@@ -6880,12 +6881,12 @@
                <p> (INEXHAVSTIS ARTANTVR) TELA PHARETRIS ita erat pharetra referta sagittis, ut exhauriri non posset. </p>
             </div>
 
-            <div type="schol" n="157-158">
+            <div type="schol" n="157">
                <p> (HERCVLEVM PAEANA CANVNT VASTATAQVE MONSTRIS) / OMNIA (FRONDOSA LONGVM DEVS AVDIT AB OETA) aut canunt omnia uastata monstris id est purgata, aut certe omnia audit Hercules in frondosa Oeta positus, quae uastata est monstris. In qua etiam concrematus Hercules eo loci cui Typhrestion nomen est. PAEANA proprie paean Apollini canitur. CANVNT ut Vergilius:</p> 
                <l>'ibant aequati numero regemque canebant'.</l>
             </div>
 
-            <div type="schol" n="159-160">
+            <div type="schol" n="159">
                <p> (DAT NEMEA COMITES ET QVAS IN PROELIA VIRES) / SACRA CLEONAEI (COGVNT VINETA MOLORCHI) ordo: Nemea dat comites, dant et Molorchi uineta. CLEONAEI <supplied>Cleonae</supplied> ciuitatis nomen est Nemeae siluae uicinae. Herculem eo loco Molorchus accepit hospitio censu pauper, diues affectu. Vt:</p>
                <lg>
                   <l>'ille Cleonaei proiecit terga leonis,</l>
@@ -6895,7 +6896,7 @@
                </p>
             </div>
 
-            <div type="schol" n="&lt;161&gt;">
+            <div type="schol" n="161">
                <p> 
                   <supplied>GLORIA NOTA CASAE</supplied> quia omnes in clipeorum pictura casam Molorchi et Herculis hospitium auro figuris notantes descripserunt. </p>
             </div>
@@ -6912,15 +6913,15 @@
                   <hi rend="italic">Sedeant</hi> autem mire. Significat enim factam lacunam terrae Herculis mole. Hanc descriptionem poetae pictam ipsius Tirynthe portabat exercitus. </p>
             </div>
 
-            <div type="schol" n="165-166">
+            <div type="schol" n="165">
                <p> AT PEDES (ET TOTO DESPECTANS VERTICE BELLVM / ... CAPANEVS) pedes quidem erat Capaneus, sed omnibus eminebat. Solent enim equites altiores esse pedestribus. <hi rend="italic">Bellum</hi> ergo pro bellatoribus posuit. </p>
             </div>
 
-            <div type="schol" n="166-168">
+            <div type="schol" n="166">
                <p> (QVATTVOR INDOMITIS CAPANEVS EREPTA IVVENCIS / TERGA SVPERQVE RIGENS) INIECTV MOLIS (AENAE / VERSAT ONVS) ostendit multis taurorum coriis, laminis etiam aeneis Capanei clipeum obductum fuisse. </p>
             </div>
 
-            <div type="schol" n="168-169">
+            <div type="schol" n="168">
                <p> (SQVALET TRIPLICI RAMOSA CORONA) / HYDRA RECENS (OBITV) ita ueritatem expressit pictura, ut paene recenti obitu Hydra cum suis serpentibus interiret. </p>
             </div>
 
@@ -6965,11 +6966,11 @@
                <p> DORION oppidum de quo hic poeta fuit. </p>
             </div>
 
-            <div type="schol" n="183">
+            <div type="schol" n="183a">
                <p> AONIDAS Musas a montis nomine nuncupatas. </p>
             </div>
 
-            <div type="schol" n="183-185">
+            <div type="schol" n="183b">
                <p> (MVTOS ...) DAMNATVS (IN ANNOS / ORE SIMVL CITHARAQVE... / CONTICVIT PRAECEPS) <supplied>
                      <hi rend="italic">damnatus</hi>
                   </supplied> caecatus mente, non lumine. <del>ORE SIMVL</del> optime poeta Homeri ambiguum uerbum <foreign xml:lang="grc">πηρόν</foreign> intellexit de hoc ipso, quod accentus commutatione significauit non caecatum, sed eum cuius sit <hi rend="italic">damnatum</hi> ingenium ut nec chordarum gloriam nec sonum uocis inferret. </p>
@@ -6985,7 +6986,7 @@
                <l>'damnatae Phoebo uictore Celaenae'.</l>
             </div>
 
-            <div type="schol" n="&lt;191&gt;">
+            <div type="schol" n="191">
                <p> 
                   <supplied>VETITOQVE DOMVS IAM FVLGVRAT AVRO</supplied> Alcmaeon hoc monile occisa matre Apollini consecrauit, quod in fontem missum hodieque cerni dicitur, quod si quis manu attrectauerit <supplied>et</supplied> ostenderit caelo, offendi solem et tempestates oriri. Vnde Vergilius:</p>
                <lg>
@@ -6994,11 +6995,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="193-194">
+            <div type="schol" n="193">
                <p> (SED PERFIDA CONIVNX) / DONA VIRO (MVTARE VELIT) de Homero transtulit. Ita uelit pacisci, ut malit monile habere quam coniugem. </p>
             </div>
 
-            <div type="schol" n="196-198">
+            <div type="schol" n="196">
                <p> (NAM REGVM ANIMOS ET PONDERA BELLI) / HAC NVTARE VIDET (PARITER NI PROVIDVS HEROS / MILITET) uidet Argia belli totius mutari sententiam, si Amphiaraus desit auxiliis. </p>
             </div>
 
@@ -7006,7 +7007,7 @@
                <p> SACROS exsecrandos. </p>
             </div>
 
-            <div type="schol" n="202-203">
+            <div type="schol" n="202">
                <p> SAT DVBIVM (COETV SOLANTE TIMOREM / FALLERE ET INCVLTOS ARIS ADVERRERE CRINES) sensus: sufficit ad solacium feminae tali tempore <supplied>
                      <gap/>
                   </supplied> orantibus carere. Ordo talis est: sat mihi timorem dubium coetu solante fallere hoc est dissimulare. </p>
@@ -7029,7 +7030,7 @@
                <p> DISPARE COETV bene <hi rend="italic">dispare</hi>. Nec enim tanta nobilitas equi ex eadem stirpe equam potuit inuenire. <hi rend="italic">Coetu</hi> a coeundo dixit in uenerem. </p>
             </div>
 
-            <div type="schol" n="&lt;215&gt;">
+            <div type="schol" n="215">
                <p> 
                   <supplied>CYLLARVS IGNARO ... CASTORE</supplied> hunc equum Pollucis dixit Vergilius licentia poetae:</p> 
                <l>'Cyllarus et quorum Grai meminere poetae'.</l> 
@@ -7066,16 +7067,16 @@
                <p> (PHARIS) VOLVCRVMQVE PARENS (CYTHEREIA MESSE) et hunc uersum de Homero transtulit. <hi rend="italic">Volucrum</hi> ergo <hi rend="italic">parens</hi> columbarum, unde se probat Cytheream esse quia amat aues Veneri consecratas. Quae autem causa sit ficta quod Venus columba delectata <supplied>sit</supplied>, talis est: quod Venus et Cupido, cum quodam tempore uoluptatis gratia in quosdam nitentes descendissent campos, lasciua contentione certare coeperunt qui plus sibi gemmantes colligeret flores. Quorum Cupido adiutus mobilitate pennarum, quamquam naturam corporis uolatu superauit, uictus est numero. Peristera enim Nympha subito accurrit et adiuuando Venerem superiorem effecit cum poena sua. Cupido siquidem indignatus mutauit puellam in auem quae a Graecis <foreign xml:lang="grc">περιστερά</foreign> appellatur. Sed poenam honor minuit. Venus namque, consolatura <del>et</del> innocentis transfigurationem, columbam in tutela sua esse mandauit. </p>
             </div>
 
-            <div type="schol" n="227-228">
+            <div type="schol" n="227">
                <p> EVROTAE / (DVRA MANVS) <hi rend="italic">Eurotae</hi> cur dixerit, ipse narrauit. Iuxta hunc fluuium Lacones uapulando contendunt. Gloriosior tamen ille est qui ultra praescriptum numerum plagarum animae non pepercit, quod, cum deuouerit spiritum, publice funeratus capite coronatur. Tanta enim crudelitas in hac gente est ut mater lacrimas suas consoletur funere coronato. </p>
             </div>
 
-            <div type="schol" n="&lt;228-230&gt;">
+            <div type="schol" n="228">
                <p> 
                   <supplied>DEVS IPSE VIROS IN PVLVERE CRVDO / ARCAS ALIT NVDAEQVE MODOS VIRTVTIS ET IRAS / INGENERAT</supplied> deum dixit hoc hortari Mercurium quia palaestrarum numen est. Vnde Mercurius ad uirtutem et belli officia studiosus palaestrae est. </p>
             </div>
 
-            <div type="schol" n="231-232">
+            <div type="schol" n="231">
                <p> GAVDENT (NATORVM FATA PARENTES / HORTANTVRQVE MORI) quia, cum dimicant, contra uerbera patientiam dicuntur hortari, cum autem ad bellum eunt, arma dant liberis et ha<supplied>n</supplied>c hortatione<supplied>m</supplied> subiciunt: 'aut cum his aut supra haec', quod significat uel uictores debere reuerti uel mortuos. Vnde Lucanus:</p>
                <lg>
                   <l>'inde ruenti</l>
@@ -7083,7 +7084,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="232-233">
+            <div type="schol" n="232">
                <p> (DEFLENT IAMQVE OMNIS EPHEBVM / TVRBA CORONATO CONTENTA EST) FVNERE MATER sensus: omnis quidem turba ephebi lamentantur interitum, mater sola neglegit luctus, quia filius coronatur exstinctus. </p>
             </div>
 
@@ -7102,7 +7103,7 @@
                <p> DEPRESSAE (... PISAE) quia uallibus undique Pisae cinguntur et Cro<del>to</del>nio monte premuntur. </p>
             </div>
 
-            <div type="schol" n="239-240">
+            <div type="schol" n="239">
                <p> (FLAVE ...) ALPHEE SICANIS / (ADVENA) constat enim hunc fluuium amore Arethusae Nymphae occultas egisse uias subter mare et in Sicilia fluctibus amatae misceri. ADVENA<del>M</del> merito scilicet <hi rend="italic">aduena<del>m</del>
                   </hi>, quia ab Elide in Siciliam labitur per mare nec tamen aquae marinae miscetur. </p>
             </div>
@@ -7112,15 +7113,15 @@
                <l>'et cui putre solum — namque hoc imitamur arando'. </l>
             </div>
 
-            <div type="schol" n="242">
+            <div type="schol" n="242a">
                <p> ET BELLIS (ARMENTA DOMANT) aut <hi rend="italic">in bellis ... domant</hi>.</p>
             </div>
 
-            <div type="schol" n="242-244">
+            <div type="schol" n="242b">
                <p> (EA GLORIA GENTI / INFANDO DE MORE ET FRACTIS DVRAT AB VSQVE) / AXIBVS OENOMAI ex quo Oenomaus hanc legem procis filiae posuit, ut uictus interficeretur, uxorem uictor acciperet. Qui<del>a</del>, Myrtili aurigae sui fraude deceptus, ipse supplicia quae praeponebat expendit. ET FRACTIS ... AXIBVS ingenio ut diximus Myrtili, qui corruptus rotas cera coniunxerat. Dixit autem de his qui ex Pisa sunt ingenitum esse ut equis gaudeant ex illo studio, quod rex Oenomaus <supplied>ea</supplied> arte praecelleret. </p>
             </div>
 
-            <div type="schol" n="246-248">
+            <div type="schol" n="246">
                <p> TV QVOQVE ... / ... / (PARTHENOPAEE) Parthenopaeus, Atalantae filius. PARRHASIAS (... CATERVAS) Arcadias. Vt Vergilius:</p> 
                <l>'Parrhasio dictum Panos de more Lycaei'. </l>
             </div>
@@ -7130,7 +7131,7 @@
                <l>'ante annos animumque gerens curamque uirilem'. </l>
             </div>
 
-            <div type="schol" n="248-250">
+            <div type="schol" n="248">
                <p> (SALTVS TVNC FORTE REMOTOS / TORVA PARENS...) / PACABAT CORNV (GELIDIQVE AVERSA LYCAEI) id est: uenationibus pacata ferarum reddebat interitu. Vt Vergilius:</p>
                <lg>
                   <l>'aut Erymanthi</l>
@@ -7138,7 +7139,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="251-252">
+            <div type="schol" n="251">
                <p> PVLCHRIOR HAVT VLLI (TRISTE AD DISCRIMEN ITVRO / VVLTVS) id est: Parthenopaeo pulchrior nullus fuit. </p>
             </div>
 
@@ -7146,11 +7147,11 @@
                <p> NEC DESVNT ANIMI (VENIAT MODO FORTIOR AETAS) id est: in Parthenopaeo animorum uigebat insigne, si modo ad id etiam aetatis robur accederet. </p>
             </div>
 
-            <div type="schol" n="254-255">
+            <div type="schol" n="254">
                <p> QVAS NON ILLE (DVCES NEMORVM FLVVIISQVE DICATA / NVMINA QVAS MAGNO NON IMPVLIT IGNE NAPAEAS) Nymphas aut Dryadas <del>aut Oreadas</del> aut Potamidas aut Napaeas dicit. Dryades sunt, quae quercubus delectantur, <del>Oreades montibus,</del> Potamides fluminibus, Napaeae uirgultis et floribus. </p>
             </div>
 
-            <div type="schol" n="256-258">
+            <div type="schol" n="256">
                <p> IPSAM MAENALIA (PVERVM CVM VIDIT IN VMBRA / DIANAM TENERO SIGNANTEM GRAMINA PASSV / IGNOVISSE FERVNT COMITI) <supplied>
                      <hi rend="italic">ipsam</hi>
                   </supplied> Dianam scilicet, quae Atalantae ob amissam uirginitatem ignouit <supplied>SIGNANTEM GRAMINA</supplied> eleganter infantis gressum non calcantem sed <hi rend="italic">signantem</hi> ostendit. Vt Horatius:</p>
@@ -7161,7 +7162,7 @@
                <p>Dicit ergo Dianam, cum tam pulchrum uidisset Parthenopaeum, Atalantae dedisse ueniam, cui propter concubitus fuerat irata Meleagri. </p>
             </div>
 
-            <div type="schol" n="261-262">
+            <div type="schol" n="261">
                <p> (PVLVERE BELLI) / FLAVENTEM SORDERE COMAM Horatius:</p>
                <lg>
                   <l>'sunt, quos curriculo puluerem Olympicum</l>
@@ -7169,7 +7170,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;263-264&gt;">
+            <div type="schol" n="263">
                <p> 
                   <supplied>TITVLVMQVE NOCENTEM / SANGVINIS HVMANI PVDOR EST NESCIRE SAGITTAS</supplied> sensus: erubescebat Parthenopaeus, quod nondum humano sanguine suas sagittas infecerat et quod non hac crudelitate laudis fuerat titulum consecutus. </p>
             </div>
@@ -7178,15 +7179,15 @@
                <p> VNDANTEM(QVE) SINVM (NODIS INRVGAT HIBERIS) qui undantem chlamydem quassando facit panno. NODIS ... HIBERIS balteo. </p>
             </div>
 
-            <div type="schol" n="267">
+            <div type="schol" n="267a">
                <p> IMBELLI PARMA cum qua nunquam pugnasset. </p>
             </div>
 
-            <div type="schol" n="267-268">
+            <div type="schol" n="267b">
                <p> (IMBELLI PARMA PICTVS CALYDONIA) MATRIS / PROELIA hoc est scuto picta gerens proelia. Calydonium quippe aprum comitata uiros Atalante sagittis fixit, ut priore libro docuimus. </p>
             </div>
 
-            <div type="schol" n="268-269">
+            <div type="schol" n="268">
                <p> ASPERA PLVMIS / (TERGA) loricae squamas explicuit, quam alii 'cataphractam' uocant. Vnde Vergilius:</p>
                <lg>
                   <l>'quem pellis aënis</l>
@@ -7199,7 +7200,7 @@
                <l>'corytique leues humeris et letifer arcus'.</l>
             </div>
 
-            <div type="schol" n="272-273">
+            <div type="schol" n="272">
                <p> (ARMA) / MIRANTEM GRAVIORIS ERI armorum permutatio grauiorem equo fecerat dominum. Addita enim lorica onerosior Parthenopaeus exstiterat. </p>
             </div>
 
@@ -7212,12 +7213,12 @@
                </lg>
             </div>
 
-            <div type="schol" n="276-277">
+            <div type="schol" n="276">
                <p> NEMORVM <supplied>Q</supplied>VOS STIRPE RIGENTI / (FAMA SATOS) non quia de arboribus uere nati sunt, sed quia deerat usus casarum et in morem pecorum uagabantur. Filios autem suos aut arborum caueis aut cautium specubus contegebant, quos transeuntes arborum filios aestimabant. Quam opinionem Vergilius asserit dicens:</p> 
                <l>'gensque uirum truncis et duro robore nati'.</l>
             </div>
 
-            <div type="schol" n="282-283">
+            <div type="schol" n="282">
                <p> HI LVCIS STVPVISSE VICES (NOCTISQVE FERVNTVR / NVBILA) quasi qui primi nati sunt, quod diei nox obscura succederet. </p>
             </div>
 
@@ -7225,19 +7226,19 @@
                <p> (OCCIDVVM LONGE) TITANA SECVTI oculis persecuti sunt solis occasum. </p>
             </div>
 
-            <div type="schol" n="284">
+            <div type="schol" n="284a">
                <p> DESPERASSE DIEM dicit homines arboribus natos perpetuam noctem timuisse solis occasu. </p>
             </div>
 
-            <div type="schol" n="284-285">
+            <div type="schol" n="284b">
                <p> RARESCVNT (ALTA COLONIS / MAENALA) desolantur necessitate bellorum. Vt Vergilius: <supplied>'squalent abductis arua colonis'. </supplied> (ALTA ...) / MAENALA <del>ET</del> PARTHENIVM (... NEMVS) mons et nemus Arcadiae. </p>
             </div>
 
-            <div type="schol" n="286">
+            <div type="schol" n="286a">
                <p> VENTOSA (... ENISPE) <hi rend="italic">uentosam</hi> dixit aut tempestatibus grauem aut, ut quidam uolunt, in edito positam. </p>
             </div>
 
-            <div type="schol" n="286-288">
+            <div type="schol" n="286b">
                <p> (RHIPEQVE ET STRATIE VENTOSAQVE DONAT ENISPE / NON TEGEA) NON IPSA DEO (VACAT ALITE FELIX / CYLLENE TEMPLVMQVE ALEAE NEMORALE MINERVAE) omnes hae ciuitates Arcadiae in Maenalo monte. Vnde Vergilius:</p> 
                <l>'Tegeaeum subligat ensem'</l> 
                <p>et:</p> 
@@ -7255,11 +7256,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="289">
+            <div type="schol" n="289a">
                <p> CLITOR et hic fluuius est Arcadiae. </p>
             </div>
 
-            <div type="schol" n="289-290">
+            <div type="schol" n="289b">
                <p> (TIBI PYTHIE LADON) / PAENE SOCER propter Daphnen Ladonis filiam, quam Apollo dilexit. <hi rend="italic">Paene</hi> autem, quia <del>uirginitatis damnum est</del> in laurum ante concubitum <supplied>dicitur</supplied> fuisse conuersa. (CANDENSQVE IVGIS) LAMPIA NIVOSIS Lampia ciuitas est Arcadiae niuosis montibus constituta. Ergo <hi rend="italic">Lampiam</hi> a candore pruinarum dictam nominis ipsius proprietas monstrat. <foreign xml:lang="grc">λαμπρόν</foreign> enim Graece 'splendidum' dicitur. </p>
             </div>
 
@@ -7300,7 +7301,7 @@
                <l>'stipitibus duris agitur sudibusue praeustis'. </l>
             </div>
 
-            <div type="schol" n="306-308">
+            <div type="schol" n="306">
                <p> MILITE VICINAE (NVLLO IVVERE MYCENAE / FVNEREAE TVNC NAMQVE DAPES MEDIIQVE RECVRSVS / SOLIS ET HIC ALII MISCEBANT PROELIA FRATRES) <del>plenus enim fabulae ita se continet textus.</del> Atreus et Thyestes, Pelopis filii, Tantali nepotes, alternis uicibus regnum regebant. Verum Thyestes, cum incestasset Aeropam, fratris uxorem, ab eo pulsus <supplied>est</supplied> a regno. Sed inter eos, quia scelere certabant, uidebatur pro uindicta ficta gratia reconciliationis. Atreus fratri filios suos apposuit epulandos, cui post epulas filiorum capita signum conuiuii feralis ostendit. In cuius rei <unclear>delectationem</unclear>, cum Thyestes consulta de oraculis posceret, responsum est per eum illi certam uenire posse uindictam qui ex ipso et filia Pelopeia natus fuisset. Vnde ille cito filiae amplexus inuasit. Ex qua natus est puer quem illa in siluas propter conscientiam abiecit. Hic caprae uberibus nutritus ex eadem re Aegisthus nomen accepit. Atreum in uindictam patris, cum adoleuisset, occidit. Idem autem Agamemnonem, cum Clytaemestram uxorem eius adulterasset, occidit. Vt ipse Vergilius:</p>
                <lg>
                   <l>'ipse Mycenaeus magnorum ductor Achiuum</l>
@@ -7328,7 +7329,7 @@
                <l>'ingenti clamore premes ad retia ceruum'. </l>
             </div>
 
-            <div type="schol" n="329-330">
+            <div type="schol" n="329">
                <p> VIX DRYADVM THALAMIS (ERYMANTHIADVMQVE FVRORI / NYMPHARVM MATVRE PVER) <supplied>
                      <hi rend="italic">mature</hi>
                   </supplied> ueneriae uoluptati. Adeo filium dehortatur ut nec <supplied>se</supplied> uirum credat. </p>
@@ -7347,11 +7348,11 @@
                   <del>HOC</del> SEGNIOR ARCVS celeres sagittas non mittens. </p>
             </div>
 
-            <div type="schol" n="336-337">
+            <div type="schol" n="336">
                <p> (DVM ROSEIS VENIT VMBRA GENIS) VVLTVSQVE RECEDVNT / (ORE MEI) ne leuitate uultus femina esse credaris. Dum tuo ore mei uultus recedunt, id est: dum uiri sumis formam. Nam modo similis es matri. </p>
             </div>
 
-            <div type="schol" n="339-340">
+            <div type="schol" n="339">
                <p> (VOS AVTEM HVNC IRE SINETIS / ARCADES) O SAXIS NIMIRVM ET ROBORE NATI ut origini conueniret animus, quia dura corda habetis et non uos flectit misericordia. Maledicit illis dicendo asperos durosque quia materno non commouentur affectu. </p>
             </div>
 
@@ -7359,7 +7360,7 @@
                <p> (AT PARTE EX ALIA) CADMI MAVORTIA PLEBES utique Thebani. Transitus ad Thebas. </p>
             </div>
 
-            <div type="schol" n="358-360">
+            <div type="schol" n="358">
                <p> (FIDE SACRA / AEQVATOS CAELO) SVRDVM ATQVE IGNOBILE (MVROS / FIRMAT OPVS) <hi rend="italic">surdum ... opus</hi> pro cantu: <foreign xml:lang="grc">διαστολή</foreign> illa ui operis, quod canente Amphione instructum est. Modo autem <hi rend="italic">surdum</hi> est, quia manu, non carmine, condebatur. Ad Thebarum muros cantilena Amphion dicitur saxa traxisse. Vt Vergilius:</p>
                <lg>
                   <l>'canto, quae solitus, siquando armenta uocabat,</l>
@@ -7367,7 +7368,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="360-362">
+            <div type="schol" n="360">
                <p> TAMEN ET BOEOTIS VRBIBVS (VLTRIX / ADSPIRAT FERRI RABIES NEC REGIS INIQVI / SVBSIDIO QVANTVM SOCIA PRO GENTE MOVENTVR) hoc dicit Eteocli quoque dedisse Boeotiae urbes auxilia. Nullus regis causa uenit ad bellum, sed aut uicinitate compulsae sunt aut misericordia ciuitates. </p>
             </div>
 
@@ -7383,7 +7384,7 @@
                <p> NON INSCIVS AVSI occisi pecoris, ut conscius audacis facti. </p>
             </div>
 
-            <div type="schol" n="370-371">
+            <div type="schol" n="370">
                <p> (HIC IAM DISPERSOS) ERRARE ASOPIDE RIPA / (LERNAEOS EQVITES) ut Lucanus:</p>
                <lg>
                   <l>'est qui, tauriferis ubi se Meuania campis</l>
@@ -7401,7 +7402,7 @@
                <p> NVNTIAT EXCVBIIS (VIGILES ARSISSE PLATAEAS) id est: nuntiat Argiuos hostili more excubias agere. VIGILES ARSISSE PLATAEAS pro multo lumine excubantium uigiles Plataeas dicit <hi rend="italic">arsisse</hi>. Est autem ciuitas Boeotiae in confinio hostium: ideo semper inuigilat. Aut, quia in aditu est posita, dicit primo fuisse uastatam. </p>
             </div>
 
-            <div type="schol" n="374-375">
+            <div type="schol" n="374">
                <p> (NAM TYRIOS SVDARE LARES ET SANGVINE DIRCEN / IRRIGVAM) FETVSQVE NOVOS <supplied>
                      <hi rend="italic">Tyrios ... lares</hi>
                   </supplied> quos in Thebas Cadmus inuexit. Dirce autem fons est Thebanorum. Vtrumque monstrauit ut Vergilius:</p> 
@@ -7415,7 +7416,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="378-382">
+            <div type="schol" n="378">
                <p> (SPARSIS SVBITO CORREPTA CANISTRIS / SILVESTRIS REGINA CHORI DECVRRIT IN AEQVVM / VERTICE AB OGYGIO) TRIFIDAMQVE HVC TRISTIS ET ILLVC / (LVMINE SANGVINEO PINVM DISIECTAT ET ARDENS / ERECTAM ATTONITIS IMPLET CLAMORIBVS VRBEM) pathos tribus modis fit. Attendamus igitur, ut haec complexus sit: facto <hi rend="italic">sparsis subito correpta canistris / siluestris regina chori</hi> ... <supplied>habitu</supplied>: <hi rend="italic">trifidamque huc et illuc / lumine sanguineo pinum disiectat</hi>, <supplied>dictu</supplied>: <hi rend="italic">et ardens erectam attonitis implet clamoribus urbem</hi>. De fonte Vergiliano hunc colorem deriuauit. Is enim Amatam in siluis eadem fecisse describit. Pathos ipsius tribus modis ostendit: facto:</p>
                <lg>
                   <l>'ipsa inter medias flagrantem feruida pinum</l>
@@ -7428,7 +7429,7 @@
                <p>(SILVESTRIS) REGINA CHORI ut choros ducebat sacerdos una Baccharum. Ostendit autem antistitem Liberi, quae Cithaeronem incolebat. </p>
             </div>
 
-            <div type="schol" n="383-384">
+            <div type="schol" n="383">
                <p> GENTIS AVITAE / (... AMOR) propter Semelen, Cadmi filiam, matrem Liberi. </p>
             </div>
 
@@ -7439,7 +7440,7 @@
                <l>'per septem portus in maris exit aquas'. </l>
             </div>
 
-            <div type="schol" n="391-393">
+            <div type="schol" n="391">
                <p> (BELLVM LACRIMASQVE METVMQVE / COGNATVMQVE NEFAS INIVSTI MVNERA REGNI) / PENDIMVS inuidiose. Quasi pro sacrificio bellum lacrimasque tibi pendimus. </p>
             </div>
 
@@ -7447,15 +7448,15 @@
                <p> AMAZONIIS VLVLATVM CAVCASON ARMIS Caucasus mons Scythiae. Ideo <hi rend="italic">ululatum</hi>, quod Amazones cum finitimis bellare dicuntur, quarum ululatus 'barritus' est, id est 'barbarus ritus'. </p>
             </div>
 
-            <div type="schol" n="396-397">
+            <div type="schol" n="396">
                <p> (ALIVM TIBI BACCHE FVROREM) / IVRAVI iuraui tibi in furorem sacrorum, non bellicum, hoc est non ut bella canerem, sed ut sacrorum causas intellegerem. Et bene de more militiae <hi rend="italic">iuraui</hi> dixit, quia militiae sacramentum dicitur. Et sacerdotio se dixit iurasse, non bello. </p>
             </div>
 
-            <div type="schol" n="404">
+            <div type="schol" n="404a">
                <p> ET SALTVM DVX ALTER HABET Creontem significat, qui post interitum fratrum solus possedit imperium. </p>
             </div>
 
-            <div type="schol" n="404-405">
+            <div type="schol" n="404b">
                <p> GELATIS / VVLTIBVS pallore. Nam iam deposuerat numinis furorem. </p>
             </div>
 
@@ -7463,7 +7464,7 @@
                <p> VARIIS TERRORIBVS IMPAR qui <del>non</del> terretur. <del>ac per hoc inconterritus.</del> Par est enim timori, qui non terretur. </p>
             </div>
 
-            <div type="schol" n="407-408">
+            <div type="schol" n="407">
                <p> TENEBRASQVE SAGACES / (TIRESIAE) quia caecus sed diuinus Tiresias. <del>
                      <hi rend="italic">Tenebras</hi> dicit ignorantiam futurorum,</del> 
                   <hi rend="italic">sagaces</hi>, quae totum inuestigarent. </p>
@@ -7483,16 +7484,16 @@
                <p> TRIPODE IMPLICITO obscuro Apollinis responso. NVMERISQVE SEQVENTIBVS ASTRA ut arithmetici, quos mathematicos dicimus, quorum in numeris est tota doctrina. </p>
             </div>
 
-            <div type="schol" n="&lt;412&gt;">
+            <div type="schol" n="412a">
                <p> 
                   <supplied>TVREA ... SVPRA VOLITANTE ALTARIA FVMO</supplied> est etiam ars quaedam ex fumo arae uerum prouidere, quia ex diuisione ipsius fumi quae sint futura cognoscunt quos <foreign xml:lang="grc">καπνομάντεις</foreign> appellant. </p>
             </div>
 
-            <div type="schol" n="412-414">
+            <div type="schol" n="412b">
                <p> (NEC ... / TAM PENITVS DVRAE QVAM MORTIS LIMITE MANES) / ELICITOS PATVISSE REFERT non aliis rebus melius quam manibus elicitis. Id est: tantum interius inferos aperire refert, quam sunt <supplied>in</supplied> mortis durae spatia demersi. </p>
             </div>
 
-            <div type="schol" n="415-416">
+            <div type="schol" n="415">
                <p> (ET MERSVM ... / ...) PARAT ANTE DVCEM ad futurum scilicet sacrificium Eteoclen. ET MERSVM ... PARAT uerbum figurauit a nomine. (ISMENI SVBTER) CONFINIA (PONTO / MISCENTIS) inter iuncturas Ismeni fluuii pelagique. </p>
             </div>
 
@@ -7512,7 +7513,7 @@
                <p> (GETICA ...) AB VRSA a septentrionali plaga. </p>
             </div>
 
-            <div type="schol" n="423-424">
+            <div type="schol" n="423">
                <p> (VACVVSQVE) SILENTIA SERVAT / HORROR possidet quaedam ueneratio, quia in magno silentio horror nascitur. </p>
             </div>
 
@@ -7524,7 +7525,7 @@
                <p> NEC CARET VMBRA DEO quasi alios quoque deos habeat consecratos. </p>
             </div>
 
-            <div type="schol" n="426-427">
+            <div type="schol" n="426">
                <p> (HANC PICEAE CEDRIQVE ET ROBORE IN OMNI) / EFFICTAM (SANCTIS OCCVLTAT SILVA TENEBRIS) <supplied>
                      <hi rend="italic">effictam</hi>
                   </supplied> sculptam, quasi in omnibus arboribus imago eius esset insculpta. Omnis lucus Dianae est consecratus, ut quercus Ioui. </p>
@@ -7534,7 +7535,7 @@
                <p> HVIVS INASPECTAE (LVCO) STRIDERE SAGITTAE ut sonus tantum sit, uisus uero nullus. </p>
             </div>
 
-            <div type="schol" n="429-430">
+            <div type="schol" n="429">
                <p> (VBI LIMINA PATRVI / EFFVGIT) INQVE NOVAE MELIOR R(EDIT) O(RA) D(IANAE) <hi rend="italic">melior</hi>, quando inferos deserit. Lucanus:</p>
                <lg>
                   <l>'ad quos alio procedere uultu</l>
@@ -7546,11 +7547,11 @@
                <p> (EXTRA) IMMANE PATET TELLVS (MAVORTIA CAMPI) extra ipsum lucum campus late diffunditur. </p>
             </div>
 
-            <div type="schol" n="435-437">
+            <div type="schol" n="435">
                <p> (DVRVS) QVI VOMERE PRIMO / (POST CONSANGVINEAS ACIES SVLCOSQVE NOCENTES / AVSVS HVMVM VERSARE) <hi rend="italic">durus</hi>, quisquis primo hunc arauit, id est Cadmus satis draconis dentibus. </p>
             </div>
 
-            <div type="schol" n="438-441">
+            <div type="schol" n="438">
                <p> (INGENTES) INFELIX TERRA TVMVLTVS / (... / EXSPIRAT NIGRI CVM VANA IN PROELIA SVRGVNT / TERRIGENAE) <hi rend="italic">tumultus</hi> dicit illarum animarum, quae se occiderunt. Id est: aratoris proscissione indignantes pugnant inter se. </p>
             </div>
 
@@ -7562,11 +7563,11 @@
                <p> INSANI ... IVVENCI metu perterriti. </p>
             </div>
 
-            <div type="schol" n="443-444">
+            <div type="schol" n="443">
                <p> HIC SENIOR VATES (STYGIIS ADCOMMODA QVIPPE / TERRA SACRIS VIVOQVE PLACENT SOLA PINGVIA TABO) causam dicit, cur ibi Tiresias sacrificet, quia nunc terrigenarum sanguine sanguineus est locus. Sanguine enim inferi delectantur. SOLA PINGVIA TABO satiata cruore. Describitur locus in quo hoc contendit, opportunus inferis sacris. </p>
             </div>
 
-            <div type="schol" n="445-446">
+            <div type="schol" n="445">
                <p> ARMENTAQVE SISTI / ATRA MOVET ut Vergilius:</p>
                <lg>
                   <l>'quattuor hic primum nigrantis terga iuuencos</l>
@@ -7574,7 +7575,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="447-448">
+            <div type="schol" n="447">
                <p> (INGEMVIT DIRCE MAESTVSQVE CITHAERON / ET NOVA CLAMOSAE) STVPVERE SILENTIA VALLES Baccharum uocibus clamosae ualles destitutae immolatarum pecudum mugitibus stupuere. Dicit paene phantasia omnem gregem in luco immolatum usque adeo ut fons de quo potabant armenta et mons per quem errabant ingemiscerent, cum se armentis destitutos uiderent. </p>
             </div>
 
@@ -7582,20 +7583,20 @@
                <p> IPSE MANV TRACTANS cum oculorum officio manibus fungeretur. </p>
             </div>
 
-            <div type="schol" n="451">
+            <div type="schol" n="451a">
                <p> (NOVIENS) TELLVRE CAVATA pro nouem scrobibus factis, in quibus ductus aquae quae sacris esset necessaria collocauit. </p>
             </div>
 
-            <div type="schol" n="&lt;451-452&gt;">
+            <div type="schol" n="451b">
                <p> 
                   <supplied>LARGOS ... / INCLINAT BACCHI LATICES</supplied> id est: nobiles latices fudit. </p>
             </div>
 
-            <div type="schol" n="453-454">
+            <div type="schol" n="453a">
                <p> ACTAEOS IMBRES (SVADVMQVE CRVOREM / MANIBVS AGGERITVR QVANTVM BIBIT ARIDA TELLVS) Actaea dicitur regio Attica, de qua <del>et</del> mella quae ueniunt et liquida sunt et nimis dulcia. Vnde Vergilius et montem Atticum Aracynthum dixit <hi rend="italic">Actaeum</hi>, quia omnis regio maritima est. Actaeum imbrem mulsum dicit, <del>aut <hi rend="italic">Actaeos imbres</hi> aquam fontis illius unde Actaeon aspersus in ceruum mutatus est.</del> sed utrum mulsum purum <del>an fontem</del> an cruorem pecudum, quo possit tellus arida satiari, incertum est. <del>Nonnulli rorem marinum in Actaeo Aracyntho dicunt.</del> SVADVMQVE CRVOREM / (MANIBVS) qui persuadeat manibus ad superos redire. AGGERITVR infunditur. Deest 'tantum'. </p>
             </div>
 
-            <div type="schol" n="456-460">
+            <div type="schol" n="456">
                <p> TRIS HECATAE (TOTIDEMQVE SATIS ACHERONTE NEFASTO / VIRGINIBVS IVBET ESSE FOCOS TIBI RECTOR AVERNI / QVAMQVAM INFOSSVS HVMO SVPERAT TAMEN AGGER IN AVRAS / PINEVS HANC IVXTA CVMVLO MINOR ARA PROFVNDAE / ERIGITVR CERERI) <supplied>
                      <hi rend="italic">tris Hecatae</hi>
                   </supplied> quia triformis est aut quia eadem Deum Mater creditur et Proserpina uel Terra uel Vesta. Sic Ouidius de simili sacrificio:</p>
@@ -7609,7 +7610,7 @@
                <p>VIRGINIBVS Furiis. (CVMVLO MINOR ARA) PROFVNDAE / ERIGITVR CERERI tria sunt in sacrificiis deorum loca, per quae piationem facimus: scrobiculo facto inferis, terrestribus supra terram sacrificamus, caelestibus exstructis focis. Vnde etiam nominata sunt 'altaria', ad quae sacrificantes manus porrigimus in altum. </p>
             </div>
 
-            <div type="schol" n="460-461">
+            <div type="schol" n="460">
                <p> CVPRESSVS / ... PLORATA luctibus apta. Cyparissus speciosus puer dum uenaretur in amorem sui Apollinem compulit. A quo accepit ceruum pulcherrimum munere et mansuetum. Qui cum <del>diligeret</del> lassus somnum sub arbore capere coepit, subito excitatus strepitu ceruum longe uidit. Credens siluestrem missa sagitta eum <supplied>quem diligeret</supplied> interemit agnitoque usque eo ingemuit ut ab omni cibo et potu abstineret. Quo tabescente Apollo misertus eius uertit eum in arborem sui nominis. De qua Vergilius:</p>
                <lg>
                   <l>'fronde coronat</l>
@@ -7638,11 +7639,11 @@
                <p> TER CIRCVM ACTA PYRAS cum ter omnes pyras circumisset. </p>
             </div>
 
-            <div type="schol" n="466-467">
+            <div type="schol" n="466">
                <p> (ADHVC SPIRANTIA) REDDIT / VISCERA aut aris imponit aut nuntiat patri suo. </p>
             </div>
 
-            <div type="schol" n="468-470">
+            <div type="schol" n="468">
                <p> ATQVE IPSE SONANTIA FLAMMIS / VIRGVLTA (ET TRISTES CREPVISSE VT SENSIT ACERVOS / TIRESIAS) <supplied>tristes… sensit aceruos</supplied> hostias, ut sic futura dicat. Ars autem haruspicinae hoc habet, ut et turis motus et crepitus et fumi motus et flexus colligat, quoniam haec primum signa aut testantur extorum promissus, si bona sint, aut, si contraria, refra<del>n</del>gantur, ut testatur liber de turis signis, qui ipsi<del>us</del> Tiresiae <supplied>a</supplied>scribitur. SENSIT quia carebat oculis sacerdos. </p>
             </div>
 
@@ -7662,23 +7663,23 @@
                <p> ET PLENA REDEAT STYGA PORTITOR ALNO <supplied>ordo: </supplied> et portitor plena alno redeat <del>ad hanc</del> Styga<del>m</del>. <supplied>REDEAT STYGA</supplied> quomodo dicimus 'uiam redeat'. </p>
             </div>
 
-            <div type="schol" n="480-481">
+            <div type="schol" n="480">
                <p> FERTE SIMVL GRESSVS (NEC SIMPLEX MANIBVS ESTO / IN LVCEM REMEARE MODVS) nocentes, inquit, de Tartaro, pii de Elysio ueniant. MANIBVS Graecorum manes dicit. </p>
             </div>
 
-            <div type="schol" n="481-483">
+            <div type="schol" n="481">
                <p> (TV SEPARE COETV / ELYSIOS PERSEI PIOS) VIRGAQVE POTENTI / NVBILVS ARCAS AGAT <hi rend="italic">nubilus</hi> infernus. Imperat autem Mercurio et Liberae ut animas piorum euocent. Quare autem <hi rend="italic">Perse<supplied>i</supplied>
                   </hi>
                   <supplied> He</supplied>cate, ratio est. Quidam enim uolunt non Iouis filiam esse <del>Mercurium</del>, sed Persae, in qua opinione etiam Hesiodus uersatur in his libris, quos de Theogonia scripsit <del>quidam Persei</del>.<unclear>Coruilius</unclear> quattuor Mercurios esse scribit: unum Iouis et Maiae filium, alterum Caeli et Diei, tertium Liberi et Proserpinae, quartum Iouis et Cyllenes, a quo Argus occisus est. Quem ipsum ob hanc causam Graeci profugum dicunt, Aegyptiis autem litteras demonstrasse. Ergo Mercurium Liberi et Proserpinae filium dicunt animas euocare. De quo Vergilius:</p> 
                <l>'Leth<supplied>ae</supplied>um ad fluuium deus euocat agmine magno'. </l>
             </div>
 
-            <div type="schol" n="&lt;483&gt;">
+            <div type="schol" n="483">
                <p> 
                   <supplied>CONTRA PER CRIMINA FVNCTIS ... / 486 TISIPHONE DVX PANDE DIEM</supplied> ordo: <hi rend="italic">per crimina functis, o Tisiphone, pande diem</hi>. Sensus hic est: Hecate et Mercurius pias animas ducant, nocentes uero Tisiphone. </p>
             </div>
 
-            <div type="schol" n="484-486">
+            <div type="schol" n="484">
                <p> QVI PLVRES EREBO (PLVRESQVE E SANGVINE CADMI / ANGVE TER EXCVSSO ET FLAGRANTI PRAEVIA TAXO / TISIPHONE DVX PANDE DIEM) ut Vergilius:</p> 
                <l>'quae maxima turba est'.</l> 
                <p>Sed modo aucti per sanguinem Theba<supplied>no</supplied>rum. TAXO quia de hac arbore uenenosa faces Furiae dicuntur habere. TISIPHONE DVX (PANDE DIEM) tu, inquit, Tisiphone, illos reduc qui scelerati sunt plurimique de stirpe Thebana. </p>
@@ -7692,7 +7693,7 @@
                <p> ILLI FORMIDINE NVLLA subaudimus 'stabant'. </p>
             </div>
 
-            <div type="schol" n="492-493">
+            <div type="schol" n="492">
                <p> NVNC (VMEROS NVNC ILLE MANVS ET) VELLERA PRESSAT / (ANXIVS) amplectitur, constringit petens auxilium timoris. </p>
             </div>
 
@@ -7700,7 +7701,7 @@
                <p> CONFRAGA aspera et deserta. </p>
             </div>
 
-            <div type="schol" n="496-497">
+            <div type="schol" n="496">
                <p> ET SVDANTIA NISV / (TELA PREMENS) ex manuum sudore. Nam per timorem sudor oritur uenatori. </p>
             </div>
 
@@ -7712,7 +7713,7 @@
                <p> LAEVAQVE CONVVLSAE DEDIMVS CARCHESIA TERRAE quae sinistra manu funduntur, laeua manu infuderat.Inferis sinistra manu immolamus pocula. </p>
             </div>
 
-            <div type="schol" n="503-504">
+            <div type="schol" n="503">
                <p> CASSVSNE SACERDOS / (AVDIOR) et hunc locum de Lucano mutuatus est. Vt:</p>
                <lg>
                   <l>'Tisiphone uocisque meae secura Megaera,</l>
@@ -7725,16 +7726,16 @@
                <p> COLCHIS <del>AGET</del> ciuitas Scythiae, de qua omnes ueneficae. Vnde Medea. </p>
             </div>
 
-            <div type="schol" n="&lt;507&gt;">
+            <div type="schol" n="507">
                <p> 
                   <supplied>NOSTRI CVRA MINOR</supplied> hoc est: illis obtemperatis, nostra praecepta contemnitis. </p>
             </div>
 
-            <div type="schol" n="509-510">
+            <div type="schol" n="509">
                <p> (MIXTOS CAELIQVE EREBIQVE) SVB VNVM / FVNESTARE DEOS pro 'in unum' et 'in commune'. </p>
             </div>
 
-            <div type="schol" n="&lt;510-511&gt;">
+            <div type="schol" n="510">
                <p> 
                   <supplied>EXSANGVIA FERRO / ORA SEQVI ATQVE AEGRAS FVNCTORVM CARPERE FIBRAS</supplied> immolationem hominis. Propter necromantiam. His enim inferi delectantur. </p>
             </div>
@@ -7749,7 +7750,7 @@
                </p>
             </div>
 
-            <div type="schol" n="516-517">
+            <div type="schol" n="516">
                <p> ET TRIPLICIS MVNDI SVMMVM (QVEM SCIRE NEFASTVM / ILLVM SED TACEO) dicit <del>autem</del> deum <foreign xml:lang="grc">δημιουργόν</foreign>, cuius scire non licet nomen. Infiniti autem philosophorum <supplied>et</supplied> magorum <del>Persae</del> etiam confirmant <del>aut</del> reuera esse praeter hos deos cognitos qui coluntur in templis alium principem et maximum dominum, ceterorum numinum ordinatorem, de cuius genere sint soli Sol atque Luna. Ceteri uero, qui circumferi a sphaera <supplied>astra</supplied> nominantur, eius clarescunt spiritu. <del>Maximis in hoc auctoribus Pythagora et Platone et ipso Tagete.</del> Sed dire sentiunt qui eum interesse nefandis artibus actibusque magicis arbitrantur. In uersu ergo poeta sic dixit <hi rend="italic">illum</hi>, quasi nomen sciret <supplied>sic</supplied> 
                   <del>'sic' repetiuit</del> ut proderet, sed hoc magis ad terrorem dixit <del>
                      <hi rend="italic">illum</hi> ut putaretur scire</del>. Si ergo sciri nefas est, dicci a uate non potuit. Licet magi sphragidas habeant quas putant Dei nomina continere, sed Dei uocabulum a nullo sciri hominum potest. Sed quid ueritas habeat, percipe. Huiusne dei nomen sciri potest qui nutu tantum regit et continet cuncta, cuius arbitrio deseruiunt, cuius nec aestimari potest mundus nec finibus claudi? Sed cum magi uellent uirtutes eius, ut putabant, <del>sese</del> comprehendere, singulas appellationes, quasi per naturarum potestates, abusiuo modo designarunt et quasi plurimorum numinum nobilitate Deum appellare conati sunt, quasi ab affectu cuiusque dei ductis uocabulis, sicut Orpheus fecit et Moyses, Dei summi antistes, et Esaias et his similes. Etrusci confirmant Nympham quae nondum nupta fuerit praedicasse maximi Dei nomen exaudire hominem per naturae fragilitatem pollutionemque fas non esse, quod, ut documentis assereret, in conspectu ceterorum ad aurem tauri Dei nomen nominasse, quem ilico ut dementia correptum et nimio turbine coactum exanimasse. Sunt qui se — licet secreto — scire dicunt, sed falsum sciunt, quoniam res ineffabilis comprehendi non potest. </p>
@@ -7762,7 +7763,7 @@
                <p>deest. </p>
             </div>
 
-            <div type="schol" n="&lt;520&gt;">
+            <div type="schol" n="520">
                <p> 
                   <supplied>PANDITVR ELYSIVM CHAOS</supplied> iuxta picturam illam ueterem in qua haec tormenta descripta sunt <del>et ascensio ad deum</del>.</p>
             </div>
@@ -7773,7 +7774,7 @@
                <p>Et ideo hic <hi rend="italic">interflua</hi> nominauit. </p>
             </div>
 
-            <div type="schol" n="526-527">
+            <div type="schol" n="526">
                <p> (STYGIAEQVE SEVEROS) / IVNONIS THALAMOS Pythagoras dicit duo esse hemisphaeria, quibus proprios deos assignat. Et facit superioris regem Iouem et reginam Iunonem, inferioris Ditem Iouem esse infernum, Proserpinam uero Iunonem infernam. Et duas Veneres: unam supernam et alteram Libitinam. Et alios deos binos constituit: Hecaten, sicuti Ditem Iouem, ita et hanc Stygiam Iunonem. Vt Vergilius:</p> 
                <l>'Iunoni infernae dictus sacer'.</l>
             </div>
@@ -7836,11 +7837,11 @@
                <p> NOSTRAMQVE MONE PER SINGVLA NOCTEM quia a Iunone caecatus fuerat Tiresias, qui maiorem libidinem locutus mulierum est, ideo quod ante femina fuisset. Et merito, quia utriusque sexus fuerat expertus naturam. De qua re et ante dictum est.
 </p>
             </div>
-            <div type="schol" n="549-550">
+            <div type="schol" n="549">
                <p> CARMENQVE SERIT (QVO DISSIPAT VMBRAS / QVO RECIET SPARSAS) sensus: et serit carmen, quod collectas umbras et non necessarias spargeret, necessarias uero ac passim uagantes in unum cogeret. </p>
             </div>
 
-            <div type="schol" n="550-551">
+            <div type="schol" n="550">
                <p> QVALIS SI CRIMINA DEMAS / COLCHIS (ET AEAEO SIMVLATRIX LITORE CIRCE) talis erat Manto, qualis Medea aut Circe, criminibus ademptis, magica arte perfecta. Vt collatio conueniret, Medeae artem tulit herbarum, quia Manto uno carmine potentiam exercet. Circen autem non carminibus constat, sed herbis ualuisse, quia decipiebat poculis transeuntes. Vt Vergilius:</p>
                <lg>
                   <l>'potentibus herbis</l>
@@ -7849,7 +7850,7 @@
                <p>Equidem cum sit naturae ratio fingendo corpora facere homines qui fuerant beluae, resoluta ferae figura humanos uultus effingunt. Circe ergo fuit mortalis, quam stulti Solis filiam fuisse dixerunt, si fas est, ut dei filia credatur esse mortalis. Sed ordinem fabulae perstringamus. Haec igitur Circe in insulam Aeaeam delatos ad se in feras mutabat. Ad hanc forte delatus Vlixes Eurylochum cum uiginti et duobus sociis misit, quos ab humana specie commutauit. Sed Eurylochus inde fugit et Vlixi nuntiauit. Is solus ad eam proficiscitur, cui in itinere Mercurius remedium dedit monstrauitque quomodo Circen deciperet. Qui, postquam ad eam uenit, ab ea poculo accepto Mercurii remedium miscuit et eduxit ensem eique minatus est, ut socios sibi restitueret. Tunc Circe sensit sine uoluntate deorum non esse factum fideque data socios ei restituit. Ipse cum ea concubuit, ex qua Telegonum procreauit. Inde proficiscens ad Auernum delatus ad inferos descendit. — reliquos labores eius Tiresias uates edocuit. </p>
             </div>
 
-            <div type="schol" n="553-554">
+            <div type="schol" n="553">
                <p> PRIMVS SANGVINEO (SVBMITTIT INERTIA CADMVS / ORA LACV) eleganter coepit a conditore Thebarum posteriorum historias narraturus. Cadmum et Harmoniam diximus in dracones esse conuersos, quorum ueniunt animae ut bibant fossam sanguinis plenam. </p>
             </div>
 
@@ -7861,13 +7862,13 @@
                <p> TERRIGENAE quos sparsis draconis dentibus terra edidit. </p>
             </div>
 
-            <div type="schol" n="557">
+            <div type="schol" n="557a">
                <p> (QVIS AEVI) MENSVRA DIES quibus nascendi moriendique <supplied>
                      <gap/>
                   </supplied> dies fuit. </p>
             </div>
 
-            <div type="schol" n="557-560">
+            <div type="schol" n="557b">
                <p> (MANVS OMNIS IN ARMIS / OMNIS ET IN CAPVLO PROHIBENT OBSTANTQVE RVVNTQVE) / SPIRANTVM RABIE (NEC TRISTI INCVMBERE FOSSAE / CVRA SED ALTERNVM CVPERENT HAVRIRE CRVOREM) id est: furore uiuentium adhuc arma tractabant suumque magis fundere sanguinem festinabant quam eum, qui erat fusus in fossa, <supplied>haurire</supplied>. <del>SED ALTERNVM CVPERENT HAVRIRE CRVOREM</del> 
                   <del>quos draconis dentibus satis tellus ediderat,</del> odia uetera retinentes potandi ordinem immatura festinatione turbarunt. </p>
             </div>
@@ -7894,15 +7895,15 @@
                </p>
             </div>
 
-            <div type="schol" n="570">
+            <div type="schol" n="570a">
                <p> TRISTEM NOSCO LYCVM <del>hic est Lycus, qui Megaram filiam suam Herculi dedit uxorem et ob hoc a Iunone in furorem uersus est et filios Herculis ex Megara susceptos Oxea et Creontiadem occidit. <hi rend="italic">Tristem</hi> ergo propter mortem nepotum.</del> hic est <del>ergo</del> Lycus maritus Antiopae, Nyctei regis filiae, et <hi rend="italic">tristis</hi> ob stuprum coniugis, quam per uim stuprauerat Epaphus. Ille eam proiecit. Epaphus autem fuit ex Io<del>ne</del> et Ioue natus. Quam fabulam latius aperiemus. Antiopa, Nyctei regis filia, ab Epapho per dolum est stuprata, quae ob id a uiro Lyco est eiecta ui. Qua pulsa Dircen duxit uxorem. Cui suspicio incidit uirum suum clam cum Antiopa concubuisse. Itaque impetrauit a famulis ut eam uinctam in tenebris clauderent. Cui cum partus instaret, Iouis uoluntate effugit uincula et in monte Cithaerone partum exposuit. Natos Zethum et Amphionem proiecit. Hos pastor pro suis educauit, quos postea mater agnouit. Iniurias eius exsecuti Lycum interfecerunt, Dircen tauro indomito religatam uita priuauerunt. </p>
             </div>
 
-            <div type="schol" n="570-571">
+            <div type="schol" n="570b">
                <p> (DEXTRAMQVE IN TERGA REFLEXVM) / AEOLIDEN (VMERO IACTANTEM FVNVS ONVSTO) Athamanta dicit, Aeoli filium, cum <hi rend="italic">humero ... onusto</hi>, quia sic pingitur: insequens Ino uxorem, collo portans filii Learchi cadauer. </p>
             </div>
 
-            <div type="schol" n="572-573">
+            <div type="schol" n="572">
                <p> (NECDVM ILLE AVT HABITVS) AVT VERSAE CRIMINA FORMAE / (MVTAT ARISTAEO GENITVS FRONS ASPERA CORNV / TELA MANV REICITQVE CANES IN VVLNVS HIANTES) <supplied>
                      <hi rend="italic">crimina</hi>
                   </supplied> propter crimina, quia in Dianam nudam inciderat. <del>FRONS ASPERA CoRNV</del> Actaeonem significat, quem dicit apud inferos eadem forma mansisse qua apud superos fuerat: habentem cornua. </p>
@@ -7912,16 +7913,16 @@
                <p> TANTALIS Niobe Tantali filia <unclear>et Penelopes</unclear>, quae partus sui fecunditate praelata cum filiis <supplied>bis</supplied> septem a Diana et Apolline probatur exstincta. </p>
             </div>
 
-            <div type="schol" n="577-578">
+            <div type="schol" n="577">
                <p> NIL DEIECTA MALIS I(VVAT) E(FFVGISSE) D(EORVM) / N(VMINA) filiis delectatur exstinctis amplius sibi posse in deorum iniuriam licere, cum desint in quibus peccatorum licentia uindicetur. Nam ideo subdidit:</p> 
                <l>'et insanae plus iam permittere linguae'. </l>
             </div>
 
-            <div type="schol" n="584">
+            <div type="schol" n="584a">
                <p> EXTERNAE SATIS EST MIHI LVCIS duplex hic expositio est. Nam <hi rend="italic">externae</hi> aut humanis aspectibus, quoniam diuinam lucem uult magis intellegi, aut certe quod ipse diuinatione alieno fruebatur aspectu. </p>
             </div>
 
-            <div type="schol" n="584-585">
+            <div type="schol" n="584b">
                <p> INERTES / (DISCEDVNT) NEBVLAE (ET VVLTVM NIGER EXVIT AER) <hi rend="italic">inertes</hi> epitheton est nebulae. Nam <hi rend="italic">uultum</hi> caecitate obrutum ad uidenda quae sunt diuina, perpetua nox <hi rend="italic">exuit</hi> caecitatis. </p>
             </div>
 
@@ -7935,25 +7936,25 @@
                <p>PHORONEVS hic est, qui primus Iunoni sacrificasse dicitur, ut Dardanus Ioui. Phoroneus autem Inachi filius, qui primus mortalibus regnauit, cuius filiam Nioben, quae alia<supplied>s</supplied> Tantali est, Iuppiter primo mortalem dicitur compressisse. </p>
             </div>
 
-            <div type="schol" n="590">
+            <div type="schol" n="590a">
                <p> TRVNCATVSQVE PELOPS Vergilius:</p> 
                <l>'humeroque Pelops insignis eburno'. </l>
             </div>
 
-            <div type="schol" n="590-591">
+            <div type="schol" n="590b">
                <p> SAEVO PVLVERE SORDENS / (OENOMAVS) <hi rend="italic">sordens</hi>, quia per circum tractus est. <hi rend="italic">Saeuo</hi>, quia ibi occisi fuerant innocentes. </p>
             </div>
 
-            <div type="schol" n="592-593">
+            <div type="schol" n="592">
                <p> (QVID AVTEM / HI) GREGE CONDENSO isti sunt quinquaginta quos Tydeus occidit. </p>
             </div>
 
-            <div type="schol" n="595">
+            <div type="schol" n="595a">
                <p> FALSO CLAMORE ut Vergilius:</p> 
                <l>'inceptus clamor frustratur hiantes'. </l>
             </div>
 
-            <div type="schol" n="595-597">
+            <div type="schol" n="595b">
                <p> (LEVATAS) / INTENDVNT SINE PACE MANVS R(EX) F(ALLOR) A(N) H(I) S(VNT) / (QVINQVAGINTA ILLI) <supplied>
                      <hi rend="italic">rex</hi>
                   </supplied> o rex Eteocles. Eos ostendit Eteocli quos etiam ipse posset agnoscere. <hi rend="italic">Sine pace</hi> autem dixit aut bellicosas aut ipsi discordes, cuius causa fuerant interempti. </p>
@@ -7963,7 +7964,7 @@
                <p> (NOSTRA) PRAESIGNEM MAEONA LAVRV Maeonem illum uatem dicit ideo <hi rend="italic">praesignem ... lauru</hi>, quoniam fuit sacerdos Apollinis et diuinatione pollebat. Quem Tydeus a quinquaginta uirorum caede seruatum remisit Thebas incolumem. Qui se in conspectu regis donatam uitam respuens conscientia uirtutis occidit. </p>
             </div>
 
-            <div type="schol" n="599-602">
+            <div type="schol" n="599">
                <p> NE SAEVITE DVCES (NIHIL IN MORTALIBVS AVSVM / CREDITE CONSILIIS HOS FERREA NEVERAT ANNOS / ATROPOS EXISTIS CASVS BELLA HORRIDA NOBIS / ATQVE ITERVM TYDEVS) quasi apud indignantes eos loquitur qui fuerant interempti a Tydeo, et casum humanae sortis excusat Fatorum legibus euenisse. Omina prospera uiderat de parte Thebana et Argolicos duces uultu pronuntiasse de fato belli. Sed uidit illos Thebanos quos Tydeus peremit. Quos hic minantes ciuibus suis placat dicens Fatorum fuisse legem ut tot caderent, non uirtutis alienae, dein superstitibus Thebanis, qui Tydeum uidentur esse passuri. Hoc autem mihi uidetur dixisse Statius historiae ductus exemplo ut animas seu manes irasci diceret et a Tiresia placatas. Alexander igitur cum in Asia<supplied>m</supplied> traduceret exercitum conspexit proximam litori manum armatorum armis Achiuis candentium. Propterea tubam canere iussit et milites nauibus egredi armatos. Sed cum isset a conspectu Macedonum ea species umbrarum ante cunctis perspecta, ut attigit Troicam terram, certus a uicinis factus quod eiusmodi uisiones ibi frequentissime fierent, suspicatus animas esse Achiuorum qui consociati foedere Thessalis fuerant heroico bello, inferias apud tumulos eorum dedit precatus aduersus barbaram gentem auxiliarios sibi fieri, opinatus eosdem et in excessione classis apud litus sibi uisos. Itaque in ea pugna, cum apud Granicum conflixere exercitus, multas eiusdem speciei in proelio conspecta<del>n</del>s puta<supplied>uit iuua</supplied>ntes Macedonum exercitum nec minus alias animas apparuisse barbarico habitu, ex aduerso existimans eos <supplied>in</supplied> hostium numero. Eo proelio multis ex utraque parte caesis, locus in quo ceciderunt faba primo floruit, quae nata fidem ueteribus praebuit qua abstinendum usu fabae suadent. NIHIL IN MORTALIBVS AVSVM quotiens ratione carent facti immanitate uirtutes, humanis non sunt assignandae consiliis. Vergilius simili admiratione ait:</p>
                <lg>
                   <l>'non haec humanis opibus, non arte magistral</l>
@@ -7976,11 +7977,11 @@
                <l>'nos alias hinc ad lacrimas'. </l>
             </div>
 
-            <div type="schol" n="606-609">
+            <div type="schol" n="606">
                <p> (DIRVMQVE TVENS OBLIQVA NEPOTEM / NOSCIT ENIM VVLTV) NON ILLE AVT SANGVINIS HAVSTVS / C(ETERA) C(EV) P(LEBES) A(LIVMVE) A(CCEDIT) A(D) I(MBREM) / (IMMORTALE ODIVM SPIRANS) <hi rend="italic">obliqua</hi> ob parricidium posteris. Horret nepotem Laius ex scelere procreatum nec sacrificii oblatione mitescit. Nam cum importune instantes abigit illos quinquaginta qui Tydei manu fuerant interempti, quos uittis redimitos dicit utpote reges, eosque sanguine sacrificii placat ostenso, illum tamen non sanguinis sacer, non alius liquor qui sacrificiis consueuit offerri mitigat, id est uini aut mellis aut lactis. Sed <hi rend="italic">immortale odium</hi> posteris seruans nulla sacrificii oblatione placatur. </p>
             </div>
 
-            <div type="schol" n="611-612">
+            <div type="schol" n="611">
                <p> (CVIVS AB INTERITV NON VLLA AMPHIONIS ARCES) / VIDIT AMICA DIES <supplied>
                      <hi rend="italic">amica</hi>
                   </supplied> prospera, id est quae ab exsecrabilibus facinoribus esset aliena. Nam post eius obitum uxor filii sui Oedipodis est sortita coniugium, qui funestam rem saepissime fecunditate partus incesti significauit. Secutum est nihilo minus ut re cognita filius coniunx uoluntaria se caecitatis poena damnaret, deinde Polynicis exilium et post omnia imminens bellum. </p>
@@ -8006,16 +8007,16 @@
                <p> LITANTI pro 'litato'. </p>
             </div>
 
-            <div type="schol" n="620-621">
+            <div type="schol" n="620">
                <p> (VENTVRASQVE VICES ET FVNERA BELLI) / PANDE VEL INFENSVS VEL RES MISERATE TVORVM quoniam si iratus es, narra quod doleam, si placatus es, posteris ede quod caueant. </p>
             </div>
 
-            <div type="schol" n="&lt;622-624&gt;">
+            <div type="schol" n="622">
                <p> 
                   <supplied>TVNC EGO TE OPTATA VETITAM TRANSMITTERE LETHEN / PVPPE DABO PLACIDVMQVE PIA TELLVRE REPONAM / ET STYGIIS MANDABO DEIS</supplied> ut in inferorum squalore perpetuo posito regi suaderet quae poscebat edicere, spem ulterioris ripae, ad quam praeter gloriosam mortem quam belli necessitas ingerebat uiolenter occisi prohibebantur accedere, promittit carminibus posse concedere et deis inferis se commendare, quamuis esset contra iura prohibitum. </p>
             </div>
 
-            <div type="schol" n="624-625">
+            <div type="schol" n="624">
                <p> MVLCETVR HONORIS / MVNERIBVS T(INGVIT)Q(VE) G(ENAS) placatus muneribus sacerdotis sumpsit sacra libamina et tunc demum reddidit consultanti responsum. Alii <hi rend="italic">tinguitque genas</hi> magis intellegi uolunt fletu quam sanguine. </p>
             </div>
 
@@ -8027,12 +8028,12 @@
                <p> (AVGVRIO ...) POTISSIMVS melior ad augurandum. </p>
             </div>
 
-            <div type="schol" n="630-632">
+            <div type="schol" n="630">
                <p> 
                   <del>POSCITIS</del> ILLVM ILLVM (SACRIS ADHIBETE NEFASTIS / QVI LAETO FODIT ENSE PATREM QVI SEMET IN ORTVS / VERTIT ET INDIGNAE REGERIT SVA PIGNORA MATRI) schema epizeuxis id est repetitio nominis. Dicit ergo Oedipum, filium suum, haec sacra debuisse facere, qui nece patris et matris concubitu Thebanum mouerat bellum. </p>
             </div>
 
-            <div type="schol" n="633-634">
+            <div type="schol" n="633">
                <p> (ET NVNC ILLE DEOS FVRIARVMQVE) ATRA FATIGAT / (CONCILIA) imprecando filiis lassat. Horatius:</p>
                <lg>
                   <l>'prece qua fatigent</l>
@@ -8049,11 +8050,11 @@
                <p> HOS TERRAE MONSTRA propter Amphiaraum, qui hiatu terrae demersus est, seu propter Tydeum, qui prodigialiter Melanippi, percussoris sui, cerebrum uorando defunctus est. </p>
             </div>
 
-            <div type="schol" n="639-640">
+            <div type="schol" n="639">
                <p> DEVMQVE / TELA (MANENT) propter Capaneum, qui eo clarior fuit, quod Iouis fulmine meruerit interire. </p>
             </div>
 
-            <div type="schol" n="640-641">
+            <div type="schol" n="640">
                <p> (AB IGNE SVPREMO) / SONTES LEGE MORAE id est ex lege morae uenientes, ne sontes sepelirentur Achiui. — <hi rend="italic">sontes</hi> autem <hi rend="italic">morae</hi> optime nocentes, quia differunt sepulturam. Sic et in primo:</p>
                <lg>
                   <l>'tumulisque carentia regum</l>
@@ -8073,17 +8074,17 @@
                <p> SIDONIAS (... PRAEDAS) Thebanas, quia Thebarum conditor Cadmus. <hi rend="italic">Sidonius</hi> uero Tyrius. </p>
             </div>
 
-            <div type="schol" n="652-653">
+            <div type="schol" n="652">
                <p> MARCIDVS (... LIBER) lassus, ebrius, aut quod molles faciat per pacem. </p>
             </div>
 
-            <div type="schol" n="653-654">
+            <div type="schol" n="653">
                <p> (IBI ARMIFEROS GEMINAE IAM SIDERE) BRVMAE / (ORGIA FERRE GETAS) eleganter <hi rend="italic">brumas</hi> pro annis posuit, non 'aestates', quia Thracas et Getas perpetuae semper habent hiemes. Vt Vergilius:</p> 
                <l>'semper hiems, semper spirantes frigora cauri'.</l> 
                <p>Dicit ergo duobus annis Thracas Getasque exutos furore bellandi docuisse culturas. </p>
             </div>
 
-            <div type="schol" n="654-655">
+            <div type="schol" n="654">
                <p> (CANVMQVE VIRESCERE DORSO / OTHRYN ET ICARIA RHODOPEN ADSVEVERAT) VMBRA id est uitibus obsitam facere. <hi rend="italic">Icaria...umbra</hi> dixit, quia Icar<supplied>i</supplied>us comes Liberi accipitur, qui a Libero uini usum ut mortalibus traderet sumpsit. Quod cum pastoribus exhibuisset potandum, ebrii facti putauerunt se ueneno fuisse temptatos <supplied>et</supplied> Icar<supplied>i</supplied>um peremerunt. Cuius Erigone filia cum ductu canis inuentum fleret cadauer, in uindictam patris deorum implorauit auxilium. Recepti ambo dicuntur in sidera, Erigone in Virginem, Icar<supplied>i</supplied>us in stellam Bootae. Dicitur enim cum plaustro suo receptus in caelum. Vnde Iuuenalis:</p>
                <lg>
                   <l>'haud illo tempore, quo se</l>
@@ -8091,7 +8092,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="656-657">
+            <div type="schol" n="656">
                <p> ET IAM PAMPINEOS M(ATERNA) A(D) M(OENIA) C(VRRVS) / P(ROMOVET) Ouidius:</p>
                <lg>
                   <l>'ipse racemiferis frontem circumdatus uuis,</l>
@@ -8115,7 +8116,7 @@
                <l>'torua Mimalloneis implerunt cornua bombis'. </l>
             </div>
 
-            <div type="schol" n="661-662">
+            <div type="schol" n="661">
                <p> (NEC COMITATVS INERS) S(VNT) I(LLIC) I(RA) F(VROR)Q(VE) / E(T) M(ETVS) E(T) V(IRTVS) (ET) N(VNQVAM) S(OBRIVS) A(RDOR) quae omnia nascuntur ex uino. Vt Vergilius:</p> 
                <l>'Bacchus et ad culpam causas dedit'</l>
             </div>
@@ -8129,18 +8130,18 @@
                <l>'tympana uox buxusque uocant'. </l>
             </div>
 
-            <div type="schol" n="671-672">
+            <div type="schol" n="671">
                <p> (SAEVVM) / ARGOS masculini generis in plurali tantum numero esse Vergilius docet:</p> 
                <l>'si patrios unquam remeassem uictor ad Argos',</l> 
                <p>in singulari uero <hi rend="italic">saeuum Argos</hi> notandum neutri generis ciuitatem Argos dictam. Nam et Horatius neutro genere posuit:</p> 
                <l>'aptum ... equis Argos'. </l>
             </div>
 
-            <div type="schol" n="673-674">
+            <div type="schol" n="673">
                <p> CINERI DATA MATER INIQVO / (NATALESQVE ROGI) illud dicit tempus quo fraude Iunonis Semele mater optauit Iouem eo cultu uidere quo cum Iunone concumberet. Quod cum ferre non potuisset, diuino igni apud Thebas consumpta est. Merito ergo eam ciuitatem matris sepulcrum Liber appellat. </p>
             </div>
 
-            <div type="schol" n="674-675">
+            <div type="schol" n="674">
                <p> (QVAEQVE IPSE MICANTIA) SENSI / (FVLGVRA) ad exaggerationem materni supplicii dicit etiam se in utero constitutum sensisse uim fulminum. </p>
             </div>
 
@@ -8162,16 +8163,16 @@
                <l>'dicto citius tumida a(equora) p(lacat)'. </l>
             </div>
 
-            <div type="schol" n="680-681">
+            <div type="schol" n="680">
                <p> (TEMPVS ERAT MEDII CVM SOLEM IN CVLMINA MVNDI) / TOLLIT ANHELA DIES <hi rend="italic">anhela</hi> aestuosa, quando sol in Cancro est. </p>
             </div>
 
-            <div type="schol" n="&lt;682&gt;">
+            <div type="schol" n="682">
                <p> 
                   <supplied>ATQVE OMNES ADMITTVNT AETHERA LVCI</supplied> et necesse est, quando sol in medio caelo est, omnia illustret. </p>
             </div>
 
-            <div type="schol" n="683-684">
+            <div type="schol" n="683">
                <p> (VNDARVM VOCAT ILLE DEAS) MEDIVSQVE SILENTVM / (INCIPIT) cum silerent Nymphae, quibus conuocatis medius ipse constiterat. </p>
             </div>
 
@@ -8188,17 +8189,17 @@
                <p> (ERRANTES OBDVCITE PVLVERE) RIVOS id est: tanta uis sit siccitatis ut riuorum aluei puluere impleantur. </p>
             </div>
 
-            <div type="schol" n="688-689">
+            <div type="schol" n="688">
                <p> (PRAECIPVAM) NEMEEN (QVA NOSTRA IN MOENIA BELLIS / NVNC ITER) <supplied>
                      <hi rend="italic">Nemeen</hi>
                   </supplied> paludis nomen unde erant Argiui. Ex qua et campum significat quo aduentat Argiuus exercitus. </p>
             </div>
 
-            <div type="schol" n="689">
+            <div type="schol" n="689a">
                <p> EX ALTO FVGIAT LIQVOR penitus imperat ut humor ex alto in profundum discedat. </p>
             </div>
 
-            <div type="schol" n="689-691">
+            <div type="schol" n="689b">
                <p> (ADIVVAT IPSE / PHOEBVS) ADHVC SVMMO (CESSET NI VESTRA VOLVNTAS / LIMITE VIM COEPTIS INDVLGENT ASTRA) quia medio caeli spatio uiolentior terris ardor solis infunditur, per quem unda siccatur. Vt Vergilius:</p>
                <lg>
                   <l>'et medium sol igneus orbem</l>
@@ -8208,18 +8209,18 @@
                <p>Et sensus hic est: nisi uestra uoluntas cesset, summo limite indulgent astra uim coeptis. Constat etiam Liberum eundem et Apollinem esse et Solem. Ideo iuuenes omnes imberbes, quia ignis non senescit. </p>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691">
                <p> MEAEQVE / ERIGONES SPVMAT CANIS <supplied>
                      <hi rend="italic">meae</hi>
                   </supplied> id est quam ego uindicaui, id est Erigone. Singulis enim mensibus aliorum siderum ortus ingreditur. Canicularem ergo dicit stellam, quae ideo inter sidera recepta est quia seruauit cadauer Icar<supplied>i</supplied>i interempti, aut quia ipsa Erigonae nuntiauit interitum domini. Et bene ait <hi rend="italic">meae</hi> et propter Icar<supplied>i</supplied>um patrem. Hodieque enim sacra Libero dantur in Erigones honore<supplied>m</supplied>. Vergilius:</p> 
                <l>'oscilla ex alta suspendunt mollia pinu'. </l>
             </div>
 
-            <div type="schol" n="695-696">
+            <div type="schol" n="695">
                <p> (NOCTVRNAQVE FVRTA) LICENTVM / CORNIPEDVM (ET CVPIDAS FAVNORVM ARCEBO RAPINAS) licenter facientium Panum, nam solent Nymphas ad usum libidinis rapere. Etiam Faunos sumpto uino in uenerem constat esse petulantes. </p>
             </div>
 
-            <div type="schol" n="&lt;698&gt;">
+            <div type="schol" n="698">
                <p> 
                   <supplied>VIRIDISQVE COMIS EXHORRVIT VMOR</supplied> ad imitationem radiorum qui luce sua funduntur. Ergo aut ipse Liber a se cepit ardorem aut uelociter quod petierat impetrauit, ut uirides uuae situ caloris horrescerent. </p>
             </div>
@@ -8234,7 +8235,7 @@
                <l>'et uictum seges aegra <supplied>negabat</supplied>'. </l>
             </div>
 
-            <div type="schol" n="705-710">
+            <div type="schol" n="705">
                <p> SIC VBI SE MAGNIS (REFLVVS SVPPRESSIT IN ANTRIS / NILVS ET EOAE LIQVENTIA PABVLA BRVMAE / ORE PREMIT FVMANT DESERTAE GVRGITE VALLES / ET PATRIS VNDOSI SONITVS EXSPECTAT HIVLCA / AEGYPTVS DONEC PHARIIS ALIMENTA ROGATVS / DONET AGRIS) Ouidius libro primo:</p>
                <lg>
                   <l>'sic ubi deseruit madidos septemfluus agros</l>
@@ -8256,21 +8257,21 @@
                <l>'effusis magnum Libye tulit imbribus annum'. </l>
             </div>
 
-            <div type="schol" n="713">
+            <div type="schol" n="713a">
                <p> (NVNQVAM IN RIPIS) AVDAX ERASINVS qui ripis suis se contineri non patitur. Et idcirco dixit <hi rend="italic">audacem</hi> id est grauiter sonantem. </p>
             </div>
 
-            <div type="schol" n="713-714">
+            <div type="schol" n="713b">
                <p> (AEQVVS / FRVCTIBVS) ASTERION) Erasino contrarius fluuio. Nam cum sit ille populator aruorum, hic fructibus est aequus. Et haec flumina in Nemea silua sunt omnia. </p>
             </div>
 
-            <div type="schol" n="716-717">
+            <div type="schol" n="716">
                <p> (VNA TAMEN TACITAS SED) IVSSV NVMINIS (VNDAS / HAEC QVOQVE SECRETA NVTRIT LANGIA SVB VMBRA) <supplied>
                      <hi rend="italic">iussu numinis</hi>
                   </supplied> ipsius Liberi. Bona uero oeconomia. Nam si ei<supplied>s</supplied> Langia defecisset, perissent Argiui et non esset bellum quod fataliter debebatur. </p>
             </div>
 
-            <div type="schol" n="717-719">
+            <div type="schol" n="717">
                <p> LANGIA ... / (NONDVM ILLI RAPTVS DEDERAT LACRIMABILE NOMEN / ARCHEMORVS NEC FAMA DEAE) fons est qui postea uocatus est Archemorus. Et huic consecratus est fons et Nympha, cuius famam postea Argiui accepto beneficio extulerunt quia non perdiderat aquam. Iuxta hunc fontem agon celebratur in honorem Archemori consecratus et in Nymphae beneficium. Archemorus est Lycurgi filius <del>Graeci</del> quem Hypsipyle acceperat nutriendum. Quae dum sitientibus Graecis Langian fontem demonstrat, regium puerum ictu serpentis amisit. Idem puer Opheltes, qui post Archemorus est dictus. NOMEN enim <hi rend="italic">lacrimabile</hi> sign<supplied>ific</supplied>at Archemorus <foreign xml:lang="grc">ἀπὸ τῆς ἀρχῆς τῆς μοίρας</foreign>, eo quod primus occisus est. NOMEN gloriam uel famam. </p>
             </div>
 
@@ -8278,7 +8279,7 @@
                <p> HYPSIPYLEN Lemnias fuit. Quodam tempore dum Lemniadum uiri in Thracia pugnantes triennio tenerentur, indignatae desiderio necem feminae aduersus omnes coniurauerunt ut omnes perimerent. Inter quas sola Hypsipyle Thoanti patri pepercit. Ex quo in se armauit ceterarum furorem. Quae dum fugeret, capta ad Lycurgum regem ducta est <del>Graeciae</del>. In cuius seruitio cum filium eius Ophelten nutriret, puer dracone periit. Qua orbitate rex iratus cum in Hypsipyle ius dominii exercere uellet eamque filio inferias mittere, a Graecis prohibitus <supplied>est</supplied>, quibus fontem sitientibus demonstrauit. Graecis uero postea responsum est non prius eos ad Thebas peruenire nisi placassent manes Archemori. Pro qua re illi ludos funebres condiderunt, de quibus ipse poeta plenius loquitur. </p>
             </div>
 
-            <div type="schol" n="723-725">
+            <div type="schol" n="723">
                <p> ERGO NEC ARDENTES C(LIPEOS) V(ECTARE) N(EC) A(RTOS) / T(HORACVM) N(EXVS) (TANTVM SITIS HORRIDA TORRET / SVFFICIVNT) <supplied>
                      <hi rend="italic">artos</hi>
                   </supplied> quia arti et angusti efficiebantur per anhelitum hominum. Nam anhelitu solet corpus intumescere. </p>
@@ -8304,7 +8305,7 @@
                <p> (NVLLAQVE VMBRATAM NVBE) SYENEN ciuitas quae Aethiopiam ab Aegypto diuidit. Quia ibi nunquam pluit, ideo <hi rend="italic">nulla nube umbratam</hi> dicit. </p>
             </div>
 
-            <div type="schol" n="740-741">
+            <div type="schol" n="740">
                <p> (ERRANTES) SVBITAM PVLCHRO IN MAERORE TVENTVR / (HYPSIPYLEN) cum septem duces Thebas oppugnatum uenissent et aquam quaererent, Adrastus deuenit ad Hypsipylen, Thoantis filiam, cuius alumnus Archemorus periit. Et ludos funebres instituerunt, quibus ludis Hypsipyle cum duobus filiis ex Iasone intererat. Qui et ipsi matrem quaerentes currendo uicerunt. Quorum nomina praeco cum pronuntiasset, Iasonis et Hypsipyles filios esse mater eos cognouit. Qui ab rege impetrarunt ut matrem recuperatam Lemnum reuocarent. </p>
             </div>
 
@@ -8312,11 +8313,11 @@
                <p> (INACHII) PROLES INFAVSTA LYCVRGI Lycurgi duo fuerunt Thrax et Nemeaeus, de quo loquitur poeta. Ille in mari praecipitatus dicitur quia primum aquis uina permiscuit et rem in haustu sinceram pluribus uenenis infecit. Infausta ideo quia peritura. </p>
             </div>
 
-            <div type="schol" n="749-751">
+            <div type="schol" n="749">
                <p> (ARQVITENENS) SEV TE LATONIA CASTO / (DE GREGE TRANSMISIT THALAMIS SEV LAPSVS AB ASTRIS / NON HVMILIS FECVNDAT AMOR) siue te, inquit, Diana de grege suo alicui uxorem dedit, siue te deus aliquis suo amore dignatus est. Nam posse hoc fieri Iouis docemur exemplis qui multas Graeciae feminas amauit. TRANSMISIT THALAMIS hoc est <supplied>in</supplied> matrimonium collocauit. Hoc ideo quia uidet illam infantem ferre. NON HVMILIS FECVNDAT AMOR id est: a numine compressa peperisti. NON HVMILIS quia non patitur iniuriam numen, si tecum id est cum Argiua concumbat. </p>
             </div>
 
-            <div type="schol" n="751-752">
+            <div type="schol" n="751">
                <p> (NEQVE ENIM IPSE DEORVM) / ARBITER ARGOLIDVM THALAMIS NOVVS quasi qui consueuerit cum Argolicis matribus saepe concumbere. An quia <supplied>Io</supplied> Inachi Argiui filiam amauit et Danaen item Acrisii Argiui filiam? Ergo uerisimile est et hanc Iouis paruisse complexibus, quia frequenter luppiter est Argiuarum concubitu delectatus. </p>
             </div>
 
@@ -8325,12 +8326,12 @@
                <l>'carpit e(nim) u(ires) p(aulatim)'. </l>
             </div>
 
-            <div type="schol" n="757">
+            <div type="schol" n="757a">
                <p> 
                   <del>SEV TIBI</del> FOEDA PALVS caenosa sordibus. </p>
             </div>
 
-            <div type="schol" n="&lt;757-758&gt;">
+            <div type="schol" n="757b">
                <p> 
                   <supplied>NIHIL HAC IN SORTE PVDENDVM / NIL HVMILE EST</supplied> unde Lucanus:</p>
                <lg>
@@ -8339,12 +8340,12 @@
                </lg>
             </div>
 
-            <div type="schol" n="763-764">
+            <div type="schol" n="763">
                <p> (DIRCAEOS TIBI DIVA GREGES) NVMERVMQVE REPENDAM / (PLEBIS ET HIC MAGNA LVCVS SIGNABITVR ARA) id est: omnis te plebs uenerabitur, ut pro numero exercitus de Thebanis gregibus tot tibi uictimas immolemus <del>perseuerat in opinione qua coepit, ut tot hostias de grege Thebano numeret quantus fuerit plebis numerus nominatus.</del>
                </p>
             </div>
 
-            <div type="schol" n="765-766">
+            <div type="schol" n="765">
                <p> (ORANTIS) MEDIA INTER ANHELITVS (ARDENS / VERBA RAPIT) inter media uerba rapit. An melius sic: media uerba interrumpit? </p>
             </div>
 
@@ -8352,7 +8353,7 @@
                <p> CVRSV ... ANIMAE spiritu uitae. </p>
             </div>
 
-            <div type="schol" n="767-768">
+            <div type="schol" n="767">
                <p> (FLATVS ...) SOLVTI / (ORIS) patuli ad auras capiendas. Egent enim humore uitali, ideo aerem expetunt. </p>
             </div>
 
@@ -8360,7 +8361,7 @@
                <p> ETSI CAELESTIS ORIGO EST nam pater eius Thoas Liberi patris fuisse filius dicitur. Ergo ista neptis Liberi fuit. </p>
             </div>
 
-            <div type="schol" n="771-772">
+            <div type="schol" n="771">
                <p> (ALTRICEM MANDATI CERNITIS) ORBAM / (PIGNORIS) haec cum Iasone aliquando in Lemno concubuit. Ex quo enixa est geminos, quorum alter Thoas, alter Euneus dictus est, quos fugiens reliquit in Lemno. Et quia <supplied>quod</supplied> uiuant ignara est, orbam se pignoris esse confessa est. </p>
             </div>
 
@@ -8380,15 +8381,15 @@
                <p> (MISERVM ...) ALVMNVM Archemorum, Lycurgi filium, quem draco interemit. Cui proprium nomen Opheltes est. </p>
             </div>
 
-            <div type="schol" n="780-782">
+            <div type="schol" n="780">
                <p> PONIQVE NEGANTIS / (FLORIBVS ADGESTIS ET AMICO MVRMVRE DVLCES / SOLATVR LACRIMAS) ordo est: lacrimas poni negantis murmure consolatur et floribus. <hi rend="italic">Poni</hi> autem significat abici et conquiescere. Legitur et <hi rend="italic">ponit ... negantem</hi> id est inuitum et reluctantem. Expressit enim morem infantiae, quia nolunt a nutricibus separari. </p>
             </div>
 
-            <div type="schol" n="783-784">
+            <div type="schol" n="783">
                <p> (DVM PARVVM CIRCA IVBET EXSVLTARE TONANTEM) / CVRETAS TREPIDOS aut ad naturam rettulit Curetum, quod sint celeres ac feroces, aut <hi rend="italic">trepidos</hi> metu Saturni intellegamus uel quasi iam deum formidantes Iouem. </p>
             </div>
 
-            <div type="schol" n="784-785">
+            <div type="schol" n="784">
                <p> (ILLI CERTANTIA) PLAVDVNT / ORGIA ad certationem <hi rend="italic">plaudunt</hi> hoc est feriunt <hi rend="italic">orgia</hi> id est tympana. </p>
             </div>
 
@@ -8408,11 +8409,11 @@
                <p> (TENERIS MEDITANS) VERBA ILLVCTANTIA LABRIS quia infanti quasi quoddam est inter uerba et labra certamen. Nam, dum conatur uerba proferre, impeditur a labris immaturis. </p>
             </div>
 
-            <div type="schol" n="795-796">
+            <div type="schol" n="795">
                <p> (TALIS PER LITORA REPTANS / IMPROBVS) ORTYGIAE LATVS (INCLINABAT APOLLO) Iuppiter cum Asterien, Titani filiam, amaret et illa eum contemneret, in auem ortygiam conuersa est, quam nos coturnicem dicimus, eamque in mare deiecit. Vnde insula Ortygia est dicta. Postea ibi Latona enixa est Apollinem et Dianam. Quibus natis insula 'Delos' est nominata. INCLINABAT suo scilicet pondere. </p>
             </div>
 
-            <div type="schol" n="802-805">
+            <div type="schol" n="802">
                <p> (IBI EXSVLTANS CONCLAMAT AB AGMINE PRIMVS / SICVT ERAT LEVIBVS TOLLENS VEXILLA MANIPLIS) / ARGVS AQVAE (LONGVSQVE VIRVM SVPER ORA CVCVRRIT / CLAMOR AQVAE) <supplied>
                      <hi rend="italic">Argus</hi>
                   </supplied> hic uexillum portabat et, ut erat in primis positus, exclamauit 'aquae, aquae sunt hic'. Cui tota multitudo respondit exercitus: 'aquae'. Vt Vergilius:</p>
@@ -8434,11 +8435,11 @@
                <p> (SALVTATVS CVM) LEVCADA PANDIT (APOLLO) hoc est: facit uideri montem ipsum id est Leucada, promuntorium Epirotici maris. </p>
             </div>
 
-            <div type="schol" n="809-811">
+            <div type="schol" n="809">
                <p> (INCVBVERE VADIS PASSIM DISCRIMINE NVLLO / TVRBA SIMVL PRIMIQVE NEQVIT SECERNERE MIXTOS) / AEQVA SITIS ut omnibus aequa sitis fuerat, ita omnibus aequam fecerat dignitatem. </p>
             </div>
 
-            <div type="schol" n="811-812">
+            <div type="schol" n="811">
                <p> (FRENATA SVIS) IN CVRRIBVS (INTRANT / ARMENTA) pro 'in currus impliciti', ut biberent. </p>
             </div>
 
@@ -8446,16 +8447,16 @@
                <p> DIRIPITVR populatur. </p>
             </div>
 
-            <div type="schol" n="&lt;818-819&gt;">
+            <div type="schol" n="818">
                <p> 
                   <supplied>NVNC SORDET AQVIS EGESTVS AB IMIS / ALVEVS VNDE TOROS RIPARVM TVRBANT a</supplied> bibentibus siccantur tori riparum. </p>
             </div>
 
-            <div type="schol" n="825-826">
+            <div type="schol" n="825">
                <p> SILVARVM NEMEE LONGE REGINA V(IRENTVM) / LECTA IOVIS SEDES) memor sui poeta laudat Nemeam siluam, quae inter Thebas et Argos est, quod in ea Iuppiter <supplied>colitur</supplied>, cuius sacerdos erat Lycurgus rex, pater Archemori. </p>
             </div>
 
-            <div type="schol" n="833-835">
+            <div type="schol" n="833">
                <p> (NEQVE ENIM TIBI) CANA REPOSTAS / (BRVMA NIVES RAPTASQVE ALIO DE FONTE REFVNDIT / ARCVS AQVAS GRAVIDIVE INDVLGENT NVBILA CAVRI) flumina enim quae ex niuibus uel imbribus sumunt uires possunt siccari. Vel hoc intellegendum: non interim effunduntur, niues cum uerticibus montium solis calore liquuntur. </p>
             </div>
 
@@ -8473,7 +8474,7 @@
                   <hi rend="italic">Centaureum</hi> ideo quia hunc Nessus Centaurus custodiebat. Herculis uero fabula cunctis notissima est. </p>
             </div>
 
-            <div type="schol" n="840-841">
+            <div type="schol" n="840">
                <p> (CELEBRABERE ...) / AB IOVE PRIMVS HONOS post Iouem tu secundus inuocabere. Sic Horatius:</p>
                <lg>
                   <l>'tu secundo</l>
@@ -8483,7 +8484,7 @@
 
          </div>
 
-         <div type="lib" n="V">
+         <div type="lib" n="5">
             <head>LIBER V</head>
 
             <div type="pr" n="pr">
@@ -8498,12 +8499,12 @@
                <p> (AGMINA) LINQVEBANT (RIPAS) postquam ductu Hypsipylae Argiuus exercitus sitis ardore succensus uires liquore et haustu recuperauit, rursus ordinatur ad bellum. AMNEMQVE MINOREM quem per potum minorem fecit exercitus. </p>
             </div>
 
-            <div type="schol" n="&lt;3-4&gt;">
+            <div type="schol" n="3">
                <p> 
                   <supplied>PEDES ARMA / IMPLET</supplied> quia uacuantur, cum exuuntur, et ubi corpus muniunt, implentur. </p>
             </div>
 
-            <div type="schol" n="&lt;4-5&gt;">
+            <div type="schol" n="4">
                <p> 
                   <supplied>REDIERE VIRIS ANIMIQVE MINAEQVE / VOTAQVE</supplied> Lucanus:</p>
                <lg>
@@ -8514,15 +8515,15 @@
                   <supplied>VOTA</supplied> uota belli, quae ante susceperant aqua inuenienda. </p>
             </div>
 
-            <div type="schol" n="7-8">
+            <div type="schol" n="7">
                <p> LEGEMQVE SEVERI / (ORDINIS) quem confundi militaris prohibet disciplina. </p>
             </div>
 
-            <div type="schol" n="8-9">
+            <div type="schol" n="8">
                <p> (VT CVIQVE ANTE LOCVS DVCTORQVE) MONENTVR / (INSTAVRARE VIAS) id est: unusquisque locum suum et dignitatem post potum recepit. </p>
             </div>
 
-            <div type="schol" n="9-10">
+            <div type="schol" n="9">
                <p> (TELLVS IAM PVLVERE PRIMO) / CRESCIT quia dum erigitur puluis crescit terra in altitudinem. </p>
             </div>
 
@@ -8530,7 +8531,7 @@
                <p> PHARIIS (... SERENIS) Aegyptiis. Pharos enim ciuitas est Aegypti. </p>
             </div>
 
-            <div type="schol" n="11-13">
+            <div type="schol" n="11">
                <p> (QVALIA ...) / RAVCA PARAETONIO (DECEDVNT AGMINA NILO / CVM FERA PONIT HIEMS) laetitiae congrua comparatio. Sic Argiui post sitim laeti erant et alacres ut redeuntes grues ex Aegypto in Thraciam quando fugiunt Notum, qui in Aegypto calorem aeri<supplied>s</supplied> tempore auget aestatis. CVM FERA PONIT HIEMS desinit. Vt Vergilius:</p> 
                <l>'cum uenti posuere'. </l>
             </div>
@@ -8549,7 +8550,7 @@
                <p> DVX TALAIONIDES <supplied>Adrastus</supplied>, Talai et Eurynomes filius. </p>
             </div>
 
-            <div type="schol" n="20-21">
+            <div type="schol" n="20">
                <p> CVI GLORIA TANTA / (VENIMVS) quasi ad gloriam Hypsipyles pertinet quod saluti sit restitutus exercitus. </p>
             </div>
 
@@ -8587,7 +8588,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="31">
+            <div type="schol" n="31a">
                <p> INSERTA inducta. Vt Vergilius:</p>
                <lg>
                   <l>'clipeoque sinistram</l>
@@ -8595,7 +8596,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;31-32&gt;">
+            <div type="schol" n="31b">
                <p> 
                   <supplied>DEBELLATOSQVE PVDENDO / ENSE MARES</supplied> ita, inquit, fuimus furore mutatae ut nostro scelere sexus omnis uirilis occumberet. </p>
             </div>
@@ -8604,7 +8605,7 @@
                <p> (O MISERAE QVIBVS HIC) FVROR ADDITVS bene <hi rend="italic">additus</hi>, cum libido iam esset in furia uel quasi naturaliter <supplied>non</supplied> haberent furorem. </p>
             </div>
 
-            <div type="schol" n="34-36">
+            <div type="schol" n="34">
                <p> ILLA EGO NAM PVDEAT (NE FORTE BENIGNAE / HOSPITIS ILLA DVCES RAPTVM QVAE SOLA PARENTEM / OCCVLVI) ordo: illa, quae raptum sola parentem occului. Sensus: ne uos pudeat quod me benignam fortuna fecerit, non uoluntas. <hi rend="italic">Hospitem</hi> autem se dixit, ne se tamquam parricidam audientes horrerent. Id est: ego illa sum quae non fortuna suadente bene feci, sed sponte occului patrem. </p>
             </div>
 
@@ -8622,7 +8623,7 @@
                <p> NEC FACILIS NEMEE (LATAS EVOLVERE VIRES) explicare tantam multitudinem. Id est: angusta uia est, per quam omnes transire non possumus. Ergo, dum mora est in transitu, narrandi spatium habes. </p>
             </div>
 
-            <div type="schol" n="53-54">
+            <div type="schol" n="53">
                <p> (THRACES ARANT CONTRA) THRACVM FATALIA NOBIS / (LITORA ET INDE NEFAS) id est: uicinitas Thraciae in nos suum transtulit nefas. Nam quemadmodum illic Procne filium necauit, ita et nos in Lemno maritos peremimus. — uel quia exemplum de caede maritorum petitum est a crudelitate Terei, qui fuit ex Thracia. </p>
             </div>
 
@@ -8630,7 +8631,7 @@
                <p> (INNVMERIS QVAS SPVMIFER) ASSILIT AEGON mare Aegaeum, quod insulas plurimas habet, dictum ab Aegeo, Thesei patre. Et eleganter insulam insulis comparauit. <hi rend="italic">Assilit</hi> insulas id est circumfluit. </p>
             </div>
 
-            <div type="schol" n="58-59">
+            <div type="schol" n="58">
                <p> (NVLLOS VENERI SACRAVIMVS IGNES) / NVLLA DEAE SEDES quia adulterium Veneris in honorem Vulcani damnauera<supplied>n</supplied>t, inde nulla Veneris sedes in Lemno. Vnde iratum numen immisit odorem feminis hircinum, ob quam causam horruisse uiri dicuntur uxores. Igitur pergentes ad Thraciam eorum filias sortiti sunt. Quo dolore commotae Lemniades reuersos uiros uniuersae peremerunt. Sed hanc ueritatem poeta declinauit. Alii dicunt templum Veneris fuisse in Lemno Graecorum opinione celebratum. Diuersa est odii causa. Nam hoc alii asserunt, quia adulterium eius in hac insula uidetur esse detectum. Vt ipsa Venus:</p> 
                <l>'hoc mihi Lemniacae de te meruere catenae'.</l> 
                <p>Ideo etiam illas ineptas Solis filias acriter persecuta est. QVONDAM interdum. Vt:</p> 
@@ -8647,7 +8648,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="62-63">
+            <div type="schol" n="62">
                <p> (NEC VVLTV NEC CRINE PRIOR) SOLVISSE IVGALEM / CESTON id est sui dissimilis, omnibus deliciarum signis amotis, quoniam ira molles abicit habitus. <hi rend="italic">Ceston</hi> est uinculum ornamenti quo circumdatur Venus, omnibus illecebris nuptiarumque cupiditatibus elaborato quo matrimonia dicitur alligare. <del>CESTON subligar.</del> Declinatur autem 'haec cestos' ut 'Delos, Lemnos'. Specialiter tamen <hi rend="italic">ceston</hi> zonam Veneris debemus accipere, quae non rutilo auro gemmisque sit, sed pelle, ut probentur corporeae uoluptates. <hi rend="italic">Ceston</hi> uocatur quia copula et matrimonio uis est, quia adeo quae pro adulterio perpetrantur 'incesta' dicuntur, quasi quod non uinctum fuerit sit incestum. </p>
             </div>
 
@@ -8660,7 +8661,7 @@
                <l>'qui mihi reddat eum uel eo me soluat amantem'. </l>
             </div>
 
-            <div type="schol" n="66-67">
+            <div type="schol" n="66">
                <p> TARTAREAS (INTER THALAMIS VOLITASSE SORORES / VVLGARENT) sunt qui dicerent Venerem se cum Furiis uidisse. Et bene, philosophice prope, se<supplied>d</supplied> obscure, hic poeta tetigit furias amori esse coniunctas secundum Vergilium:</p> 
                <l>'in furias ignemque ruunt'.</l> 
                <p>Talia enim per amorem committuntur qualia per furorem solent. Quid est enim uoluptas Veneris nisi mera insania? Ideo Venus ignis dicitur, ideo Vulcani et Martis coniunx, ignis et furoris. Idcirco et Furiae ignis facibus distinguuntur armatae. </p>
@@ -8672,18 +8673,18 @@
                <p>Dicuntur spiramina ignis in hac insula esse quae constat efflari semper. </p>
             </div>
 
-            <div type="schol" n="81-82">
+            <div type="schol" n="81">
                <p> (NAM ME TVNC LIBERA CVRIS / VIRGINITAS) ANNIQVE TEGVNT <supplied>
                      <hi rend="italic">tegunt</hi>
                   </supplied> defendunt id est separabant a tali consilio. Siue <hi rend="italic">tegunt</hi>: a curis defendunt. Vt Vergilius:</p> 
                <l>'hunc tegere et dirae ualeam subducere pugnae'. </l>
             </div>
 
-            <div type="schol" n="85-86">
+            <div type="schol" n="85">
                <p> (SOL OPERVM MEDIVS SVMMO LIBRABAT OLYMPO / LVCENTES) CEV STARET EQVOS quia meridie cursus solis uidetur stare. </p>
             </div>
 
-            <div type="schol" n="86-87">
+            <div type="schol" n="86">
                <p> QVATER AXE SERENO / (INTONVIT) de numero tonitruum ratio est. Nam omnis impar numerus prospera significat et uiuis ascribitur, id uero quod par est exit infectum. Quod ergo nihil agit, defunctorum est. Vt Vergilius:</p> 
                <l>'numero deus impare gaudet'.</l> 
                <p>Et ubique mortuis geminum hoc est parem ascribit numerum uel dualem: quattuor iuuencas inferis Orphei immolat, quattuor dis tauros inferis mactat. Ideo etiam hic quattuor, quia aduersum tonat. Et nitide obseruauit ut senae horae eo tempore diuiderentur a sole ut par numerus, qui est uiuis contrarius, poneretur. Dicitur autem hic impar numerus a Pythagora repertus et masculinae uirtutis et deorum superum propter trinam regulam diuinae rationis. Ergo huiusmodi signa contigerant ut:</p>
@@ -8694,7 +8695,7 @@
                <p>Perocculte Vergilius de numero actus equi infernam infaustamque rem id est mortem pronuntiari praedicebat. </p>
             </div>
 
-            <div type="schol" n="87-88">
+            <div type="schol" n="87">
                <p> (QVATER ANTRA DEI FVMANTIS ANHELOS) / EXSERVERE APICES flammarum scilicet. Vt:</p>
                <lg>
                   <l>'de uertice uisus Iuli</l>
@@ -8710,27 +8711,27 @@
                <p> (TOLLITVR IN FVRIAS ...) INSVETA hoc est: praeter solitum tollitur in furorem. </p>
             </div>
 
-            <div type="schol" n="92">
+            <div type="schol" n="92a">
                <p> TEVMESIA THYIAS <hi rend="italic">Teumesia</hi> Boeotia. Teumesus enim campus iuxta Thebas prope Cithaeronem. <hi rend="italic">Thysias</hi> Baccha <foreign xml:lang="grc">ἀπὸ θυίειν, βακχᾶν</foreign>.</p>
             </div>
 
-            <div type="schol" n="92-93">
+            <div type="schol" n="92b">
                <p> INSANO ... / ... DEO <hi rend="italic">insanum</hi> Liberum dicit, qui cultores suos faciat insanos. </p>
             </div>
 
-            <div type="schol" n="95-96">
+            <div type="schol" n="95">
                <p> TREMENTI / SANGVINE instabili furore. </p>
             </div>
 
-            <div type="schol" n="98-99">
+            <div type="schol" n="98">
                <p> INFELIX COMITATVS (EVNTI / HAEREBANT NATI) quia eos primum occisura est ut fidem faciat sceleris ceteris suadere. </p>
             </div>
 
-            <div type="schol" n="100-101">
+            <div type="schol" n="100">
                <p> SVMMASQVE AD PALLADOS ARCES / (IMPETVS) opportune in templo uirginis deae in maritorum interitum feminae uniuersae coniurant. Haec enim dea uidetur damnasse matrimonium uirginitate contenta. </p>
             </div>
 
-            <div type="schol" n="104-106">
+            <div type="schol" n="104">
                <p> REM SVMMAM (INSTINCTV SVPERVM MERITIQVE DOLORIS / ... / LEMNIADES SANCIRE PARO) <supplied>
                      <hi rend="italic">meriti ... doloris</hi>
                   </supplied> quem meritum habemus in uiros. Instinctu enim superorum, non humano errore paramus ista committere. Et est ordo: rem summam sancire paro.</p>
@@ -8740,22 +8741,22 @@
                <p> O VIDVAE <hi rend="italic">uiduas</hi> maritas uidetur incongrue posuisse, sed ad explicandum dolorem muliebrem dixit. Hoc est: quae, cum habeatis uiros, illis longe a uobis positis uiduarum uiuitis more. Bene ergo nomen uiduitatis opposuit, quo uocabulo iam de coniugibus desperarent et ut quasi alienos sine affectu uideantur occidere. (FIRMATE ANIMOS ET) SEXVM (PELLITE) non dixit 'sexum perdite' id est naturam immutate, quod fieri nulla poterat ratione, sed pulsa feminea imbecillitate uiriles ad facinus arripite animos. </p>
             </div>
 
-            <div type="schol" n="106-108">
+            <div type="schol" n="106">
                <p> (SI TAEDET INANES) / AETERNVM (SERVARE DOMOS TVRPEMQVE IVVENTAE / FLORE SITVM ET LONGIS STERILES IN LVCTIBVS ANNOS) sic ait, quasi semper desint mariti. Vt Vergilius:</p> 
                <l>'solane perpetua maerens carpere iuuenta?'</l> 
                <p>IVVENTAE FLORE ideo posuit <hi rend="italic">iuuentae</hi>, ne spes sit ulterius neue malum sit temporale. SITVM uetustatem, quae turpis est in iuuene. Vt Vergilius:</p> 
                <l>'nec ego uicta situ'. </l>
             </div>
 
-            <div type="schol" n="109-110">
+            <div type="schol" n="109">
                <p> (VIAM ... / QVA) RENOVANDA VENVS <hi rend="italic">Venerem</hi> hic pro 'maritis' posuit. Id est: ut inueniamus alios uiros. </p>
             </div>
 
-            <div type="schol" n="112-113">
+            <div type="schol" n="112">
                <p> CVI CONVBIALIA VINCLA / (AVT THALAMI SECRETVS HONOS) interrogatiue, id est: cui uestrum fuit thalami honos secretus? </p>
             </div>
 
-            <div type="schol" n="113-114">
+            <div type="schol" n="113">
                <p> CVI CONIVGE (PECTVS / INTEPVIT) cuius pectus intepuit blandimentis mariti complexum? </p>
             </div>
 
@@ -8763,15 +8764,15 @@
                <p> (CVIVS VIDIT) LVCINA LABORES ab inutilibus maritis argumentatur ut doce<supplied>a</supplied>t quid habeant utilitatis, si uoluerint mutare consilia. </p>
             </div>
 
-            <div type="schol" n="115-116">
+            <div type="schol" n="115">
                <p> (VEL IVSTOS CVIVS PVLSANTIA MENSES) / VOTA TVMENT metaphora ab inclusis, qui pulsant ut aperiatur. Et hic partus inclusus est. Non uota tument, sed crescentibus mensibus uterus tumet. Propter quem, <supplied>p</supplied>artu ut detumescat, uota suscipiuntur. </p>
             </div>
 
-            <div type="schol" n="117-119">
+            <div type="schol" n="117">
                <p> (POTVITNE VLTRICIA) GRAIVS / (VIRGINIBVS DARE TELA PATER LAETVSQVE DOLORVM / SANGVINE SECVROS IVVENVM PERFVNDERE SOMNOS) Danaum dicit, qui quinquaginta filiabus suasit ut sponsos suos eadem nocte qua fuerant coniugatae perimerent. Quarum omnes sponsi filii Aegypti, fratris Danai, fuerunt. Et totum hoc ab exemplis posuit. </p>
             </div>
 
-            <div type="schol" n="120-122">
+            <div type="schol" n="120">
                <p> QVOD SI PROPIORIBVS ACTIS / (EST OPVS ECCE ANIMOS DOCEAT RHODOPEIA CONIVNX / VLTA MANV THALAMOS PARITERQVE EPVLATA MARITO) <supplied>
                      <hi rend="italic">propioribus actis</hi>
                   </supplied> 
@@ -8787,16 +8788,16 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;122&gt;">
+            <div type="schol" n="122">
                <p> 
                   <supplied>PARITERQVE EPVLATA MARITO</supplied> hoc historia non habet, quod Procne pariter cum Tereo filium comedisset. Sed ut Lemniadum animos hoc scelere magis accenderet, Procnen quoque pariter epulatam pro loco persuasioni<del>s</del> suae necessario fuisse mentita est. </p>
             </div>
 
-            <div type="schol" n="123-124">
+            <div type="schol" n="123">
                <p> (NEC VOS IMMVNIS SCELERVM) SECVRAVE COGO / (PLENA MIHI DOMVS) nec uos ideo e<del>r</del>go hortor ad scelus, quod minime orbitate plena mihi sit domus filiis. Et est figura anthypophora: ne ideo uideatur hoc ipsa persuadere quia non habet ipsa quos perimat. </p>
             </div>
 
-            <div type="schol" n="&lt;124&gt;">
+            <div type="schol" n="124">
                <p> 
                   <supplied>INGENS EN CERNITE SVDOR</supplied> 
                   <hi rend="italic">sudorem</hi> autem dixit filiorum multiplicem partum, in quo dolore nimium laboratur. Siue <hi rend="italic">sudorem</hi> occidendorum quattuor posuit filiorum, siue <hi rend="italic">sudorem</hi> dixit liberos: quos parturiendo et educando sudaui. </p>
@@ -8814,19 +8815,19 @@
                </lg>
             </div>
 
-            <div type="schol" n="132">
+            <div type="schol" n="132a">
                <p> FORTVNAM occasionem temporis. Vt Vergilius:</p> 
                <l>'si fortuna permittitis uti'. </l>
             </div>
 
-            <div type="schol" n="132-134">
+            <div type="schol" n="132b">
                <p> (SVPERISNE VOCANTIBVS VLTRO / DESVMVS ECCE) RATES (DEVS HOS DEVS VLTOR IN IRAS / ADPORTAT COEPTISQVE FAVET) <supplied>
                      <hi rend="italic">rates</hi>
                   </supplied> reuertentium uirorum. Persuasio est: dicit enim deorum nutu factum esse ut eo tempore coniuges aduenirent quo de eorum caede tractatum est. <supplied>Ex</supplied> probabili argumento agendi uirtute necessarium fecit dicendo: 'deus hos, deus ultor in iras...' <del>SVPERISNE VOLENTIBVS VLTRO DESVMVS</del> ut Vergilius:</p> 
                <l>'dis equidem auspicibus reor et Iunone secunda'. </l>
             </div>
 
-            <div type="schol" n="134-135">
+            <div type="schol" n="134">
                <p> NEC IMAGO QVIETIS / (VANA MEAE) confirmat audaciam suam deos adiuuare somnii expositione. Et est ratio philosophica: cur, quae futura sint, miseris mortalibus praesagiis somniorum demonstrantur? Sed de multis paululum dicam. Natura rerum, ex qua homines mixti sunt, effectus suos silere non patitur. Et cur per ipsam essentiam corporis sentire permittit? Est animae diuina prouidentia, quae, quamuis caeco carcere ac tenebris clausa tenetur, quid e contrario natura factura sit, somniorum uaticinatione denuntiet. (NEC IMAGO QVIETIS) VANA MEAE id est: nec somnium meum uanum est, sed uerum. Ergo debet perfici, quoniam somnium ueritatis imago est. Vt Vergilius:</p>
                <lg>
                   <l>'nam mihi per somnum Cassandrae uatis imago</l>
@@ -8840,7 +8841,7 @@
                <p> QVID PERDITIS AEVVM iuuentutem uestram quid perditis maritis orbatae?</p>
             </div>
 
-            <div type="schol" n="137-138">
+            <div type="schol" n="137">
                <p> (AGE) AVERSIS (THALAMOS PVRGATE MARITIS / IPSA FACES ALIAS MELIORAQVE FOEDERA IVNGAM) <supplied>
                      <hi rend="italic">auersis</hi>
                   </supplied> animo inimicis. Consideranda est persuasio, in qua primum est beneficium, quod mala tollit, deinde quod optima pollicetur. <hi rend="italic">Auersos</hi> autem dicit: qui a uobis auersi sunt et qui uos neglegunt. Vt Vergilius:</p> 
@@ -8860,26 +8861,26 @@
                <p> BISTONIDES (VENIVNT FORTASSE MARITAE) illecebrosa sic fuit. Dixerat enim supra mulieres omnes hoc dolere quia omnes Lemni iuuenes odio odoris uxorum sunt in Thraciam profecti siue in eodem loco coniugiis copulati. Et <hi rend="italic">Bistonides</hi> femininum genus posuit. Si de uiris diceret, 'Bistonii' dixisset: — <hi rend="italic">ides</hi> additum propter societatem coniugii. <supplied>FORTASSE</supplied> nam maritos earum uenire notissimum est. </p>
             </div>
 
-            <div type="schol" n="145">
+            <div type="schol" n="145a">
                <p> LVNATVM peltatum. Quod scuta Amazonarum, quas peltas appellant, in modum lunae formata sint. Vt Vergilius:</p> 
                <l>'feminea exsultant lunatis agmina p(eltis)'. </l>
             </div>
 
-            <div type="schol" n="145-146">
+            <div type="schol" n="145b">
                <p> (VBI ARMA) / INDVLGET PATER <hi rend="italic">pater</hi> aut secundum consuetudinem poetarum dixit, qui solent deos 'patres' uocare, ut Vergilius:</p> 
                <l>'quidue, pater Neptune, paras?',</l> 
                <p>aut <hi rend="italic">pater</hi> id est Mars, quia Penthesileae siue omnium Amazonum proprie Gradiuus dicitur pater. </p>
             </div>
 
-            <div type="schol" n="149">
+            <div type="schol" n="149a">
                <p> SOLARE DOMOS uastare id est solas facere. Compositiuum 'desolare'. Vt est: 'solorum nemorum'.</p>
             </div>
 
-            <div type="schol" n="149-150">
+            <div type="schol" n="149b">
                <p> IVVENVMQVE SENVMQVE / (PRAECIPITARE COLOS) id est indiscrete omnes occidere. </p>
             </div>
 
-            <div type="schol" n="150-151">
+            <div type="schol" n="150">
                <p> PLENISQVE AFFRANGERE PARVOS / VBERIBVS id est uiolenter necare et ipsis uberibus appositos enecare. Et hoc incongrue poeta posuit. Cum tanto tempore dicat earum maritos abfuisse, unde Lemniadibus lactantes filios? Purgatur obiectio, si dicatur etiam trimos infantes lactare posse. Ait enim superius:</p> 
                <l>'tertia canet hiems; cui conubialia uincla ... ?'</l>
             </div>
@@ -8913,7 +8914,7 @@
                   <del>ATQVE</del> INFERNA CERES Proserpina. </p>
             </div>
 
-            <div type="schol" n="157-158">
+            <div type="schol" n="157">
                <p> (SED FALLIT VBIQVE) / MIXTA VENVS quicquid agitur, quicquid nefarie cogitatur, Venus urget infensa. Et cum hoc poeticum uideatur, est tamen uera ratio. Cuncta enim mala quae geruntur per Venerem fiunt, cui omnes propemodum mortales student. </p>
             </div>
 
@@ -8936,7 +8937,7 @@
                </l>
             </div>
 
-            <div type="schol" n="160-161">
+            <div type="schol" n="160">
                <p> ET MIRANTIA ... / (PECTORA) id est admiratione digna et quae, nisi a talibus matribus, uiolare ferro nullus auderet. </p>
             </div>
 
@@ -8961,7 +8962,7 @@
                <l>'omnibus umbra locis adero. Dabis, improbe, poenas'. </l>
             </div>
 
-            <div type="schol" n="165-166">
+            <div type="schol" n="165">
                <p> QVALIS CVM CERVA (CRVENTIS) / CIRCVMVENTA LVPIS) comparatio non secundum artem poeticam. </p>
             </div>
 
@@ -8983,7 +8984,7 @@
                <l>'increpu<supplied>it ma</supplied>lis morsuque elusus inani est'. </l>
             </div>
 
-            <div type="schol" n="175-176">
+            <div type="schol" n="175">
                <p> NIGER OMNIBVS ARIS / (IGNIS) hic enim color conuenit morituris. Vnde Vergilius, quoniam peritura Dido erat quae sacrificium faciebat, ait:</p> 
                <l>'latices nigrescere sacros'. </l>
             </div>
@@ -8992,12 +8993,12 @@
                <p> (IN NVLLIS SPIRAT) DEVS INTEGER (EXTIS) est quoddam in extis signum quod <hi rend="italic">deus</hi> appellatur, quod si integrum apparuerit, propitium numen ostendit, sin uero dimidium, iratum significat numen aut certe non praesens. </p>
             </div>
 
-            <div type="schol" n="177-178">
+            <div type="schol" n="177">
                <p> TARDIVS HVMENTI (NOCTEM DEIECIT OLYMPO / IVPPITER) Lucanus:</p> 
                <l>'segnior Oceano, quam lex aeterna uocaret...'</l>
             </div>
 
-            <div type="schol" n="178-179">
+            <div type="schol" n="178">
                <p> ET VERSVM (MITI REOR) AETHERA (CVRA / SVSTINVIT) iuxta rationem: qua antipodes feruntur. Vergilius:</p>
                <lg>
                   <l>'nosque ubi primus equis Oriens afflauit anhelis,</l>
@@ -9008,7 +9009,7 @@
                <p>MITI ... CVRA id est: benigna mente diem tardauit et cursus aeris quo solem Iuppiter retineret longiores effecit, imminentia cupiens nefariae noctis facta tardasse. </p>
             </div>
 
-            <div type="schol" n="183-184">
+            <div type="schol" n="183">
                <p> (VNA GRAVI PENITVS) LATET OBRVTA CAELO / LEMNOS id est: cum astris relucentibus aliae insulae cernerentur, immanitate futuri sceleris obruta sola Lemno<supplied>s</supplied> latebat. </p>
             </div>
 
@@ -9017,7 +9018,7 @@
                <l>'sub remis fusi per dura sedilia nautae'. </l>
             </div>
 
-            <div type="schol" n="187-188">
+            <div type="schol" n="187">
                <p> (VACVANTQVE PROFVNDO) / AVRVM IMMANE (MERO) id est aureas pateras. Vt Vergilius:</p>
                <lg>
                   <l>'grauem gemmis auroque poposcit</l>
@@ -9026,13 +9027,13 @@
                <p>Dicit ergo hos grauibus poculis ebrios factos ut merito crederentur a feminis interempti. </p>
             </div>
 
-            <div type="schol" n="188-190">
+            <div type="schol" n="188">
                <p> (DVM QVAE) PER STRYMONA (PVGNAE / QVIS RHODOPE GELIDOVE LABOR SVDATVS IN HAEMO / ENVMERARE VACANT) <supplied>
                      <hi rend="italic">per Strymona</hi>
                   </supplied> per Thraciam. Strymon enim fluuius Thraciae est, <hi rend="italic">Rhodope</hi> et <hi rend="italic">Haemus</hi> eiusdem prouinciae montes. <supplied>Sensus: </supplied> dum ergo <del>in Rhodopen</del> commemorant quem laborem pertulerint apud fluuium Strymonem uel apud montem <supplied>Rhodopen uel apud</supplied> Haemum. </p>
             </div>
 
-            <div type="schol" n="192-193">
+            <div type="schol" n="192">
                <p> (DEDERAT) MITIS CYTHEREA (SVPREMA / NOCTE VIROS) et hic obscure illud poeta tangit, quod foetoris causa<supplied>m</supplied> hircini quem dudum Venus Lemniadibus miserat nunc dulci odore lenisset. </p>
             </div>
 
@@ -9048,11 +9049,11 @@
                <p> SECERNITQVE VIROS quos ut letifero sopore perfunderet separauit. </p>
             </div>
 
-            <div type="schol" n="204">
+            <div type="schol" n="204a">
                <p> HYRCANAE (... LEAE) Hyrcania Indiae regio in qua tigrides generantur. </p>
             </div>
 
-            <div type="schol" n="204-205">
+            <div type="schol" n="204b">
                <p> (QVAS) EXIGIT ORTV / (PRIMA DIES) id est euocat incipiente die. <hi rend="italic">Exigit</hi> proprie est Graeca annotatione signatum: quasi <foreign xml:lang="grc">ἐξάγει</foreign>.</p>
             </div>
 
@@ -9064,7 +9065,7 @@
                <p> RIMATVR quaerit, scrutatur. </p>
             </div>
 
-            <div type="schol" n="213-215">
+            <div type="schol" n="213">
                <p> (NEC SEGNIVS ILLA TENENTIS / PONE ADIGIT COSTAS DONEC SVA PECTORA FERRO) / TANGERET tunc enim <supplied>non</supplied> credidit se peremisse, si tamdiu transfigeret dormientem, donec <supplied>ad pectus</supplied> adactum ferrum ipsa sentiret. </p>
             </div>
 
@@ -9076,7 +9077,7 @@
                <p> (PROPRIA LVCTVS) DE STIRPE (RECORDOR) cognationis meae scelera referam. </p>
             </div>
 
-            <div type="schol" n="220-223">
+            <div type="schol" n="220">
                <p> QVOD TE FLAVE CYDON QVOD TE ... / CRENAEE ... (QVIBVS VBERA MECVM / OBLICVMQVE A PATRE GENVS) ... / VIDI LAPSARE hos sibi dicit et lactis alimentis et affinitate fuisse coniunctos. (QVIBVS VBERA MECVM) OBLICVMQVE A PATRE GENVS qui collactanei mei fuerant et patris mei nothi. <hi rend="italic">Oblicum</hi> ergo dicit ex concubina progenitum. Vt Lucanus:</p>
                <lg>
                   <l>'obliquo maculat qui sanguine regnum</l>
@@ -9084,7 +9085,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="222-223">
+            <div type="schol" n="222">
                <p> (FORTEMQVE TIMEBAM / QVEM DESPONSA) GYAN VIDI LAPSARE quem fortem desponsata metuebam, quia uirtus pueri formidanda puellis est. </p>
             </div>
 
@@ -9092,7 +9093,7 @@
                <p> FINXERAT composuerat. </p>
             </div>
 
-            <div type="schol" n="233-235">
+            <div type="schol" n="233">
                <p> (SIC ILLA IACENTI) / INCIDIT (VNDANTEMQVE SINV COLLAPSA CRVOREM / EXCIPIT) ordo: <hi rend="italic">incidit ... collapsa</hi>, id est a matre compulsa. </p>
             </div>
 
@@ -9108,7 +9109,7 @@
                <p> MEVS ILLE THOAS hic Thoas, Hypsipyles pater, rex Lemnius fuit. </p>
             </div>
 
-            <div type="schol" n="241-243">
+            <div type="schol" n="241">
                <p> (ILLE QVIDEM DVDVM QVIS MAGNA TVENTI / SOMNVS AGIT VERSANS SECVM ETSI LATA RECESSIT / VRBE DOMVS) QVINAM STREPITVS (QVAE MVRMVRA NOCTIS) ordo: ille quidem dudum agit uersans secum, quinam strepitus, quae murmura noctis. Ceterum illae duae sententiae per parenthesin interpositae sunt: una, quae generaliter dicit non esse quietos regnantibus somnos, altera, in qua domus remota a ciuitate fuisse monstratur. ETSI LATA RECESSIT / (VRBE DOMVS) dicit occasionem ab urbe disiunctae domus opportunitatem liberandi patris dedisse. </p>
             </div>
 
@@ -9116,7 +9117,7 @@
                <p> ET MECVM FORTASSE CADES bene de periculo suo dubitauit, quia de sexu muliebri non coniurauerant occidendo Lemniades. Perimenda enim haec fuerat ut proditrix coniurationis. </p>
             </div>
 
-            <div type="schol" n="250-251">
+            <div type="schol" n="250">
                <p> (QVOSQVE SACRIS) CRVDELIS VESPERA (LVCIS / STRAVERAT) eo quod nox ueniens eos somno prostrauerat. Inter <hi rend="italic">uesper</hi> et <hi rend="italic">uespera</hi> hoc interest: <hi rend="italic">Vesper</hi> est stella, <hi rend="italic">uespera</hi> tempus quo ingreditur nox, quod hoc loco poeta describit. </p>
             </div>
 
@@ -9124,7 +9125,7 @@
                <p> HIC IMPRESSA TORIS ORA <hi rend="italic">hic</hi> pro 'ibi'. IMPRESSA implicita ora ad lectum. </p>
             </div>
 
-            <div type="schol" n="261-263">
+            <div type="schol" n="261">
                <p> GELIDA NON SAEVIVS OSSA / (LVXVRIANT LAPITHARVM EPVLAE SI QVANDO PROFVNDO / NVBIGENAE CALVERE MERO) <supplied>
                      <hi rend="italic">nubigenae</hi>
                   </supplied> Centauri, Ixionis et nubis filii, quam pro se Iuno mutauit. Qui cum in nuptiis Pirithoi ebrietate caluissent et uellent puellae nubentis irrumpere thalamum, a Lapithis, quorum rex Pirithous fuit, interempti sunt. (SI QVANDO PROFVNDO) NVBIGENAE (CALVERE MERO) Herculis fabulam tangit. Qui cum in hospitio ad <supplied>D</supplied>examenum regem uenisset, Deianiram filiam eius corrupit et fidem dedit se eam uxorem esse ducturum. Post eius discessum Eurytion Ixionis filius Centaurus uxorem Deianiram petiit. Quam pater uim timens Eurytioni promisit, qui constituto die cum fratribus ad nuptias uenit. Eo forte die quo nuptiae celebrabantur superueniens Alcides Centauros interfecit, Deianiramque insperate suo matrimonio copulauit. <del>Item aliter: Centauri, cum in matrimonium Pirithous Hippodamiam duceret, uino pleni Lapitharum uxores conati sunt rapere. Qui omnes a Lapithis occisi sunt. Vnde Vergilius:</del>
@@ -9172,11 +9173,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="282-283">
+            <div type="schol" n="282">
                <p> (VNDE MANVS VNDE HAEC) MAVORTIA DIVAE / P(ECTORA) <hi rend="italic">diuuae</hi> Veneri. Exclamatio cum admiratione Liberi patris, sed iucunda et uere poetica. Cum sciamus Venerem semper lasciuam et delicatam, mirandum unde in delicato pectore tam repentina crudelitas. </p>
             </div>
 
-            <div type="schol" n="285-286">
+            <div type="schol" n="285">
                <p> (NOSTRVM VISVS) ARCENTIBVS VMBRIS / (MITIS ITER LONGAE CLARAVIT LIMITE FLAMMAE) <supplied>
                      <hi rend="italic">arcentibus</hi>
                   </supplied> id est quamquam arcentibus. Et est anacoluthon, ut sit: quamquam arcentibus umbris tamen iter clarauit limite longae flammae. <hi rend="italic">Longae</hi> autem dixit stellae tractu. <hi rend="italic">Clarauit</hi> ergo pro 'clarum fecit'. </p>
@@ -9186,7 +9187,7 @@
                <p> CVRVO ROBORE CLAVSVM fluuiali nauigio, quod sinu roboris incauatur. Et ideo <hi rend="italic">clausum</hi>: quasi in angusto roboris collocatum. </p>
             </div>
 
-            <div type="schol" n="288-289">
+            <div type="schol" n="288">
                <p> (CYCLADAS AEGAEONI) / AMPLEXO (COMMENDO PATREM) <supplied>
                      <hi rend="italic">amplexo</hi>
                   </supplied> participium est. Hoc est: huic Aegaeoni Cycladas amplexo — pro 'amplectenti' — patrem commendo. </p>
@@ -9206,13 +9207,13 @@
                </lg>
             </div>
 
-            <div type="schol" n="297-298">
+            <div type="schol" n="297">
                <p> DECLINIA (TITAN / OPPOSITA IVGA NVBE REFERT) <supplied>
                      <hi rend="italic">declinia</hi>
                   </supplied> quae declinarent et fugerent. Opposita enim nube ante uultus suos Lemniadum crimine declinauerat Sol. IVGA pro 'equis'. REFERT refugit. Fugit enim Sol crudelitatem. Aut <hi rend="italic">refert</hi> 'deflectit' melius intellegamus. </p>
             </div>
 
-            <div type="schol" n="299-300">
+            <div type="schol" n="299">
                <p> (LVCISQVE NOVAE FORMIDINE CVNCTIS / QVAMQVAM INTER SIMILES) HABITVS RVBOR quamquam inter similes rubor <supplied>non</supplied> habetur, tamen noui criminis conscientia se inuicem formidabant. </p>
             </div>
 
@@ -9224,7 +9225,7 @@
                <p> NOTA SITV positione nobilis. ET GETICO (NVPER DITATA TRIVMPHO) Thracio bello, ex quo redeuntes uictores Lemniadibus multas in triumpho contulerant opes. </p>
             </div>
 
-            <div type="schol" n="307-308">
+            <div type="schol" n="307">
                <p> NON MARIS INCVRSV (NON HOSTE NEC AETHERE LAEVO / PERDIDIT VNA OMNES) id est: non naufragio, non bello, non pestilentia perierunt. </p>
             </div>
 
@@ -9252,7 +9253,7 @@
                <p> MASSYLO (... SVB HOSTE) sub leone Mauro. </p>
             </div>
 
-            <div type="schol" n="335-337">
+            <div type="schol" n="335">
                <p> ECCE AVTEM (AERATA DISPELLENS AEQVORA PRORA / PELIAS INTACTI LATE SVBIT HOSPITA PONTI / PINVS) aduentum Argonautarum describit ad Lemnon, qui missi erant a Pelia rege ad Colchos <supplied>ad</supplied> Phrixei arietis pellem auream deferendam. PELIAS ... PINVS Argo nauem dicit, quae in Pelio monte Thessaliae fabricata est. Cicero:</p>
                <lg>
                   <l>'utinam in nemore Pelio n<supplied>e</supplied> caesae securibus</l>
@@ -9267,7 +9268,7 @@
                <p> MINYAE <hi rend="italic">Minyae</hi> Thessali, a Minya rege Thessalorum, a cuius nomine omnes Argonautae 'Minyae' nominati sunt. </p>
             </div>
 
-            <div type="schol" n="337-338">
+            <div type="schol" n="337">
                <p> (GEMINVS FRAGOR ARDVA) CANET / (PER LATERA) <supplied>
                      <hi rend="italic">canet</hi>
                   </supplied> spumat. Id est: dextra laeuaque reuulsi fluctus cano litore feruebant. </p>
@@ -9277,7 +9278,7 @@
                <p> TONSIS remis. </p>
             </div>
 
-            <div type="schol" n="341-345">
+            <div type="schol" n="341">
                <p> MITIOR ET SENIBVS CYGNIS (ET PECTINE PHOEBI / VOX MEDIA DE PVPPE VENIT ... / ... OEAGRIVS ILLIC / ACCLINIS MALO MEDIIS INTERSONAT ORPHEVS / REMIGIIS) Ouidius:</p>
                <lg>
                   <l>'uerba sono tenui maerens fundebat, ut olim</l>
@@ -9286,7 +9287,7 @@
                <p>Orpheum, quemadmodum in naue caneret, dicit, cuius dulcedinem morientis cygni comparat cantilenae. Dicuntur enim cygni mortis tempore dulcius solito canere. </p>
             </div>
 
-            <div type="schol" n="342-343">
+            <div type="schol" n="342">
                <p> (MARIA IPSA CARINAE) / ACCEDVNT consentiunt ut tranquilla subdant. Sic Terentius in Adelphis:</p> 
                <l>'accedo, ut melius dicas'.</l> 
                <p>Aut <hi rend="italic">accedunt</hi> ut audiant, quasi sensum recipientia. Sed melius 'consentiunt'. </p>
@@ -9296,11 +9297,11 @@
                <p> (TANTOSQVE IVBET) NESCIRE LABORES id est: cantus dulcedine laborem sentire non sinit. </p>
             </div>
 
-            <div type="schol" n="346-347">
+            <div type="schol" n="346">
                <p> ORAQVE PRIMI / (CYANEIS ARTATA MARIS) Symplegadas, ut asserit Euripides. CYANEIS <del>... MARIS</del> Cyane Nympha in Sicilia est. Venus indignata, quod Proserpina suum numen contemneret coniugia spernens, <supplied>Plutoni</supplied>, qui territus uiribus Typhoei euomentis Aetnam, cui subiectus erat, cum ab inferis emersisset, intulit amorem, ut Proserpinam circa cacumen Aetnae flores legentem eriperet. Qua compressa cum properaret curru fugere, Cyane Nympha, quam dilexerat Anapus amnis, intercedente tardatus est. At ille incensus ira morae intercedentem ut rumperet sceptro percussit. Praecepsque in inferna demersa est et in liquorem conuersa. Cuius lacus contiguus est Arethusae. </p>
             </div>
 
-            <div type="schol" n="347-348">
+            <div type="schol" n="347">
                <p> NOS THRACIA VISV / (BELLA RATAE) nos putamus Thraces in ultionem uenire nauigio, qui uicti a uiris fuerant Lemniadum. </p>
             </div>
 
@@ -9312,7 +9313,7 @@
                <p> ADVERSO (RISIT GRADIVVS IN HAEMO) utrum situ <hi rend="italic">aduersum</hi> posuit id est positione loci an <hi rend="italic">aduerso</hi> inimico, quippe Mars Lemnum merito oderat quia in ea insula a Vulcano cum Venere fuerat deprehensus? </p>
             </div>
 
-            <div type="schol" n="361-362">
+            <div type="schol" n="361">
                <p> (IAMQVE ABERANT TERRIS QVANTVM) CORTYNIA (CVRRVNT / SPICVLA) tantum, inquit, a portu aberat nauis quantum Cretensium sagittarum iactus exprimitur. <hi rend="italic">Cortynia</hi> enim dixit Cretensia. </p>
             </div>
 
@@ -9320,15 +9321,15 @@
                <p> (RATIS ...) PELASGAE Graecae nauis id est Argo. </p>
             </div>
 
-            <div type="schol" n="364">
+            <div type="schol" n="364a">
                <p> HORROR obscuritas. </p>
             </div>
 
-            <div type="schol" n="364-365">
+            <div type="schol" n="364b">
                <p> (AB OMNI / SOLE DIES pro 'ab omni die sol', noue dictum. </p>
             </div>
 
-            <div type="schol" n="367-368">
+            <div type="schol" n="367">
                <p> (NIGRIS) REDIT VMIDA TELLVS / (VERTICIBVS) arenae funditus auulsae impetu iactantur aquarum. </p>
             </div>
 
@@ -9337,7 +9338,7 @@
                <l>'hunc uehit immanis Triton'. </l>
             </div>
 
-            <div type="schol" n="373-374">
+            <div type="schol" n="373">
                <p> INSANA ... / ARBOR uel magna uel instabilis. Nimis poetice dixit <hi rend="italic">insana arbor</hi>. Accipimus enim mobilem, ut hi qui insani sunt loco stare non possunt. </p>
             </div>
 
@@ -9345,7 +9346,7 @@
                <p> DVM LABOR ILLE VIRIS dum Argonautae tempestate iactantur. </p>
             </div>
 
-            <div type="schol" n="378-380">
+            <div type="schol" n="378">
                <p> (INVALIDIS) FLVITANTIA (TELA LACERTIS / ... / SPARGIMVS) ordo: inualidis lacertis fluitantia tela spargimus. Et bene <hi rend="italic">inualidis</hi> utpote femineis. FLVITANTIA incerta. </p>
             </div>
 
@@ -9353,7 +9354,7 @@
                <p> QVID NON AVSA MANVS sensus: quod non post scelus ausae sumus? Nam, cum occidissemus uiros, etiam semideos bello attrectare temptauimus. </p>
             </div>
 
-            <div type="schol" n="382-383">
+            <div type="schol" n="382">
                <p> (AEQVORA) FVNDO / (EGERERE) hoc est sentinam proicere. Ouidius:</p> 
                <l>'egerit hic fluctus aequorque refundit in aequor'. </l>
             </div>
@@ -9367,7 +9368,7 @@
                <p>Omne enim corpus quod motu rei alterius commouetur ad iaciendum stabilem non habet firmitatem. Sicut Sallustius: 'imbecilla est fortitudo, dum pendet'. </p>
             </div>
 
-            <div type="schol" n="385-386">
+            <div type="schol" n="385">
                <p> FERREA NIMBIS / (CERTAT HIEMS) iaculorum pluuiam describit. Vt Vergilius:</p> 
                <l>'ac ferreus ingruit imber'. </l>
             </div>
@@ -9377,7 +9378,7 @@
                <l>'crinemque uolantia sidera ducunt'. </l>
             </div>
 
-            <div type="schol" n="388-389">
+            <div type="schol" n="388">
                <p> (DAT OPERTA FRAGOREM / PINVS) ET AB IVNCTIS <del>AB ILLA</del> REGEMVNT TABVLATA (CAVERNIS) <hi rend="italic">ab iunctis</hi> ergo <foreign xml:lang="grc">ὑφ' ἕν</foreign> noli accipere. <hi rend="italic">Operta</hi> autem pinus pellibus, ut mos est. <hi rend="italic">Abiunctis</hi> quidam <foreign xml:lang="grc">ὑφ' ἕν</foreign> legunt: diuisis. Sic in Olympio:</p>
                <lg>
                   <l>'abiungere luna</l>
@@ -9409,7 +9410,7 @@
                <p> ANCAEVM Lycurgi filium a Salamina. </p>
             </div>
 
-            <div type="schol" n="400-402">
+            <div type="schol" n="400">
                <p> (ATTONITO MANIFESTVS IN AGMINE SVPRA EST / AMPHITRYONIADES PVPPEMQVE) ALTERNVS (VTRIMQVE / INGRAVAT ET MEDIAS ARDET DESCENDERE IN VNDAS) eleganter <hi rend="italic">alternus</hi>: ne in uno latere forte consistens mole corporis aut uirtutis uerteret nauem. <hi rend="italic">Alternus</hi> ergo nunc hic nunc illic, in neutra parte consistens. </p>
             </div>
 
@@ -9432,12 +9433,12 @@
                <l>'neque audit currus habenas'. </l>
             </div>
 
-            <div type="schol" n="413">
+            <div type="schol" n="413a">
                <p> 
                   <supplied>TIPHYS</supplied> hic ergo Tiphys gubernator nauis Argo. </p>
             </div>
 
-            <div type="schol" n="413-414">
+            <div type="schol" n="413b">
                <p> MVTAT / IMPERIA <hi rend="italic">mutare imperia</hi> est modo huc modo illuc nauem conuertere. </p>
             </div>
 
@@ -9457,7 +9458,7 @@
                <p> (TRABIBVS) DE MORE (REVINCTIS) contrarie poeta dixit <hi rend="italic">de more</hi>, cum nemo nauigium ante temptasset. <hi rend="italic">De more</hi> ergo hic ait de propria ipsorum consuetudine. </p>
             </div>
 
-            <div type="schol" n="427-428">
+            <div type="schol" n="427">
                <p> (CAELICOLAS SI QVANDO DOMOS LITVSQVE) RVBENTVM / (AETHIOPVM ET MENSAS AMOR EST ITERARE MINORES) <supplied>
                      <hi rend="italic">rubentum</hi>
                   </supplied> quia iuxta Mare Rubrum sunt, siue quia uicino solis <supplied>igne</supplied> signati sunt. Aethiopas ergo hoc loco describit, quia cum Gigantes <supplied>
@@ -9476,7 +9477,7 @@
                <p>Quod hic de absentia numinum respirare dixit Atlantem. </p>
             </div>
 
-            <div type="schol" n="431-432">
+            <div type="schol" n="431">
                <p> (HIC ET) AB ADSERTO (NVPER) MARATHONE (SVPERBVM / THESEA) Marathon ciuitas in qua Theseus nutritus est. Quam cum Persae inuasissent, ab Atheniensibus Theseo duce caede magnorum uirorum liberati sunt. Vnde factum est ut ita Athenienses iurent: <foreign xml:lang="grc">μὰ τοὺς ἐν Μαραθῶνι</foreign>. HIC ET AB ADSERTO (NVPER MARATHONE SVPERBVM / THESEA) Minos, Iouis et Europae filius, cum patri sacrificaturus ad aras accederet, orauit potentiam numinis ut dignam aris suis hostiam ipse praeberet. Itaque subito taurus apparuit nimio candore perfusus. Quem admiratus Minos religionis oblitus armenti sui maluit esse ductorem. Cuius ardore Pasiphae fertur arsisse. Igitur contemptus a filio Iuppiter indignatus furorem tauro subiecit et Cretensium non solum agros sed etiam moenia uniuersa uastauit. Hunc Hercules missus Eurysthei imperio superauit uictumque Argos usque perduxit. Ibi consecratus <supplied>est</supplied> Iunoni ab Eurystheo. Sed Iuno exosa munus, quod ad Herculis gloriam pertinebat, taurum in Atticam regionem expulit. Ibique a monte eius 'Marathonius' appellatus est. Quem postea Theseus, Aegei filius, interemit. Quo facto aeternos sibi gloriae titulos comparauit. </p>
             </div>
 
@@ -9486,7 +9487,7 @@
                <p>Et ideo pretiosiores dicuntur a nimietate frigoris uirides lapides qui 'smaragdi' nuncupantur. </p>
             </div>
 
-            <div type="schol" n="434-435">
+            <div type="schol" n="434">
                <p> (HIC PHOEBO) NON INDIGNANTE PRIOREM / (ADMETVM) bene non <hi rend="italic">indignante</hi>, quia Admeti pecus pauerat et obsequiis eius emeritus ei tamen fauebat, apud quem passus uidebatur iniuriam. Qui<del>a</del> iuxta Amphrysum fluuium pecus pauit — unde Vergilius:</p>
                <lg>
                   <l>'et te memorande canemus</l>
@@ -9496,7 +9497,7 @@
                <l>'Paeoniis reuocatum herbis et amore Dianae'. </l>
             </div>
 
-            <div type="schol" n="436-437">
+            <div type="schol" n="436">
                <p> GENERVMQVE PROFVNDI / (NEREOS) <hi rend="italic">generum ... Nereos</hi> Peleum significat, quia Thetidem, Nerei filiam, duxit uxorem, Achillis matrem. </p>
             </div>
 
@@ -9516,7 +9517,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="445-446">
+            <div type="schol" n="445">
                <p> (ERGO ITERVM VENVS) ET TACITIS CORDA ASPERA F(LAMMIS) / (LEMNIADVM PERTEMPTAT AMOR) <supplied>
                      <hi rend="italic">tacitis</hi>
                   </supplied> occultis. Vt Vergilius:</p> 
@@ -9524,7 +9525,7 @@
                <p>Iterum, inquit, Lemniades coniugalia iura desiderant et Argonautis idcirco iunguntur ut, cum abire coeperint Argonautae, denuo suas derelictis Lemniadibus uideatur iniurias uindicare. </p>
             </div>
 
-            <div type="schol" n="446-448">
+            <div type="schol" n="446">
                <p> (TVNC) REGIA IVNO / (ARMA HABITVSQVE VIRVM PVLCHRAEQVE INSIGNIA GENTIS / MENTIBVS INSINVAT) Iuno, inquit, iniecit nobis mentem benignam quia Argonautis fauebat propter Iasonem — qui eam fluuium transiecerat, cum se illa in.anum simularet — ut eorum cupientissime thalamis iungeremur. Et ideo hic Iunonem uiros nitidos effecisse subiunxit ut nuptiis, non adulterio, si hoc Venus efficeret, placuissent. </p>
             </div>
 
@@ -9533,11 +9534,11 @@
                <l>'huic uni forsan potui succumbere culpae'. </l>
             </div>
 
-            <div type="schol" n="456-457">
+            <div type="schol" n="456">
                <p> (ETSI) BLANDVS IASON / (VIRGINIBVS DARE VINCLA NOVIS) subaudimus 'erat'. <supplied>ordo: </supplied> Iason blandus dare uincla uirginibus nouis, id est: qui solitus sit mutare coniugia. Tum sese, postea Medeam, tertio Glaucen et uxorem habuit et dimisit. </p>
             </div>
 
-            <div type="schol" n="457-458">
+            <div type="schol" n="457">
                <p> (CRVENTVM) / PHASIN fluuius quem ideo <hi rend="italic">cruentum</hi> dicit quod per eum Medea patrem fugiens insequentem interempti fratris dicitur membra iactasse. Siue fluuius Scythiae Phasis est barbarorum caedibus cruentus assidue. COLCHI ciuitas gentis eiusdem, Medeae patria. ALIOS ... (GENERATIS) AMORES quia post Hypsipylen Medeam duxit uxorem. </p>
             </div>
 
@@ -9553,7 +9554,7 @@
                <p> (IAM PLENA) QVATER QVINQVENNIA (PERGVNT) uiginti annos ostendit ex quo ediderat ex Iasone filios. </p>
             </div>
 
-            <div type="schol" n="469-470">
+            <div type="schol" n="469">
                <p> (RATIS IPSA MORAM ...) / ODIT duram animauit nauem dicendo <hi rend="italic">moram odit</hi>, ut Vergilius colli oculos dedit dicendo:</p> 
                <l>'aduersasque aspectat desuper arces'.</l> 
                <p>Mirabilis illa locutio est, quotiens dura a poetis animantur. </p>
@@ -9571,21 +9572,21 @@
                <p> TIPHYS gubernator nauis Argo. (OCCIDVI) RVBVERE CVBILIA (PHOEBI) physici serenitatem futuram dicunt, si sole occidente nubes rubescant. </p>
             </div>
 
-            <div type="schol" n="479-480">
+            <div type="schol" n="479">
                <p> VIX RESERATA DIES (ET IAM RATE CELSVS IASON / IRE IVBET PRIMOQVE FERIT DVX VERBERE PONTVM) bene ostendit tota nocte Iasonem uigilasse, siquidem ortum Luciferi primus aspexit. </p>
             </div>
 
-            <div type="schol" n="484-485">
+            <div type="schol" n="484">
                <p> (LONGVMQVE POLO) CONTEXERE (VISA EST / AEQVOR ET EXTREMI PRESSIT FRETA MARGINE CAELI) <supplied>
                      <hi rend="italic">contexere</hi>
                   </supplied> aequare, quia longe prospicientibus mare uidetur caelo coniunctum. Sic enim lumina nostra falluntur ut putemus maris fluctus usque ad caeli marginem peruenire. </p>
             </div>
 
-            <div type="schol" n="486-488">
+            <div type="schol" n="486">
                <p> FAMA SVBIT (PORTVS VECTVM TRANS ALTA THOANTA / FRATERNA REGNARE CHIO MIHI CRIMINA NVLLA / ET VACVOS ARSISSE ROGOS) sensus: rumor allatus est Lemnum patrem meum Thoantem in Chio regnare nec mihi cum ceteris Lemniadibus scelus fuisse commune. </p>
             </div>
 
-            <div type="schol" n="491-492">
+            <div type="schol" n="491">
                <p> (SOLANE FIDA SVIS NOS AVTEM IN FVNERA LAETAE) / NON DEVS HAEC (FATVMQVE) uerba Lemniadum incusantium Hypsipylen, quod sola in patrem scelerata non fuerit. Et acute dictum. Iam, inquit, illa fecimus nec deorum nutu nec necessitate fatali. His enim defensionibus facinus excusatur. Ergo cum una est innocens, purgationem reliquae perdiderunt. </p>
             </div>
 
@@ -9593,7 +9594,7 @@
                <p> (SED NON ITERVM OBVIVS) EVHAN Liber pater, qui Thoanti patri suo fuerat, cum eiceretur, auxiliatus. </p>
             </div>
 
-            <div type="schol" n="&lt;499-500&gt;">
+            <div type="schol" n="499">
                <p> 
                   <supplied>TALIA LERNAEIS ITERAT DVM REGIBVS EXSVL / LEMNIAS</supplied> eleganter <hi rend="italic">iterat</hi>. Ante enim quam inciperet ab origine Lemniadum facta narrare dixit:</p> 
                <l>'seruitium Hypsipyle uestri fero capta Lycurgi'. </l>
@@ -9608,23 +9609,23 @@
                <p> IMMEMOR ABSENTIS (... ALVMNI) infantuli Opheltis, Lycurgi scilicet fluii, quem nutriendum a patre susceperat. SIC DI SVASISTIS interpositio. Id est: hoc diis placuit. ALVMNI non filii, sed qui alebatur. </p>
             </div>
 
-            <div type="schol" n="502-503">
+            <div type="schol" n="502">
                <p> COMANTI / ... HVMO herbosae. </p>
             </div>
 
-            <div type="schol" n="503-504">
+            <div type="schol" n="503">
                <p> FESSVSQVE DIV PVERILIBVS ACTIS / LABITVR IN SOMNOS PRENSA MANVS) HAERET (IN HERBA) <foreign xml:lang="grc">δεικτικῶς</foreign> expressit aetatem. Nam in actu<del>s</del> ludicro<del>s</del>, cum somno requiescit infantia, quicquid tenuerit non relinquit. </p>
             </div>
 
-            <div type="schol" n="505-506">
+            <div type="schol" n="505">
                <p> (INTEREA CAMPIS NEMORIS SACER HORROR ACHAEI) / TERRIGENA EXORITVR (SERPENS) exoritur de nemore. Et est ordo: interea sacer serpens terrigena exoritur nemoris Achaei horror. </p>
             </div>
 
-            <div type="schol" n="516-517">
+            <div type="schol" n="516">
                <p> (SAEPE SVPER FLVVIOS GEMINAE IACET) AGGERE RIPAE / (CONTINVVS) id est: utramque ripam longitudinis suae magnitudine tangebat. </p>
             </div>
 
-            <div type="schol" n="518-519">
+            <div type="schol" n="518">
                <p> OGYGII (IVSSIS QVANDO OMNIS ANHELAT / TERRA DEI) <supplied>
                      <hi rend="italic">Ogygii</hi>
                   </supplied> Thebani hoc est Liberi patris, ab uno de terrigenis, cuius uoluntate aruerunt cuncta flumina et amnes. NYMPHAE torrentes. </p>
@@ -9634,16 +9635,16 @@
                <p> INCERTVSQVE (SVI) id est de uita desperans uel quid agat ignarus aut quo tendat. </p>
             </div>
 
-            <div type="schol" n="529-530">
+            <div type="schol" n="529">
                <p> (QVANTVS AB ARCTOIS DISCRIMINAT) AETHERA PLAVSTRIS / (ANGVIS ET VSQVE NOTOS ALIENVMQVE EXIT IN ORBEM) Anguis illius meminit qui creditur locatus in caelo, per Aratum celebratus. Hunc describit diuidentem Plaustra a Cynosura usque in australem partem pertinere, hoc est <hi rend="italic">alienum ... in orbem</hi>. Poetice autem dicit stellarum figuram quibus Plaustrum efficitur, in utroque sidus accipiens. De quo Vergilius:</p> 
                <l>'maximus hic flexu sinuoso elabitur anguis'. </l>
             </div>
 
-            <div type="schol" n="531-533">
+            <div type="schol" n="531">
                <p> (QVANTVS ET ILLE SACRI SPIRIS INTORTA MOVEBAT / CORNVA PARNASSI DONEC TIBI DELIE FIXVS) / VEXIT HARVNDINEAM (CENTENO VOLNERE SILVAM) ex monte Parnasso Pythonem dicit serpentem, qui cum Latonam Ioue grauidam persequeretur Iunonis immissu et illa fugiens ad mare usque peruenisset, opportune Delos insula quae instabilis fluctibus uehebatur admota litoribus suscepit Latonam et ingenti periculo liberauit. Ibi Apollinem Dianamque edidit. Post Apollo in uindictam matris Pythonem sagittis occidit et Delon insulam stabilitate donauit. </p>
             </div>
 
-            <div type="schol" n="548-549">
+            <div type="schol" n="548">
                <p> (PRATA RECENTES) / AMISERE NOTAS ut etiam miserae ambiguitas nasceretur quia pratorum signa defecerant. Omnia enim perierant serpentis afflatu et distinctum floribus campum ariditas indiscreta confuderat. VIRIDI uenenoso. Horatius:</p> 
                <l>'nec uirides metuunt colubras'. </l>
             </div>
@@ -9681,7 +9682,7 @@
                <p> (SIVE DEIS) VTINAMQVE DEIS (CONCESSA VOLVPTAS) optat deos esse serpentem. Est enim contemptor numinum et quaerit inuenire facultatem calcandae religionis. </p>
             </div>
 
-            <div type="schol" n="569-570">
+            <div type="schol" n="569">
                <p> (NON SI CONSERTVM SVPER HAEC MIHI MEMBRA) GIGANTA / (SVBVEHERES) quia Gigantes serpentinis pedibus fuisse dicuntur, quos 'draconipedes' uocant. Ouidius in quinto Fastorum:</p> 
                <l>'mille manus illis dedit et pro cruribus angues'.</l>
             </div>
@@ -9690,11 +9691,11 @@
                <p> (ILLVM ET) COGNATAE (STAGNA INDIGNANTIA LERNAE) in eadem palude Lerna et nata dicitur et perempta. Ergo <hi rend="italic">cognatae</hi>. Siue quod aliquando Lerna similem habuerit pestem siue quia iste anguis uideatur ab Hydra morum originem ducere. </p>
             </div>
 
-            <div type="schol" n="581-582">
+            <div type="schol" n="581">
                <p> (LVCOSQVE PER OMNIS / SILVICOLAE FRACTA GEMVISTIS) HARVNDINE FAVNI canna et ferula coronantur Fauni. <del>Haec ornamenta sua</del> hos congemuisse mortuo serpente commemorat more lugentum. </p>
             </div>
 
-            <div type="schol" n="583-585">
+            <div type="schol" n="583">
                <p> (IPSE ETIAM E) SVMMA (IAM TELA) POPOSCERAT AETHRA / (IVPPITER ... / NI MINOR IRA DEO) <supplied>
                      <hi rend="italic">e summa ... aethra</hi>
                   </supplied> id est per splendorem aetheris. Vergilius:</p>
@@ -9705,7 +9706,7 @@
                <p>Ergo commotus Iuppiter Capanei uoce sacrilega iam poposcerat fulmina, nisi ira modestior sacrilegium distulisset. </p>
             </div>
 
-            <div type="schol" n="585-586">
+            <div type="schol" n="585">
                <p> NI MINOR IRA DEO (GRAVIORAQVE TELA MERERI / SERVATVS CAPANEVS) ideo hic Capaneus fulminatus non est quia fulminandus in bello est: quando Iouem ipsum est prouocaturus iniuriis, tunc merito interibit. Maiore enim poena pro immanitate culpae plectetur. Ideo <hi rend="italic">minor ira deo</hi>, quia iustius, cum plus peccauerit, punietur. </p>
             </div>
 
@@ -9717,7 +9718,7 @@
                <p> PERERRATIS participium passiuum posuit, cum ratio non admittat. </p>
             </div>
 
-            <div type="schol" n="589-591">
+            <div type="schol" n="589">
                <p> (MODICO SVPER AGGERE) LONGE / ... / (PROSPICIT) ipsa altitudo longitudinis magnum indicat spatium quo liber plus foret aspectus. </p>
             </div>
 
@@ -9733,7 +9734,7 @@
                <p> PIGER (... SERPENS) <foreign xml:lang="grc">πρὸς ἀντιδιαστολήν</foreign>. <hi rend="italic">Piger</hi>, quantum ad alites pertinet. </p>
             </div>
 
-            <div type="schol" n="620-622">
+            <div type="schol" n="620">
                <p> (O DVRA MEI) PRAESAGIA SOMNI / (NOCTVRNIQVE METVS ET NVNQVAM IMPVNE PER VMBRAS / ATTONITAE MIHI VISA VENVS) superius dixit:</p>
                <lg>
                   <l>'iam certa malorum</l>
@@ -9741,11 +9742,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="625-627">
+            <div type="schol" n="625">
                <p> (TANTANE ME TANTAE TENVERE OBLIVIA CVRAE / DVM PATRIOS CASVS FAMAEQVE EXORSA RETRACTO) / AMBITIOSA (MEAE) tanta illius fuit cupiditas quae tantam exstingueret religionem. </p>
             </div>
 
-            <div type="schol" n="631-632">
+            <div type="schol" n="631">
                <p> NE TRISTES DOMINOS (ORBAMQVE INIMICA REVISAM / EVRYDICEN) Lycurgum Eurydicenque significat, parentes Archemori. <hi rend="italic">Dominos</hi> uero secundum ius gentium dixit quod uicti uel capti seruilibus deputentur officiis. </p>
             </div>
 
@@ -9761,7 +9762,7 @@
                <p> AVERSO (... TONANTI) <hi rend="italic">auerso</hi> aduersanti. Dederat enim numen signa contraria. PROSECTA exta, cum redduntur inspecta. Verbo sacrificantum usus est. Particulae enim minutae membrorum omnium <hi rend="italic">prosecta</hi> dicuntur in sacris quae inferuntur aris. </p>
             </div>
 
-            <div type="schol" n="643-644">
+            <div type="schol" n="643">
                <p> (HIC SESE ARGOLICIS IMMVNEM) SERVAT AB ARMIS / (HAVD ANIMI VACVVS SED TEMPLA ARAEQVE TENEBANT) hic, inquit, ideo a Thebano se abstinet bello nec Polynici ferebat auxilium quia consulenti responsum fuerat Thebanum bellum ipsius sanguine imbuendum, quod tamen contigit morte filii. </p>
             </div>
 
@@ -9769,11 +9770,11 @@
                <p> PRIMA LYCVRGE (DABIS DIRCAEO FVNERA BELLO) hoc uersu tenor oraculi continetur. </p>
             </div>
 
-            <div type="schol" n="648-649">
+            <div type="schol" n="648">
                <p> (ET MAESTVS VICINI PVLVERE MARTIS / ANGITVR AD LITVOS PERITVRISQVE) INVIDET ARMIS quod non iret ad bellum. </p>
             </div>
 
-            <div type="schol" n="&lt;650&gt;">
+            <div type="schol" n="650">
                <p> 
                   <supplied>FIDES SVPERVM</supplied> hoc est, quod superius ait: 'nosco deos'. THOANTIS Hypsipyle. <foreign xml:lang="grc">πατρονυμικόν</foreign> a Thoante patre. <del>Accentus in fine est.</del>
                </p>
@@ -9816,37 +9817,37 @@
                <p> INGRATIS non sentientibus beneficia aut praestiti minime gratiam relaturis. </p>
             </div>
 
-            <div type="schol" n="675-676">
+            <div type="schol" n="675">
                <p> (GENITORQVE THOAS ET LVCIDVS EVHAN) / STIRPIS AVVS Hypsipylae dicit Liberum patrem propter Thoantem auum fuisse. </p>
             </div>
 
-            <div type="schol" n="681">
+            <div type="schol" n="681a">
                <p> THEBES singulariter dixit. </p>
             </div>
 
-            <div type="schol" n="681-682">
+            <div type="schol" n="681b">
                <p> (EQVIDEM NON VOS AD MOENIA THEBES / REBAR) ET HOSTILES (HVC ADVENISSE CATERVAS) <del>subaudis:</del> non rebar huc uos hostiliter aduenisse. </p>
             </div>
 
-            <div type="schol" n="683-684">
+            <div type="schol" n="683">
                <p> (PERGITE) IN EXCIDIVM (SOCII SI TANTA VOLVPTAS / SANGVINIS) <supplied>
                      <hi rend="italic">excidium</hi>
                   </supplied> meum scilicet et <hi rend="italic">socium</hi>, regni communis. </p>
             </div>
 
-            <div type="schol" n="684">
+            <div type="schol" n="684a">
                <p> (IMBVITE) ARMA DOMI id est domestica caede. Subaudis: mea morte. </p>
             </div>
 
-            <div type="schol" n="684-685">
+            <div type="schol" n="684b">
                <p> (HAEC INRITA DVDVM) / TEMPLA IOVIS quae coluntur frustra aut nihil praestant. QVID ENIM HAVD LICITVM subaudis: feceram, si uilis ancillae morte luctus meos ultus fuissem.</p>
             </div>
 
-            <div type="schol" n="685-687">
+            <div type="schol" n="685">
                <p> (TEMPLA IOVIS ... FERAT) IMPIVS IGNIS / (SI VILEM... / IN FAMVLAM IVS ESSE RATVS DOMINOQVE DVCIQVE) incendite templa, quia parum est, si famulorum ius domini perdiderunt. </p>
             </div>
 
-            <div type="schol" n="688-689">
+            <div type="schol" n="688">
                <p> (SED VIDET HAEC VIDET ILLE DEVM REGNATOR ET AVSIS) / SERA QVIDEM (MANET IRA TAMEN) Tibullus:</p>
                <lg>
                   <l>'a miser, et si quis primo periuria celat,</l>
@@ -9854,7 +9855,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691">
                <p> (VOLVRES EQVITVM) PRAEVERTERAT ALAS / (FAMA RECENS) nuntiatum Argiuis fuerat Hypsipylen ad supplicium trahi. </p>
             </div>
 
@@ -9866,11 +9867,11 @@
                <p> VERSVSQVE DOLOR (DAT TERGA TIMORI) timore belli in metum uersus dolor mortis Archemori. </p>
             </div>
 
-            <div type="schol" n="699-701">
+            <div type="schol" n="699">
                <p> (SVBLIMIS ADRASTVS / SECVM) ANTE ORA VIRVM (FREMIBVNDA THOANTIDA PORTANS / IT MEDIVS TVRMIS) secum Hypsipylen ferebat, impetum furentis exercitus Adrastus cupiens refrenare, qui eam putabant interemptam fuisse. </p>
             </div>
 
-            <div type="schol" n="704-707">
+            <div type="schol" n="704">
                <p> SIC VBI (DIVERSIS MARIA EVERTERE PROCELLIS / HINC BOREAS EVRVSQVE ILLINC NIGER IMBRIBVS AVSTER / ... VENIT AEQVORIS ALTI / REX SVBLIMIS EQVIS) Vergiliana comparatio est, sed contrarie. Nam ille ad Neptuni comparationem uirum bonum posuit, hic <supplied>ad</supplied> Adrasti Neptunum. <del>VENIT AEQVORIS ALTI</del> ordo: sic uenit rex aequoris ubi maria diuersis procellis euertere uenti. </p>
             </div>
 
@@ -9887,15 +9888,15 @@
                <l>'sic cunctus pelagi cecidit fragor'. </l>
             </div>
 
-            <div type="schol" n="710-712">
+            <div type="schol" n="710">
                <p> (QVIS SVPERVM TANTO SOLATVS FVNERA VOTO / PENSAVIT LACRIMAS INOPINAQVE GAVDIA MAESTAE / RETTVLIT HYPSIPYLAE TV GENTIS CONDITOR) EVHAN inuenit poeta, quod primum dubitabat. EVHAN Liber, a quo Hypsipyle originem ducit. </p>
             </div>
 
-            <div type="schol" n="713-716">
+            <div type="schol" n="713">
                <p> QVI GEMINOS (IVVENES LEMNI DE LITORE VECTOS / INTVLERAS NEMEAE MIRANDAQVE FATA PARABAS / CAVSA VIAE GENETRIX NEC INHOSPITA TERGA LYCVRGI / PRAEBVERANT ADITVS) tunc enim Hypsipylen matrem quaerentes illuc deuenerant, a quibus cognita est. Hi tunc hospitio a Lycurgo suscepti. MIRANDAQVE FATA quae cogant Hypsipylen de seruitio ad regnum redire. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718">
                <p> PRO SORS (ET CAECA FVTVRI / MENS HOMINVM) eleganter more comoediae contigit agnitio filiorum. </p>
             </div>
 
@@ -9915,20 +9916,20 @@
                </p>
             </div>
 
-            <div type="schol" n="729-730">
+            <div type="schol" n="729">
                <p> (ADDITA) SIGNA POLO (LAETOQVE VLVLANTE TVMVLTV / TERGAQVE ET AERA DEI MOTAS CREPVERE PER AVRAS) datum signum est caelo uelut barritus. Liber dedit sonitum tympanorum. </p>
             </div>
 
-            <div type="schol" n="738-739">
+            <div type="schol" n="738">
                <p> ET PVER (HEV NOSTRI SIGNATVS NOMINE FATI / ARCHEMORVS) Lycurgi filius, qui primo Opheltes dicebatur, sed, quoniam initia Thebani belli eius initiata sunt morte, iure fatali postea Archemorus nominatus est Graeca pronuntiatione sermonis. <foreign xml:lang="grc">ἀρχή</foreign> enim Graece 'principium' dicitur, <foreign xml:lang="grc">μόρος</foreign> 'mors' sermone eodem nuncupatur. </p>
             </div>
 
-            <div type="schol" n="743-744">
+            <div type="schol" n="743">
                <p> (ATQVE VTINAM PLVRES INNECTERE PERGAS) / PHOEBE MORAS sciebat enim aduersa denuntiata, ne pugnarent. Ideo <hi rend="italic">
                      <supplied>in</supplied>necte<supplied>re</supplied> ... moras</hi>.</p>
             </div>
 
-            <div type="schol" n="748-749">
+            <div type="schol" n="748">
                <p> DVM LERNAEA PALVS (ET DVM PATER INACHVS IBIT / DVM NEMEA TREMVLAS CAMPIS IACVLABITVR VMBRAS) Vergilius:</p>
                <lg>
                   <l>'in freta dum fluuii current, <supplied>dum montibus umbrae</supplied>
@@ -9938,7 +9939,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="751-752">
+            <div type="schol" n="751">
                <p> PYLIAE NEC FATA SENECTAE / (MALVERIT PHRYGIIS AVT DEGERE LONGIVS ANNIS) <hi rend="italic">Pyliam ... senectam</hi> annos Nestoris dicit. <hi rend="italic">Phrygios</hi> autem <hi rend="italic">annos</hi> Priami dixit, quem bis excidium Troiae uidisse certissimum est. Vt Vergilius:</p>
                <lg>
                   <l>'satis una superque</l>
@@ -9954,27 +9955,27 @@
 
          </div>
 
-         <div type="lib" n="VI">
+         <div type="lib" n="6">
             <head>LIBER VI</head>
 
             <div type="pr" n="pr">
                <p>Sextus liber continet agonis causa per totam Graeciam famam futuri certaminis cucurrisse. Secuntur exsequiae Archemori. Descriptio planctus Eurydices matris et patris Lycurgi. Descriptio una Archemori, altera expiationis. Descriptio circensium cum omnium ducum nominibus et equorum et ipsius certaminis uarietate uel euentu, in quo docetur Apollinis fauore Amphiarao concessam esse uictoriam. Currentium puerorum descriptio, in quo certamine uincit Parthenopaeus. Discobole, in quo certamine uincit Hippomedon. Deinde pugiles, in quo certamine Capaneus uincit Alcidamam. Deinde luctatio, in quo certamine uincit Tydeus Agyllea<del>m</del>. Prohibitio monomachiae Agrei et Polynicis. Adrasti regis sagittae iactus cum prodigio teli ad dominum reuertentis. </p>
             </div>
 
-            <div type="schol" n="1-3">
+            <div type="schol" n="1">
                <p> (NVNTIA MVLTIVAGO DANAAS PERLABITVR VRBES / FAMA GRADV) SANCIRE NOVO SOLLEMNIA BVSTO / (INACHIDAS LVDVMQVE SVPER) agon Archemori apii corona celebratur idcirco quia puer hic cuius memoriae certamen Nemeaeum dicatum est admodum paruus obierat. Ex hoc creditum est hoc coronae genus indicium immaturae mortis electum nam humilis herba immaturi luctus ostendit indicium. Quidam super hanc herbam puerum reptantem a nutrice derelictum et serpente interemptum uolunt. Nam in hoc agone etiam poetae certantes apio coronatur. Vnde Vergilius:</p> 
                <l>'floribus atque apio crinis ornatus amaro'. </l>
             </div>
 
-            <div type="schol" n="5-7">
+            <div type="schol" n="5">
                <p> (PRIMVS PISAEA PER ARVA) / HVNC PIVS ALCIDES (PELOPI CERTAVIT HONOREM / PVLVEREVMQVE FERA CRINEM DETERSIT OLIVA) primus Hercules hunc honorem manibus Pelopis exhibuit, qui<del>a</del> erat Herculi per Alcmenam genere coniunctus hoc ordine: Pelopis et Hippodamiae Lysidice filia, Lysidices Alcmena, Iouis et Alcmenae Hercules. Prima ergo certaminum genera haec fuerunt, quae per ordinem hoc loco poeta descripsit: Olympia in honorem Pelopis, cuius uictores oleastro coronantur; Pythia in honorem Apollinis, cuius uictores lauro coronantur; Isthmia in honorem Palaemonis, cuius uictores pinu coronantur; Nemea in honorem Archemori, cuius uictores apio coronantur. <hi rend="italic">Pium</hi> autem dixit, quia hoc Hercules Pelopi in honorem consanguinitatis exhibuit. (PELOPI) CERTAVIT HONOREM in honorem ipsius consecrauit. FERA ... OLIVA pro oleastro, quia uictores ipsius certaminis hac fronde coronantur. Possumus et <hi rend="italic">feram</hi> pro 'feraci' intellegere. </p>
             </div>
 
-            <div type="schol" n="8-9">
+            <div type="schol" n="8">
                <p> (PROXIMA) VIPEREO (CELEBRAVIT) LIBERA NEXV / (PHOCIS APOLLINEAE BELLVM PVERILE PHARETRAE) Pythone enim interfecto Achaei agonem Apollini instituerunt, quem 'Pythicum' nominauerunt. </p>
             </div>
 
-            <div type="schol" n="&lt;13-14&gt;">
+            <div type="schol" n="13">
                <p> 
                   <supplied>PLANCTV CONCLAMAT VTERQVE / ISTHMOS</supplied> sic uocantur Isthmia. Celebrantur apud Corinthum in honorem Palaemonis et Leucotheae, marinorum deorum. ISTHMOS terra in longum porrecta quae Ionium ab Aegaeo diuidit. Ouidius:</p>
                <lg>
@@ -9983,11 +9984,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="15-16">
+            <div type="schol" n="15">
                <p> (EXIMII REGVM QVIBVS ARGOS ALVMNIS) / CONEXVM CAELO genus, id est qui originem ducunt propter illam opinionem qu<del>i</del>a dicuntur dii terrenis feminis mixti liberos procreasse. Disputatio est quae dicit bonorum hominum animas ac uirorum fortium a diis sumpsisse principium. </p>
             </div>
 
-            <div type="schol" n="16-17">
+            <div type="schol" n="16">
                <p> (QVORVMQVE INGENTIA TELLVS) / AONIS (ET TYRIAE SVSPIRANT NOMINA MATRES) <supplied>
                      <hi rend="italic">tellus Aonis</hi>
                   </supplied> Boeotiam dixit, quia ah his uastabitur. TYRIAE <del>SVSPIRANT NOMINA</del> MATRES Thebanas significat a Cadmo Tyrio conditore. <hi rend="italic">Suspirant</hi> autem <hi rend="italic">nomina</hi> quia uirtute Graecorum orbabuntur maritis amissis aut liberis. </p>
@@ -10008,15 +10009,15 @@
                <l>'cum sese exsiccat somno Romana iuuentus'. </l>
             </div>
 
-            <div type="schol" n="30-31">
+            <div type="schol" n="30">
                <p> EXVTVS HONORO / (VITTARVM) NEXV lugubriter indutus. </p>
             </div>
 
-            <div type="schol" n="37">
+            <div type="schol" n="37a">
                <p> ARCET ET IPSE PATER pensanda est in matre doloris acerbitas, cum et pater prohibeat luctum. </p>
             </div>
 
-            <div type="schol" n="37-43">
+            <div type="schol" n="37b">
                <p> (MOX VT MAERENTIA) DIGNIS / VVLTIBVS (INACHII PENETRARVNT LIMINA REGES / ... ACCENSAE CLAMORE FORES) <hi rend="italic">dignis</hi> dixit pro aptis temporibus ac per hoc lacrimantibus. <del>39 CEV NOVA TVNC CLADES</del> lacrimas orbitatis ingredientium Argiuorum <supplied>dicit</supplied> renouare solacia. <del>Naturale enim est ut intermissa lamenta repetantur, cum aliquis notus aduenerit.</del> Vergilius:</p>
                <lg>
                   <l>'ut uero Aeneas tectis sese extulit altis,</l>
@@ -10026,7 +10027,7 @@
                <p>RESVLTANT / (ACCENSAE CLAMORE FORES) ictae clamore aedes resiliunt. </p>
             </div>
 
-            <div type="schol" n="43-44">
+            <div type="schol" n="43">
                <p> SENSERE PELASGI / (INVIDIAM) id est: agnouerunt Argiui lamentationis augmento sibi imputari causam mortis Archemori. </p>
             </div>
 
@@ -10034,7 +10035,7 @@
                <p> ET LACRIMIS EXCVSANT (CRIMEN OBORTIS) flendo ostendunt interitum Archemori non sua culpa, sed Fatorum ordine prouenisse. </p>
             </div>
 
-            <div type="schol" n="45-46">
+            <div type="schol" n="45">
                <p> DATVM QVOTIENS (INTERCISOQVE TVMVLTV / CONTICVIT STVPEFACTA DOMVS) id est: quotiens ei flentum stupore permissum est. </p>
             </div>
 
@@ -10046,7 +10047,7 @@
                <p> TRISTIBVS <del>INTEREA</del> RAMIS non ramis tristibus, sed ipsis tristibus qui pyram frondibus intexebant. </p>
             </div>
 
-            <div type="schol" n="[55]">
+            <div type="schol" n="55">
                <p> 
                   <del>FERETRVM Graece <foreign xml:lang="grc">φέρτρον</foreign>, unde per diaeresin <hi rend="italic">feretrum</hi> fecit. Nam Latine 'capulus' dicitur ab eo quod corpus capiat. Vnde Plautus:</del>
                </p> 
@@ -10066,7 +10067,7 @@
                <p> ARABVM STRVE odoribus Arabicis. </p>
             </div>
 
-            <div type="schol" n="&lt;60-61&gt;">
+            <div type="schol" n="60">
                <p> 
                   <supplied>EOAS COMPLEXVS OPES INCANAQVE GLEBIS / TVRA ET AB ANTIQVO DVRANTIA CINNAMA BELLO</supplied> compositus recenti ture et cinnamo, ut ostenderet eum poeta orientales gentes uicisse. INCANA non longa aetate corrupta. AB ANTIQVO (DVRANTIA CINNAMA BELLO) ueteris belli praedam istis ostentat odoribus. Liber enim deuicta India hoc unguenti genus gentibus dedit. Et bene dixit <hi rend="italic">durantia</hi>. Constat enim cinnama <supplied>non</supplied> fugere, uel ad illud magis dixisse uideatur quod cinnamum odorem suum longo tempore non amittit. Vnde Lucanus:</p>
                <lg>
@@ -10084,11 +10085,11 @@
                <p> MOLLE SVPERCILIVM <hi rend="italic">supercilium</hi> pro 'fastigio' posuit. </p>
             </div>
 
-            <div type="schol" n="64-66">
+            <div type="schol" n="64">
                <p> MEDIO LINVS INTERTEXTVS ACANTHO / (LETIFERIQVE CANES OPVS ADMIRABILE SEMPER / ODERAT ATQVE OCVLOS FLECTEBAT AB OMINE MATER) hanc historiam in primo libro Adrasto narrante cognouimus: Linum, filium Apollinis et Psamathes, Crotopi filiae, expositum a matre a canibus fuisse discerptum. Haec ergo fabula, cum arte esset intertexta, odiosa erat matri quia miserationem paruuli commouebat. Pari enim modo etiam Archemori mors uidebatur illata. </p>
             </div>
 
-            <div type="schol" n="67-68">
+            <div type="schol" n="67">
                <p> (ARMA ETIAM ET VETERVM EXVVIAS CIRCVMDAT AVORVM) / GLORIA MIXTA (MALIS ADFLICTAEQVE AMBITVS AVLAE) quoniam maiorum ornamenta funeri adhibebantur. </p>
             </div>
 
@@ -10101,18 +10102,18 @@
                <l>'tibi quam noctes festina diesque'. </l>
             </div>
 
-            <div type="schol" n="84-87">
+            <div type="schol" n="84">
                <p> (PARTE ALIA) GNARI MONITIS (EXERCITVS INSTAT / AVGVRIS AERIAM ... / ... CVMVLARE PYRAM QVAE CRIMINA CAESI / ANGVIS ET INFAVSTI CREMET ATRA PIACVLA BELLI) <hi rend="italic">
                      <supplied>gnari</supplied> ... auguris</hi> conscii praeceptorum. Pater pyram filio faciebat, sacerdos serpenti, quia fuisse Martis filius credebatur. </p>
             </div>
 
-            <div type="schol" n="94-96">
+            <div type="schol" n="94">
                <p> (NEC SOLOS HOMINVM TRANSGRESSA VETERNO / FERTVR AVOS) NYMPHAS (ETIAM MVTASSE SVPERSTES / FAVNORVMQVE GREGES) <supplied>
                      <hi rend="italic">Fauni et</hi>
                   </supplied> Nymphae diu uiuunt et tandem moriuntur. Istam autem siluam dicit illis antiquiorem fuisse et post mortem illorum incolumem ob honorem numinis perdurasse. <hi rend="italic">Veterno</hi> autem dixit ad ostentationem aetatis antiquae. </p>
             </div>
 
-            <div type="schol" n="98-106">
+            <div type="schol" n="98">
                <p> (CADIT ARDVA FAGVS / CHAONIVMQVE NEMVS BRVMAEQVE) ILLAESA CVPRESSVS / (PROCVMBVNT ... VLMVS) <supplied>
                      <hi rend="italic">brumaeque illaesa cupressus</hi>
                   </supplied> quae nunquam exuitur honore foliorum. <del>CHAONIVMQVE NEMVS</del> Ouidius hanc enumerationem arborum epithetis suis decimo libro monstrauit:</p>
@@ -10150,7 +10151,7 @@
                <p> (SILVANVSQVE) ARBITER VMBRAE id est dom<supplied>in</supplied>us nemorum. </p>
             </div>
 
-            <div type="schol" n="112-113">
+            <div type="schol" n="112">
                <p> SEMIDEVMQVE PECVS (MIGRANTIBVS ADGEMIT ILLIS / SILVA NEC AMPLEXAE DIMITTVNT ROBORA NYMPHAE) <supplied>
                      <hi rend="italic">semideumque pecus</hi>
                   </supplied> Panes. Tetigit hanc opinionem ut diceret Nymphas et Faunos esse mortales. Vt Vergilius Turnum, a Venilia Nympha natum, ab Aenea demonstrat occisum, cum ipsius auctor sanguinis immortalis esset. Sunt qui dicunt illam auram numinis quae fontibus arboribusque deuincta est casu aut aquae siccatae aut excisae arboris ilico emori. Sed<del>es</del> absurdum est ut numen emoriatur, neque enim res in aliquo potest casu accidere, cum omnia uisibilia et quae incorporata sunt <unclear>multis uisa</unclear> mori opinentur. <del>Ceterum</del> succisa arbore aut siccato fonte ille spiritus qui societate <del>illius</del> tenebatur naturae astrictus fugit inuitus, <unclear>interdum</unclear> aufertur ratione diuina. Ceterum nec ipsis corporibus contingit interitus. Soluta enim figura ad naturam suam recidunt. Vnde et Vergilius:</p>
@@ -10170,7 +10171,7 @@
                <p> IMMODICI MINOR ILLE FRAGOR (QVO BELLA GEREBANT) ille fragor immodici tumultus non erat minor eo tumultu quo gesturi erant bella. Id est: maiore clamore diripiunt urbem, quam ante pugnauerant. </p>
             </div>
 
-            <div type="schol" n="118-119">
+            <div type="schol" n="118">
                <p> IAMQVE PARI CVMVLO (GEMINAS HANC TRISTIBVS VMBRIS / AST ILLAM SVPERIS AEQVVS LABOR AVXERAT ARAS) <supplied>
                      <hi rend="italic">pari cumulo</hi>
                   </supplied> similibus pyris: una pro filio Lycurgus, altera Amphiaraus pro serpente. </p>
@@ -10186,22 +10187,22 @@
                </lg>
             </div>
 
-            <div type="schol" n="122-124">
+            <div type="schol" n="122">
                <p> LEGE PHRYGVM MAESTA (PELOPEM MONSTRASSE FEREBANT / EXSEQVIALE SACRVM CARMENQVE MINORIBVS VMBRIS / VTILE) est enim in musicis modus Phrygius, quem dicit poeta ad euocationem animae conuenire. Quem Pelopem Phrygium Argis asserit tradidisse. Ita et Homerus. Ne autem esset quaestio unde hoc Argiui nouerint subdidit facultatem ut Pelops Phrygius docuerit. </p>
             </div>
 
-            <div type="schol" n="124-125">
+            <div type="schol" n="124">
                <p> QVO GEMINIS (NIOBE CONSVMPTA) PHARETRIS / (SQVALIDA BISSENAS SIPYLON DEDVXERAT VRNAS) <hi rend="italic">geminis</hi> id est Apollinis et Dianae. Niobe secundum Homerum duodecim filios habuit, Sophocles autem dicit eam quattuordecim habuisse. Amborum opiniones secutus poeta diuersis locis utrumque taxauit. In hoc loco ait:</p> 
                <l>'bina per ingentes stipabant funera portas'.</l> 
                <p>Est autem ordo: quo carmine Niobe squalida bis senas Sipylon deduxerat urnas. Quia occisis liberis apud Thebas ad patriam Sipylon funera cuncta deduxerat. <hi rend="italic">Sipylon</hi> uero mons est, in quo Niobe in saxum dicitur immutata. </p>
             </div>
 
-            <div type="schol" n="&lt;128-130&gt;">
+            <div type="schol" n="128">
                <p> 
                   <supplied>LONGO POST TEMPORE SVRGIT / COLLA SVPER IVVENVM NVMERO DVX LEGARAT OMNI / IPSE FERO CLAMORE TORVS</supplied> hyperbaton. Sed ordo eius talis est: longo post tempore surgit colla super iuuenum torus, quos iuuenes ipse dux legerat. <supplied>NVMERO DVX LEGARAT OMNI</supplied> hoc est minatus ne triste uitarent officium. </p>
             </div>
 
-            <div type="schol" n="139-140">
+            <div type="schol" n="139">
                <p> (NEC TALIA DEMENS) / FINGEBAM VOTIS ANNORVM (ELEMENTA TVORVM) <hi rend="italic">elementa</hi> pro 'initiis' posuit. Omnia enim rerum humanarum initia <hi rend="italic">elementa</hi> sunt dicta. </p>
             </div>
 
@@ -10209,11 +10210,11 @@
                <p> QVIDNI EGO deest: occidi filium quem neglegenti commisi. Nam dolori interrupta uox conuenit. (NARRABAT) SERVATVM FRAVDE PARENTEM illi ego paruulum crederem quae a se patrem seruatum fuisse iactabat? </p>
             </div>
 
-            <div type="schol" n="150-151">
+            <div type="schol" n="150">
                <p> (FERALE ...) / ABIVRASSE SACRVM id est facinus exsecrandum, aut quia sacramentum fuit inter Lemniadas. ABIVRASSE a suo animo abdicasse. </p>
             </div>
 
-            <div type="schol" n="152-155">
+            <div type="schol" n="152">
                <p> HAEC ILLA EST (CREDITIS AVSAE / HAEC PIETATE POTENS SOLIS ABIECIT IN ARVIS / NON REGEM DOMINVMVE ALIENOS IMPIA PARTVS / HOC TANTVM) demonstratiue. Id est: quae fuerit <hi rend="italic">ausa <supplied>
                         <gap/>
                      </supplied> dominum</hi> proicere, linquere. NON REGEM (DOMINVMVE) pro concessione. ALIENOS (IMPIA PARTVS) deest 'sed'. </p>
@@ -10225,16 +10226,16 @@
                <p>TRAMITE <hi rend="italic">trames</hi> est uia transuersa. Ergo in periculosae siluae uia filium dimisit expositum. Proprie tamen <hi rend="italic">trames</hi> est uia priuata, non publica, id est quae paucis cognita unumquemque ad agrum proprium ducit. Sallustius: 'per tramites occultos exercitum Metelli anteuenit'. </p>
             </div>
 
-            <div type="schol" n="&lt;164-165&gt;">
+            <div type="schol" n="164">
                <p> 
                   <supplied>ILLA TVOS QVESTVS LACRIMOSOSQVE IMPIA RISVS / AVDIIT</supplied> Hypsipylen dicit laetitiae blandimenta sensisse de luctu. </p>
             </div>
 
-            <div type="schol" n="171-172">
+            <div type="schol" n="171">
                <p> (QVAESO DVCES PER EGO HAEC) PRIMORDIA (BELLI / CVI PEPERI) oro uos per primordia belli. Per mortem filii Argiuos adiurat cuius obitu Thebanum ueluti sacro aliquo initiatum est bellum. </p>
             </div>
 
-            <div type="schol" n="186-190">
+            <div type="schol" n="186">
                <p> (NON SECVS ... / ... / ... / NVNC VALLEM SPOLIATA PARENS) NVNC FLVMINA (QVESTV / NVNC ARMENTA MOVET) ordo: non secus spoliata parens nunc uallem, nunc questu flumina, nunc armenta mouet. </p>
             </div>
 
@@ -10246,16 +10247,16 @@
                <p> CVLTVSQVE T(ONANTIS) infulas dicit quibus ornatus incesserat quia Iouis erat sacerdos. </p>
             </div>
 
-            <div type="schol" n="194-196">
+            <div type="schol" n="194">
                <p> (TERGOQVE ET PECTORE FVSAM) / CAESARIEM (FERRO MINVIT SECTISQVE IACENTIS / OBNVBIT TENVIA ORA COMIS) nouo sermone <hi rend="italic">caesariem</hi> posuit pro 'barba'. Supra uultum filii sui et comam misit et barbam. Datur enim sacerdoti<del>bus</del> dolor immensus. </p>
             </div>
 
-            <div type="schol" n="197-198">
+            <div type="schol" n="197">
                <p> ALIO TIBI (PERFIDE PACTO / IVPPITER HVNC CRINEM VOTI REVS ANTE DICARAM) ut Vergilius:</p> 
                <l>'quem non incusaui amens hominumque deumque'. </l>
             </div>
 
-            <div type="schol" n="199-200">
+            <div type="schol" n="199">
                <p> (SI PARITER VIRIDES NATI) LIBARE D(EDISSES) / (AD TVA TEMPLA GENAS) libatio duabus rebus expeditur: lacte et sanguine. Vnde Vergilius:</p> 
                <l>'duo lacte nouo, duo sanguine sacro',</l> 
                <p>quod alterum eorum alimonium sit uitae retinendae, alterum uirium continendarum, quia uita hominum his rebus iuuatur, eaque propterea sepulturae commendari solent, ut <unclear>societate parta curationis lucis amissae posteritas defectionis honoretur</unclear>. Vnde et flores sparguntur in honorem mortuorum infantum. Vnde Vergilius:</p> 
@@ -10280,15 +10281,15 @@
                <l>'crocumque rubentem' masculino genere dixit poetice. </l>
             </div>
 
-            <div type="schol" n="211-212">
+            <div type="schol" n="211">
                <p> ET ATRI / SANGVINIS (ET RAPTI GRATISSIMA CYMBIA LACTIS) duas res mittit: unam quae nutrit animam, id est lac, alteram qua constat, id est sanguis. Nec mirandum quod sanguinem ad inferos placandos intulerit. Nam sanguis proprie uidetur animae esse possessio, unde 'exsangues' mortuos dicimus. CYMBIA pocula nauibus similia, ut et ipsa nominis figura indicat diminutiue a 'cumba' dicta. </p>
             </div>
 
-            <div type="schol" n="213-214">
+            <div type="schol" n="213">
                <p> TVM SEPTEM N(VMERO) T(VRMAS) (CENTENVS VBIQVE / SVRGIT EQVES VERSIS DVCVNT INSIGNIBVS) ordo: tum septem numero turmas uersis ducunt insignibus. SVRGIT EQVES id est equis sedentes. <supplied>VERSIS ... INSIGNIBVS</supplied> reuersis peditibus. </p>
             </div>
 
-            <div type="schol" n="215-216">
+            <div type="schol" n="215">
                <p> (LVSTRANTQVE EX MORE) SINISTRO / (ORBE ROGVM) quia nihil dextrum mortuis conuenit. <del>Vt funeribus absoluantur, dextro orbe redeunt milites ut resoluantur. Hoc ideo finxit, ne exsequiis implicentur, ut dextro orbe redeant.</del>
                </p>
             </div>
@@ -10303,19 +10304,19 @@
                   </supplied> nunc percussionem manuum significat. <hi rend="italic">Planctus</hi> etenim dicitur omnis collisio. Varronis opinio est ideo mulieres solitas in luctu ora lacerare ut sanguine ostenso inferis satisfiat. </p>
             </div>
 
-            <div type="schol" n="221-223">
+            <div type="schol" n="221">
                <p> (HIC LVCTVS ABOLERE NOVIQVE / FVNERIS AVSPICIVM VATES) QVAMQVAM O(MINA) (SENTIT / VERA IVBET) id est: quamuis nouerat calamitatem imminere immutabilem, tamen <supplied>
                      <gap/>
                   </supplied>
                </p>
             </div>
 
-            <div type="schol" n="&lt;223-224&gt;">
+            <div type="schol" n="223">
                <p> 
                   <supplied>DEXTRI GYRO ... / HAC REDEVNT</supplied> dextro orbe redeunt milites ut exsoluant se ne exsequiis implicentur. </p>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224">
                <p> RAPTVMQVE SVIS LIBAMEN AB ARMIS / (QVISQVE IACIT) unusquisque Amphiarai iussu quodcumque ex armis raptum in ignem iaciebant ut inde expiatio fieret occisi serpentis. </p>
             </div>
 
@@ -10323,11 +10324,11 @@
                <p> PVTRES molles. </p>
             </div>
 
-            <div type="schol" n="235-236">
+            <div type="schol" n="235">
                <p> MVLTOQVE SOPORANT / (IMBRE ROGVM) id est: aqua exstinguunt. </p>
             </div>
 
-            <div type="schol" n="239-241">
+            <div type="schol" n="239">
                <p> LVCIFER (ET TOTIDEM LVNAE PRAEVENERAT IGNES / MVTATO NOCTVRNVS EQVO NEC CONSCIA FALLIT / SIDERA ET ALTERNO DEPRENDITVR VNVS IN ORTV) <supplied>
                      <hi rend="italic">Lucifer</hi>
                   </supplied> et mane oritur et uespere, sed <hi rend="italic">equo mutato</hi>. Quam rem sciunt sidera, quod unum astrum sit, nec falluntur sicut mortales, qui putant duos esse. Poetae autem quadrigas dant Soli, bigas Lunae, equos singulos sideribus. Eundem ergo Vesperum uult haberi. Vt Horatius Vesperum pro Lucifero posuit:</p>
@@ -10338,7 +10339,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="247-248">
+            <div type="schol" n="247">
                <p> EXSPECTES (MORIENTIS AB ORE CRVENTA / SIBILA MARMOREA SIC VOLVITVR ANGVIS IN HASTA) laus operis. </p>
             </div>
 
@@ -10347,7 +10348,7 @@
                <l>'it comes Ino<supplied>a</supplied>s Ephyren solata querelas'</l>
             </div>
 
-            <div type="schol" n="255-256">
+            <div type="schol" n="255">
                <p> COLLIBVS INCVRVIS (VIRIDIQVE OBSESSA CORONA / VALLIS IN AMPLEXV NEMORVM SEDET) locum spectaculi describit. </p>
             </div>
 
@@ -10355,7 +10356,7 @@
                <p> ILLIC CONFERTI id est in cohortem densati. </p>
             </div>
 
-            <div type="schol" n="268-269">
+            <div type="schol" n="268">
                <p> (EXIN MAGNANIMVM) SERIES ANTIQVA P(ARENTVM) / (INVEHITVR) maiorum imagines proferri significat uel<supplied>ut</supplied> ad miraculum spectantium, quia moris fuit ut in funere praeferrentur. Vt Horatius:</p>
                <lg>
                   <l>'funus atque imagines</l>
@@ -10373,7 +10374,7 @@
                   <del>IVPPITER ATQVE</del> H(OSPES) (IAM TVNC AVRORA COLEBAT) hoc est: hi qui in oriente sunt. Colitur autem et in Aegypto, ubi etiam Isis uocatur. Simul notandum quod communis generis declinauit <hi rend="italic">hospes</hi>, cum legerimus: 'bellum, o terra hospita, portas'. </p>
             </div>
 
-            <div type="schol" n="&lt;280-282&gt;">
+            <div type="schol" n="280">
                <p> 
                   <supplied>TANTALVS INDE PARENS ... / ... / PIVS ET MAGNI VEHITVR CONVIVA TONANTIS</supplied> hoc est regali habitu et in meliore fortuna. Id est: qualis fuerat antequam deos offenderet. </p>
             </div>
@@ -10383,7 +10384,7 @@
                <l>'pomaque et Alcinoi siluae'. </l>
             </div>
 
-            <div type="schol" n="283-285">
+            <div type="schol" n="283">
                <p> (VICTOR CVRRV) NEPTVNIA TENDIT / (LORA PELOPS PRENSATQVE ROTAS AVRIGA NATANTES / MYRTILOS ET VOLVCRI IAM IAMQVE RELINQVITVR AXE) <del>Vergilius:</del>
                </p> 
                <l>
@@ -10413,7 +10414,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="287-288">
+            <div type="schol" n="287">
                <p> (ET IN AMNE REPERTO) / TRISTIS (AMYMONE) Belus Danai pater, Danaus Amymones. Amymone a Neptuno compressa Nauplion generauit, Nauplius Palameden. Vnde Vergilius:</p> 
                <l>'Belidae nomen Palamedis'. </l>
             </div>
@@ -10423,7 +10424,7 @@
                <l>'tergemini nece Geryonis'. </l>
             </div>
 
-            <div type="schol" n="290-291">
+            <div type="schol" n="290">
                <p> (IVNGVNT DISCORDES INIMICA IN FOEDERA DEXTRAS) / BELIDAE FRATRES ex Belo nati Danaus et Aegyptus fratres. His cum par numerus filiorum filiarumque esset, Danaus deprehendit oraculo se ab uno Aegypti fratris filio occidendum. Itaque simulauit se fratris filiis natas in matrimonii consortium traditurum armauitque occulte filias coniugali nocte ut sponsos occiderent. Vniuersae uoluntatem patris secutae sponsos suos occiderunt. Hypermestra sola Lynceo pepercit. A quo postea Danaus, ut oraculi fides impleretur, occiditur. <hi rend="italic">Inimica</hi> ergo <hi rend="italic">in foedera</hi> dixit, quae dextrarum coniunctio <del>ad</del> discordiam perfecit. </p>
             </div>
 
@@ -10436,17 +10437,17 @@
                <p> ARION equus Adrasti qui ex Neptuno et Cerere natus dicitur, humano uestigio dextri pedis. </p>
             </div>
 
-            <div type="schol" n="309-310">
+            <div type="schol" n="309">
                <p> (STVPVERE RELICTA / NVBILA CERTANTES) EVRIQVE NOTIQVE (SECVNTVR) equi uelocitate etiam nubila uincebantur, quasi et ipsa certarent. Item <hi rend="italic">Euri ... secuntur</hi> diuine dictum: dedit illis uotum uictoriae, sed ademit effectum. </p>
             </div>
 
-            <div type="schol" n="311-313">
+            <div type="schol" n="311">
                <p> (NEC MINOR IN TERRIS ... / AMPHITRYONIADEN) ALTO PER GRAMINA (SVLCO / DVXERAT) <supplied>
                      <hi rend="italic">sulco</hi>
                   </supplied> id est orbita illius currus quem ducebat. Ideo, quod sessoris pondere praegrauabatur, altius infigebantur terrae uestigia. </p>
             </div>
 
-            <div type="schol" n="322-324">
+            <div type="schol" n="322">
                <p> ASTRA INSIDIOSA (DOCEBAT / NOLENTESQVE TERI ZONAS MEDIAMQVE POLORVM / TEMPERIEM) <supplied>
                      <hi rend="italic">insidiosa</hi>
                   </supplied> periculosa, ideo quod sunt signa uisu terribilia. Monebat ergo Phaethontem Sol ut non ageret currus per australem aut septentrionalem plagam. Lucanus de Phaethonte in libro, qui <supplied>in</supplied>scribitur Iliacon, ita:</p>
@@ -10458,11 +10459,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="326-327">
+            <div type="schol" n="326">
                <p> OEBALIOS (... / ... EQVOS) Laconicos. </p>
             </div>
 
-            <div type="schol" n="327-329">
+            <div type="schol" n="327">
                <p> FVRTO (LAPSA PROPAGO CYLLARE DVM SCYTHICI DIVERSVS AD OSTIA PONTI / CASTOR AMYCLAEAS REMO PERMVTAT HABENAS) <supplied>
                      <hi rend="italic">furto</hi>
                   </supplied> adulterio furtim commisso. CYLLARE equi Castorum Cyllarus et Xanthus. Aliter enim Vergilius:</p>
@@ -10484,28 +10485,28 @@
                <p> FELIX ADMETVS aut propter amicitiam Herculis aut propter receptam dictus uxorem. </p>
             </div>
 
-            <div type="schol" n="334-335">
+            <div type="schol" n="334">
                <p> (OMNIS) / IN VIRES ADDVCTA VENVS cupido libidinis migrauit in uires. </p>
             </div>
 
-            <div type="schol" n="337-338">
+            <div type="schol" n="337">
                <p> (TANTVS VTERQVE COLOR CREDI NEC DEGENER ILLO) / DE GREGE CASTALIO de Pegasi grege, qui fontem Hippocrenen Apollini et Musis dicatum ungula sua scalpsit. Neptunus enim pater quorundam equorum fertur: Pegasi ex Medusa, Arionis ex Cerere. Ergo equae Admeti Pegaso concolores fuerunt. </p>
             </div>
 
-            <div type="schol" n="340-343">
+            <div type="schol" n="340">
                <p> ECCE ET IASONIDAE (IVVENES NOVA GLORIA MATRIS / HYPSIPYLES ... / NOMEN AVO GENTILE THOAS ATQVE OMINE DICTVS / EVNEOS ARGOO) de Iasone et Hypsipyle duo nati sunt fluii: Thoas et Euneos, quorum Thoas maternum auum nomine refert, Euneos uocatur alter om<supplied>i</supplied>nis causa a patre nauigaturo. Quorum nomina opportuno tempore poeta commemorat, hi<supplied>c</supplied> uero quia certaturi noti esse debuerant. </p>
             </div>
 
-            <div type="schol" n="&lt;344-345&gt;">
+            <div type="schol" n="344">
                <p> 
                   <supplied>PAR ET CONCORDIA VOTIS / VINCERE VEL SOLO CVPIVNT A FRATRE RELINQVI</supplied> adeo fraterna contentio fuit ut nec uictus doleat nec uictor insultet. </p>
             </div>
 
-            <div type="schol" n="346-348">
+            <div type="schol" n="346a">
                <p> IT CHROMIS (... ALTER SATVS HERCVLE MAGNO / ... / ... GETICI PECVS HIC DIOMEDIS) Chromin dicit, Herculis filium, quem constat equos habuisse Thraces quos Hercules exstincto rege abduxerat, humanis carnibus uesci consuetos. Cum multi uero hoc exitio hospites interissent, hunc Hercules, ne ab eodem circumuentus periret, equorum suorum pabulum fecit, quos filio suo habendos concessit. </p>
             </div>
 
-            <div type="schol" n="346-350">
+            <div type="schol" n="346b">
                <p> (HIPPODAMVSQVE ...) / ALTER AB OENOMAO ... / ... (AT ILLE / PISAEI IVGA PATRIS HABET CRVDELIBVS AMBO / EXVVIIS DIROQVE IMBVTI SANGVINE CVRRVS) Hippodamum dicit Oenomai currus regentem. Eorum enim equorum non dissimilis fama est exitio tot procorum. Ideo ambigit poeta quibus equis ab eo maior crudelitas ascribatur. Ex utroque enim stabulo processit horrenda crudelitas. </p>
             </div>
 
@@ -10526,7 +10527,7 @@
                <p> ANGVIS Pythonis. FRATRVM ... HONORES id est ea facta, quae reliqui dii gloriae suae <supplied>as</supplied>signant. </p>
             </div>
 
-            <div type="schol" n="360-361">
+            <div type="schol" n="360">
                <p> QVIS SIDERA DVCAT / SPIRITVS secta Platonica dicit omnia spiritu diuino gubernari. Vnde Vergilius:</p>
                <lg>
                   <l>'principio caelum ac terras c(amposque) l(iquentis)</l>
@@ -10543,14 +10544,14 @@
                <p> VIVAT MARE ostendit poeta 'uiuum' et 'uiua<del>m</del>' posse dici ea quae neque anima neque spiritu mouentur. </p>
             </div>
 
-            <div type="schol" n="&lt;363-364&gt;">
+            <div type="schol" n="363">
                <p> 
                   <supplied>IMANE TELLVS / AN MEDIA ET RVRSVS MVNDO SVCCINCTA LATENTI</supplied> thesis philosophica: terra elementorum omnium ima sit an suspensa, ut Lucretius? Ergo utrum uoluatur caelum, quod accidit si media est terra, <supplied>an</supplied>, quod si in imo desinit, caelum esse dicat<supplied>ur</supplied> immobile? Sed cum disputantium discordat opinio, uerum non dicit, <supplied>ni</supplied>si qui rite cognouit originum causas. Vnde Vergilius:</p> 
                <l>'felix qui potuit rerum cognoscere causas'.</l> 
                <p>MVNDO SVCCINCTA LATENTI <hi rend="italic">latentem mundum</hi> antipodas dicit. <hi rend="italic">Succincta</hi> autem pro pendenti, quia, si media est, nulla stabilitate firmatur. Sed de his rebus, prout ingenio meo committere potui, ex libris ineffabilis doctrinae Persei praeceptoris seorsum libellum composui <del>Caelius Firmianus</del> Lactantius Placidus. </p>
             </div>
 
-            <div type="schol" n="366-367">
+            <div type="schol" n="366">
                <p> DVMQVE CHELYN LAVRO (TEXTVMQVE INLVSTRE CORONAE / SVBLIGAT) citharoedorum disciplinam expressit, quibus mos <supplied>est</supplied> finito carmine coronam detractam capiti citharae subligare<del>t</del>.</p>
             </div>
 
@@ -10559,7 +10560,7 @@
                <l>'Sidoniam picto chlamydem circumdata limbo'. </l>
             </div>
 
-            <div type="schol" n="369-370">
+            <div type="schol" n="369">
                <p> CERTAMINIS INSTAR / (QVADRIIVGI) speciem enim belli quadriiugum certamen adduxerat cupido uincendi. </p>
             </div>
 
@@ -10568,7 +10569,7 @@
                   <del>DICERE</del> PELIACIS (HIC CVM FAMVLARER IN ARVIS) montem Pelion in Thessalia esse notissimum est prope quem deus Apollo Admeti regis pauit armenta. Constat autem huius iniuriae hanc fuisse causam: fulminato Aesculapio quod reuocare ad uitam ausus fuisset Hippolytum, pater Apollo, ubi se uidit orbatum, sagittis Cyclopas occidit qui Iouis fulmina fabricare consueuerant. Ob hoc mortalem indutus formam pecus Admeto iuxta fluuium pauit Amphrysum. </p>
             </div>
 
-            <div type="schol" n="378-379">
+            <div type="schol" n="378">
                <p> AT HIC TRIPODVM COMES (ET PIVS ARTIS ALVMNVS / AETHERIAE) Amphiaraus scilicet. </p>
             </div>
 
@@ -10579,7 +10580,7 @@
                   </supplied> Admetus. Et notandum uarietatem nominum solis pronominibus separatam <hi rend="italic">ille</hi> et <hi rend="italic">huius</hi>.</p>
             </div>
 
-            <div type="schol" n="380-381">
+            <div type="schol" n="380">
                <p> (DATVR ORDO SENECTAE) / ADMETO SERVMQVE MORI beneficio enim uxoris Alcestae Admetus distulerat mortem. Cuius talis est fabula: Alceste Admeti uxor fuit. Haec, cum agnouisset uiro suo finem propinquare uitae, sese obtulit morti. Quam cum exstinctam Admetus impatienter doleret, Herculis laboribus ei reducta ab inferis dicitur. Eleganter ergo hic poeta <hi rend="italic">serum ... mori</hi> Admeto posuit, uidelicet pro quo alter<supplied>a</supplied> concessit in fata. Vnde Iuuenalis:</p>
                <lg>
                   <l>'spectant subeuntem fata mariti</l>
@@ -10620,11 +10621,11 @@
                <p> DIVVM VTRVMQVE GENVS quia <supplied>et</supplied> equi et auriga diuino oriuntur ex semine. </p>
             </div>
 
-            <div type="schol" n="397-398">
+            <div type="schol" n="397">
                <p> (SANGVINE FERRVM) / VRITVR calidum fit siue calore atteritur. </p>
             </div>
 
-            <div type="schol" n="400-401">
+            <div type="schol" n="400">
                <p> (STARE ADEO MISERVM EST PEREVNT) VESTIGIA MILLE / (ANTE FVGAM) quia illud uidebatur geri, quod adhuc non coeperat. Familiare enim generosorum equorum est inquietudine pedum anticipare cursum, quia multa stan<supplied>te</supplied>s <hi rend="italic">uestigia muta<supplied>n</supplied>t</hi>. Vergilius:</p> 
                <l>'stare loco nescit'. </l>
             </div>
@@ -10634,7 +10635,7 @@
                <l>'Tyrrhenusque tubae mugire per aethera clangor'.</l>
             </div>
 
-            <div type="schol" n="407-409">
+            <div type="schol" n="407">
                <p> (AMNIBVS HIBERNIS MINOR EST MINOR IMPETVS IGNI) / TARDIVS ASTRA CADVNT (GLOMERANTVR TARDIVS IMBRES / TARDIVS E SVMMO DECVRRVNT FLVMINA MONTE) parabola per hyperbolen, quae tunc adhibetur cum nec illa quidem quae comparantur ad exprimendam similitudinem posse sufficere scriptor affirmat. </p>
             </div>
 
@@ -10671,11 +10672,11 @@
                <p> CHROMIS ASPER Herculis filius. </p>
             </div>
 
-            <div type="schol" n="436-437">
+            <div type="schol" n="436">
                <p> (ASPER) / HIPPODAMVS Oenomai filius. </p>
             </div>
 
-            <div type="schol" n="437-438">
+            <div type="schol" n="437">
                <p> SED MOLE TENE<supplied>N</supplied>TVR / (CORNIPEDVM) ut Vergilius:</p>
                <lg>
                   <l>'melior remis, sed pondere pinus</l>
@@ -10703,7 +10704,7 @@
                <p> LABDACIDES patronymicum significat Polynicen, cuius auus Laius Labdaci filius fuit. </p>
             </div>
 
-            <div type="schol" n="454-455">
+            <div type="schol" n="454">
                <p> (RVRSVS PRAECIPITES IN RECTA AC) DEVIA CAMPI / (OBLIQVANT) <supplied>
                      <hi rend="italic">deuia campi</hi>
                   </supplied> antiptosis est: dum in directa tendunt, in deuia obliquant. </p>
@@ -10720,7 +10721,7 @@
                   </supplied> faciunt per transuersa camporum. </p>
             </div>
 
-            <div type="schol" n="461-462">
+            <div type="schol" n="461">
                <p> PHOLOEN <del>ADMETVS</del> ET IRIN / (FVMANTEMQVE THOEN) equarum nomina sunt. Supra enim sic dixit:</p> 
                <l>'uix steriles compescit equas'. </l>
             </div>
@@ -10733,15 +10734,15 @@
                <p> IGNEVS AETHION iucunde Graeco nomini expositionem adiecit, quia <hi rend="italic">Aethion</hi> dicitur de colore, quia igneus fuit. Vnde et Hyperion, quamuis alii <foreign xml:lang="grc">ἀπὸ τοῦ ὑπὲρ αἰῶνας</foreign> accipiant, utrumque tamen recte. </p>
             </div>
 
-            <div type="schol" n="481-482">
+            <div type="schol" n="481">
                <p> (AXE TENET PRENSO LVCTANTVR ABIRE IVGALES / NEQVIQVAM FRENOSQVE ET COLLA) RIGENTIA TENDVNT quia prensum axem reuocauit et continuit illorum cursum. <hi rend="italic">Rigentia</hi> autem dixit conatu tensa. </p>
             </div>
 
-            <div type="schol" n="483-484">
+            <div type="schol" n="483">
                <p> (VT SICVLAS SI QVANDO RATES) TENET AESTVS (ET INGENS / AVSTER AGIT MEDIO STANT VELA TVMENTIA PONTO) licet uentus inflaret, tamen aestu cogente ire non poterant. </p>
             </div>
 
-            <div type="schol" n="486-487">
+            <div type="schol" n="486">
                <p> SED THRACES EQVI (VT VIDERE IACENTEM / HIPPODAMVM REDIT ILLA FAMES) dixerat enim supra Chromin, Herculis filium, equis <supplied>usum</supplied> Diomedis Thracis — non illius, qui in Troiae excidio militauit — qui humanis carnibus uescebantur. </p>
             </div>
 
@@ -10749,7 +10750,7 @@
                <p> VICTVSQVE ET COLLAVDATVS ABISSET quia praeposuit humanitatem gloriae ne cruentam uictoriam sortiretur, et uictus est cum fauore. </p>
             </div>
 
-            <div type="schol" n="505-506">
+            <div type="schol" n="505">
                <p> (NEXVSQVE DIV) PER TERGA VOLVTVS / (EXVIT) habenarum nexum, qui diu uolutus per terga fuerat, liberauit, ne curru loris implicitus traheretur. </p>
             </div>
 
@@ -10770,11 +10771,11 @@
                <p>Sergestum significare uolens et Mnestheum. </p>
             </div>
 
-            <div type="schol" n="508-509">
+            <div type="schol" n="508">
                <p> HEROS / LEMNIVS unum de geminis Hypsipylae dicit, quorum alter, Thoas, iam ruerat, dum Admetum praeterire festinat. </p>
             </div>
 
-            <div type="schol" n="513-514">
+            <div type="schol" n="513">
                <p> QVIS MORTIS THEBANE LOCVS (NISI DVRA NEGASSET / TISIPHONE) apostropha cum ecphonesi id est cum exclamatione, quasi crudelitate funerea ad parricidium seruaretur. </p>
             </div>
 
@@ -10797,7 +10798,7 @@
                <p>— nec non etiam <del>et</del> in Africa teste Sallustio qui ait: 'postquam Hercules in Africa, sicut putant, interiit, exercitus eius uariis gentibus permixtus est'. </p>
             </div>
 
-            <div type="schol" n="535-536">
+            <div type="schol" n="535">
                <p> (AVRVMQVE FIGVRIS) / TERRIBILE declamatio e contrario propter emphasin, quia aurum naturaliter delectare solet. Vt ipse alibi:</p>
                <lg>
                   <l>'armaque in auro</l>
@@ -10805,7 +10806,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="536-537">
+            <div type="schol" n="536">
                <p> (HIC MIXTA LAPITHARVM CAEDE ROTANTVR) / SAXA FACES (ALIIQVE ITERVM CRATERES) pugna Centaurorum et Lapitharum in cratere picta erat, qui in conuiuio efferati furore nec poculis pepercerunt. Vnde Vergilius:</p> 
                <l>'et magno Hylaeum Lapithis cratere minantem'.</l> 
                <p>
@@ -10825,7 +10826,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="542-543">
+            <div type="schol" n="542">
                <p> PHRIXEI (NATAT HIC CONTEMPTOR EPHEBVS) / AEQVORIS Hellesponti, ubi Helle<del>s</del>, Phrixi soror, in mare cecidit. Dicit ergo Leandrum in chlamyde pictum fuisse natantem. </p>
             </div>
 
@@ -10844,11 +10845,11 @@
                <l>'olli serua datur'. </l>
             </div>
 
-            <div type="schol" n="550-551">
+            <div type="schol" n="550">
                <p> SOLLICITAT (TVNC AMPLA VIROS AD PRAEMIA CVRSV / PRAECELERES) transacto curruli certamine eos poeta describit quibus cursu certandum est. </p>
             </div>
 
-            <div type="schol" n="551-553">
+            <div type="schol" n="551">
                <p> (AGILE STVDIVM) ET TENVISSIMA VIRTVS / (PACIS OPVS CVM SACRA VOCANT NEC INVTILE BELLIS / SVBSIDIVM SI DEXTRA NEGET) <supplied>
                      <hi rend="italic">tenuissima uirtus</hi>
                   </supplied> definitio, quid sit cursus, id est pars non satis admiranda uirtutis. Et cum plenissime rem quam coeperat definiret, adiecit <hi rend="italic">pacis opus</hi>. Sunt etiam <hi rend="italic">sacra</hi> quae cursu celebrantur. Et ut agones declararet poeta non satis esse uirtuti, adiecit <hi rend="italic">nec inutile bellis</hi> id est necessarium fugae, si uincere non cedatur. </p>
@@ -10859,7 +10860,7 @@
                <l>'atque umbrata tegens ciuili tempora quercu'. </l>
             </div>
 
-            <div type="schol" n="[556]">
+            <div type="schol" n="556">
                <p> 
                   <del>SICYONIVS ALCON Vergilius:</del>
                </p> 
@@ -10872,7 +10873,7 @@
                <p> IN ISTHMIACA (... ARENA) id est in agone qui <del>in</del> Isthmia uocatur, in honorem Leucotheae et Palaemonis apud Corinthum consecratus. </p>
             </div>
 
-            <div type="schol" n="563-565">
+            <div type="schol" n="563">
                <p> QVIS MAENALIAE (ATALANTES / NESCIAT EGREGIVM DECVS ET VESTIGIA CVNCTIS / INDEPRENSA PROCIS) Atalantes confudit historiam. Hanc enim Atalanten diximus filiam <supplied>Iasii</supplied> fuisse, illam autem quae cum procis cursu contendit <del>Oenomai filiam, uxorem Pelopis, <supplied>Hippodamiam</supplied>
                   </del>, Hippomenis uxorem<supplied>, filiam Schoenei</supplied>. Sed parem historiam posuit secutus Vergilium. Ille enim ait:</p> 
                <l>'et manibus Procne pectus signata cruentis',</l> 
@@ -10883,11 +10884,11 @@
                <p> DIFFIBVLAT noue dixit. </p>
             </div>
 
-            <div type="schol" n="572">
+            <div type="schol" n="572a">
                <p> LAETITIA id est pulchritudo seu uenustas. </p>
             </div>
 
-            <div type="schol" n="572-573">
+            <div type="schol" n="572b">
                <p> (NEC PECTORA NVDIS) / DETERIORA GENIS (LATVITQVE IN CORPORE VVLTVS) uestitus pulcher uidebatur, sed pulchrior factus est nudus. LATVIT ... VVLTVS comparatione membrorum. Nudato enim corpore membrorum pulchritudo uenustatem uultus obnubit. </p>
             </div>
 
@@ -10900,15 +10901,15 @@
                   <supplied>PROXIMVS</supplied> aut talis aut iuxta. SEGNIOR deterior. </p>
             </div>
 
-            <div type="schol" n="584-585">
+            <div type="schol" n="584">
                <p> (ATTAMEN ILLI / IAM TENVEM PINGVES FLOREM) INDVXERE PALAESTRAE rem naturalem expressit. Cito enim genae barbae lanugine uestiuntur <del>et</del> ex calore palaestrae et exercitatio ipsa urget corpora. </p>
             </div>
 
-            <div type="schol" n="586">
+            <div type="schol" n="586a">
                <p> DESERPITQVE GENIS incipit a coma discedere. Siue <hi rend="italic">deserpit</hi>: 'de' abundat. Haec enim praepositio aut addit aut minuit aut mutat. </p>
             </div>
 
-            <div type="schol" n="586-587">
+            <div type="schol" n="586b">
                <p> (NEC SE LANVGO) FATETVR / (INTONSAE SVB NVBE COMAE) id est: non apparet, quasi sub intonsa corna lateat genarum lanugo. </p>
             </div>
 
@@ -10941,7 +10942,7 @@
                <l>'conferto<supplied>que</supplied> agmine cerui'. </l>
             </div>
 
-            <div type="schol" n="602-603">
+            <div type="schol" n="602">
                <p> (PVER ... ) / MAENALIVS Parthenopaeus Arcas, quia Maenalus mons Arcadiae est. Vt ipse inferius:</p>
                <lg>
                   <l>'crinis</l>
@@ -11024,7 +11025,7 @@
                <p> HVNC RAPITE raptim mittite. </p>
             </div>
 
-            <div type="schol" n="658-659">
+            <div type="schol" n="658">
                <p> (AST ILLVD) CVI NON IACVLABILE (DEXTRAE / PONDVS) interrogatiue cum despectu. </p>
             </div>
 
@@ -11032,7 +11033,7 @@
                <p> NVLLO CONAMINE facile et sine labore. </p>
             </div>
 
-            <div type="schol" n="661-663">
+            <div type="schol" n="661">
                <p> VIX VNVS (PHLEGYAS ACERQVE MENESTHEVS / ... / PROMISERE MANVS) ordo: uix promisere manus. Et notandum quare <hi rend="italic">unum</hi> dixerit, cum alterius etiam nomen adiecisset. Sed hoc secutus Vergilium fecit. Ille enim ait:</p>
                <lg>
                   <l>'uix unus Helenor et Lycus</l>
@@ -11056,21 +11057,21 @@
                <p> MVGIT clipeus scilicet. </p>
             </div>
 
-            <div type="schol" n="668-669">
+            <div type="schol" n="668">
                <p> (OMNES / ABSTVLIT) IN SE OCVLOS populi uidelicet. </p>
             </div>
 
-            <div type="schol" n="670-671">
+            <div type="schol" n="670">
                <p> (TERRA DISCVMQVE MANVMQVE) / ASPERAT ne dum iaceret laberetur. </p>
             </div>
 
-            <div type="schol" n="671-673">
+            <div type="schol" n="671">
                <p> (EXCVSSO MOX CIRCVM PVLVERE) VERSAT / (QVOD LATVS IN DIGITOS MEDIAE QVOD CERTIVS VLNAE / CONVENIAT) <supplied>
                      <hi rend="italic">uersat</hi>
                   </supplied> considerat. Circumuersabat enim Phlegyas discum ut colligeret quam partem lateris eius haberet in digitis, quam bracchio retentans alae subderet. </p>
             </div>
 
-            <div type="schol" n="674-677">
+            <div type="schol" n="674">
                <p> (PATRIAE NON TANTVM VBI LAVDIS OBIRET) / SACRA (SED ALTERNIS ALPHEON VTRVMQVE SOLEBAT / METARI RIPIS ET QVA LATISSIMA DISTANT / NON VMQVAM MERSO TRANSMITTERE FLVMINA DISCO) <supplied>
                      <hi rend="italic">patriae ... sacra</hi>
                   </supplied> id est agonem Iouis Olympici qui circa Alpheum fluuium Pisarum celebratur, cuius ripas solitus erat Phlegyas disco transi<supplied>ce</supplied>re. Secundum Alpheum autem Olympicum exerceri certamen etiam Vergilio teste cognouimus. Ait enim:</p>
@@ -11100,7 +11101,7 @@
                <p> IMMERGITVR ARVIS de grauitate casus altitudinis mensura monstratur. </p>
             </div>
 
-            <div type="schol" n="685-688">
+            <div type="schol" n="685">
                <p> (SIC CADIT ATTONITIS QVOTIENS AVELLITVR ASTRIS) / SOLIS OPACA SOROR (PROCVL AVXILIANTIA GENTES / AERA CREPANT FRVSTRAQVE TIMENT AT THESSALA VICTRIX / RIDET ANHELANTES AVDITO CARMINE BIGAS) sic sibi insana hominum et stulta persuasio uindicat quod carminibus caelo luna eripiatur. Quam opinionem Vergilius secutus ait:</p> 
                <l>'carmina uel caelo possunt deducere lunam'</l> 
                <p>et alibi significauit eam inductam esse uelleribus dicendo:</p>
@@ -11119,7 +11120,7 @@
                <p> MAIORQVE MANVS SPERATVR IN AEQVO id est maiore uirtute opus esse in longitudinem quam in altitudinem iaculaturo. </p>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691">
                <p> ATQVE ILLI EXTEMPLO (CVI SPES INFRINGERE DVLCE / IMMODICAS FORTVNA VENIT) ordo: atque illi subito uenit Fortuna, cui dulce est fiduciam immodicae uirtutis auferre. FORTVNA VENIT nunc 'aduersa' intellegendum. </p>
             </div>
 
@@ -11151,29 +11152,29 @@
                <p> (ERIGIT ADSVETVM) DEXTRAE GESTAMEN hoc est: quod consueuerat etiam aliis certaminibus iaculari. </p>
             </div>
 
-            <div type="schol" n="&lt;709-710&gt;">
+            <div type="schol" n="709">
                <p> 
                   <supplied>ET IPSE / PROSEQVITVR</supplied> ut iactum uigor corporis adiuuaret. </p>
             </div>
 
-            <div type="schol" n="&lt;711&gt;">
+            <div type="schol" n="711">
                <p> 
                   <supplied>IAMQVE PROCVL MEMINIT DEXTRAE</supplied> manus a qua fuerat missus. </p>
             </div>
 
-            <div type="schol" n="712-713">
+            <div type="schol" n="712">
                <p> (NEC DVBIA IVNCTAVE) MENESTHEA VICTVM / (TRANSABIIT META) solet enim hoc certamine de uictoria dubitari. </p>
             </div>
 
-            <div type="schol" n="714">
+            <div type="schol" n="714a">
                <p> (VIRIDES ...) HVMEROS extremos colles qui spatium theatri cingebant. </p>
             </div>
 
-            <div type="schol" n="714-715">
+            <div type="schol" n="714b">
                <p> OPACA THEATRI / (CVLMINA) <hi rend="italic">theatrum</hi> dicit <del>d</del>eductam utrimque uallium pronae et supinae ascensu<del>s</del> clementi <supplied>uel</supplied> arduo lenitatem. <hi rend="italic">Opaca</hi> autem <hi rend="italic">culmina</hi> quia siluae summis montibus imminebant. </p>
             </div>
 
-            <div type="schol" n="716-718">
+            <div type="schol" n="716">
                <p> (QVALE VAPORIFERA SAXVM) POLYPHEMVS (AB AETNA / LVCIS EGENTE MANV TAMEN IN VESTIGIA PVPPIS / AVDITAE IVXTAQVE INIMICVM EXEGIT VLIXEN) Homerum secutus, qui dicit Cyclopem <supplied>
                      <hi rend="italic">saxum</hi>
                   </supplied> iecisse in Vlixis nauem quia impediente caecitate eam tenere non poterat. EXEGIT transmisit. </p>
@@ -11201,7 +11202,7 @@
                <p> (HAEC BELLIS) ET FERRO PROXIMA VIRTVS quia et caestu homines occiduntur. </p>
             </div>
 
-            <div type="schol" n="733-734">
+            <div type="schol" n="733">
                <p> (TEGMINA CRVDA BOVM) NON MOLLIOR (IPSE LACERTIS / INDVITVR) <supplied>
                      <hi rend="italic">non mollior ipse</hi>
                   </supplied> aeque durissimus, cuius cutis hominis erat durata in boum pelles. </p>
@@ -11240,12 +11241,12 @@
                <p> (TVTO PROCVL) ORA RECESSV 'habent' subaudimus. </p>
             </div>
 
-            <div type="schol" n="&lt;752&gt;">
+            <div type="schol" n="752">
                <p> 
                   <supplied>ADITVSQVE AD VVLNERA CLVSI</supplied> manibus implicatis. </p>
             </div>
 
-            <div type="schol" n="756-757">
+            <div type="schol" n="756">
                <p> (HIC) PAVLO ANTE PVER (SED ENIM MATVRIVS AEVO / ROBVR) Alcidamas adolescens, qui aetatem corporis mole uincebat. Id est cuius uirtus aetatem uirilem praecesserat. </p>
             </div>
 
@@ -11253,7 +11254,7 @@
                <p> (INGENTES SPONDET) TENER IMPETVS ANNOS id est: magna in eo ex impetu aetatis tenerae uirtutis futurae indoles cernebatur. </p>
             </div>
 
-            <div type="schol" n="758-759">
+            <div type="schol" n="758">
                <p> QVEM VINCI (HAVD QVISQVAM SAEVO NEQVE SANGVINE TINGVI / MALIT) populus enim iunioribus solet fauere. <supplied>QVEM</supplied> aliquem. <supplied>QVISQVAM</supplied> ipsorum. Ordo ergo talis est: neque quisquam malit aliquem uinci aut tingui saeuo sanguine. </p>
             </div>
 
@@ -11261,7 +11262,7 @@
                <p> ERECTO ... VOTO suspenso fauore propter incertum uictoriae exitum. </p>
             </div>
 
-            <div type="schol" n="760-761">
+            <div type="schol" n="760">
                <p> (VT SESE PERMENSI OCVLIS ET) VTERQVE PRIOREM / (SPERAVERE LOCVM NON PROTINVS IRA NEC ICTVS) id est: utrique sperabant quod <del>ab</del> alterius manus certamen inciperet. Vnde Lucanus:</p>
                <lg>
                   <l>'inde manum spectant: tempus quo noscere possint</l>
@@ -11281,11 +11282,11 @@
                <p> (CVNCTATVS) VIRES DISPENSAT id est: paulatim erogat. </p>
             </div>
 
-            <div type="schol" n="766-767">
+            <div type="schol" n="766">
                <p> AT ILLE NOCENDI / (PRODIGVS) Capaneus in aduersarii nece profusior. </p>
             </div>
 
-            <div type="schol" n="767-768">
+            <div type="schol" n="767">
                <p> (AMBAS / CONSVMIT) SINE LEGE (MANVS) sine artis lege. Artis ipsius lex est ut, una manu<del>s</del> reuersa, altera<del>m</del> feriat. Consumpsit ergo ambarum manuum ictum et perdidit. </p>
             </div>
 
@@ -11297,7 +11298,7 @@
                <p> (HOS) REICIT ICTVS refundit. </p>
             </div>
 
-            <div type="schol" n="&lt;771&gt;">
+            <div type="schol" n="771">
                <p> 
                   <supplied>HOS CAVET</supplied> eludit, euitat. NVTV (CAPITIS ... CITATI) ueloci<del>s</del> capitis motu. </p>
             </div>
@@ -11307,7 +11308,7 @@
                <l>'tuto procul ora recessu'. </l>
             </div>
 
-            <div type="schol" n="774-777">
+            <div type="schol" n="774">
                <p> (SAEPE ETIAM) INIVSTIS (COLLATVM VIRIBVS HOSTEM / ... / VLTRO AVDAX ANIMIS INTRATQVE ET OBVMBRAT ET ALTE / ADSILIT) <supplied>
                      <hi rend="italic">iniustis</hi>
                   </supplied> non aequis, quia Capaneus erat fortior. Ergo frequenter, quamuis eum pateretur, tamen aliquando commotus attemptat. </p>
@@ -11341,11 +11342,11 @@
                <p> (MILLE CAVET LAPSAS CIRCVM CAVA TEMPORA) MORTES quasi singuli ictus Capanei singulas mortes afferrent. </p>
             </div>
 
-            <div type="schol" n="794-795">
+            <div type="schol" n="794">
                <p> (SED NON TAMEN IMMEMOR ARTIS) / ADVERSVS FVGIT (ET FVGIENS TAMEN ICTIBVS OBSTAT) ita Alcidama<supplied>s</supplied> aduersus cedebat furori ut nunquam fugiens uideretur. Graue enim uiro forti crimen est terga dedisse certamini. </p>
             </div>
 
-            <div type="schol" n="800-801">
+            <div type="schol" n="800">
                <p> (SIGNVM) DE PVPPE (DATVM POSVERE PARVMPER / BRACCHIA) <supplied>
                      <hi rend="italic">de puppe</hi>
                   </supplied> a gubernatore. Nam pertica est quaedam in naui quam hortator remig<del>i</del>um tenet. Quam si incusserit, remiges non desinunt; si deposuerit, quiescunt a labore. Hanc Plautus 'casteri<del>n</del>am' nominauit in Asinaria:</p> 
@@ -11431,7 +11432,7 @@
                <p> NEC MOLE MINOR magnitudine corporis non inferior. </p>
             </div>
 
-            <div type="schol" n="838-839">
+            <div type="schol" n="838">
                <p> (SIC GRANDIBVS ALTE / INSVRGENS VMERIS HOMINEM SVPER IMPROBVS) EXIT proceritate corporis humanam formam uidebatur excedere. </p>
             </div>
 
@@ -11439,7 +11440,7 @@
                <p> SED NON ILLE RIGOR (PATRIVMQVE IN CORPORE ROBVR) Herculis scilicet. </p>
             </div>
 
-            <div type="schol" n="841-842">
+            <div type="schol" n="841">
                <p> EFFVSAQVE ... / MEMBRA plana, non torosa. SANGVINE LAXO cutem enim fluentem mollior sanguis effecit. </p>
             </div>
 
@@ -11489,7 +11490,7 @@
                <p> HARENAS quas in eum Tydeus ingesserat. </p>
             </div>
 
-            <div type="schol" n="877-880">
+            <div type="schol" n="877">
                <p> (COEPTIS) NON <supplied>E</supplied>VALVERE (POTIRI / FRVSTRATAE BREVITATE MANVS VENIT ARDVVS ILLE / DESVPER OPPRESSVMQVE INGENTIS MOLE RVINAE / CONDIDIT) id est: neuter ualuit incepta perficere. CONDIDIT celauit, quia sub ingenti Agyllei corpore exiguitas Tydei celata est. </p>
             </div>
 
@@ -11523,24 +11524,24 @@
                <l>'et iniquo pondere rastri'. </l>
             </div>
 
-            <div type="schol" n="889-890">
+            <div type="schol" n="889">
                <p> (MOX LATVS) ET FIRMO (CELER IMPLICAT ILIA NEXV / POPLITIBVS GENVA INDE PREMENS) ordo: mox latus firmo nexu implicat genua premens ad ilia. </p>
             </div>
 
-            <div type="schol" n="892">
+            <div type="schol" n="892a">
                <p> IMPROBVS magnus. </p>
             </div>
 
-            <div type="schol" n="&lt;892-893&gt;">
+            <div type="schol" n="892b">
                <p> 
                   <supplied>HORRENDVM VISV AC MIRABILE PONDVS / SVSTVLIT</supplied> quia, cum esset parua statura, magni ponderis alte sustulerat uirum, siue quod se maiorem nexibus implicasset. </p>
             </div>
 
-            <div type="schol" n="893-896">
+            <div type="schol" n="893">
                <p> (HERCVLEIS PRESSVM SIC FAMA LACERTIS) / TERRIGENAM SVDASSE (LIBYN CVM FRAVDE REPERTA / RAPTVS IN EXCELSVM NEC IAM SPES VLLA CADENDI / NEC LICET EXTREMA MATREM CONTINGERE PLANTA) Antaeum dicit, quem Hercules apud Simitthum, Africae ciuitatem, palaestrico certamine superauit, quem, cum nequiret elidere, medium corripiens bracchiorum suorum nexu confregit, quia Terrae beneficio fortior cadendo surgebat. </p>
             </div>
 
-            <div type="schol" n="906-908">
+            <div type="schol" n="906">
                <p> QVOD SI NON SANGVINIS HVIVS / (PARTEM HAVD EXIGVAM SCITIS DIRCAEVS HABERET / CAMPVS) si non exhaustus fuisset uiribus in Thebano campo in quo quinquaginta insidiantes uno relicto superstite occidit. </p>
             </div>
 
@@ -11556,7 +11557,7 @@
                <p> NEGLECTVS ... THORAX uetus. </p>
             </div>
 
-            <div type="schol" n="911-912">
+            <div type="schol" n="911">
                <p> (SVNT ET QVI NVDO SVBEANT CONCVRRERE FERRO / IAMQVE ADERANT) INSTRVCTI ARMIS modo sagittariorum uult monstrare certamina id est iactum uelocium sagittarum, sed iaculatores non exhiberi permisit. Commemorationem istius spectaculi dixit, sed ipsam non exhibuit uoluptatem. <supplied>EPIDAVRIVS AGREVS</supplied> Epidaurus ciuitas Peloponnensis equis nobilis. Vt ipse in catalogo:</p> 
                <l>'qui rura domant Epidauria'. </l>
             </div>
@@ -11585,17 +11586,17 @@
                <p> FLVERE uenire aut procedere. (QVIS FLVERE OCCVLTIS RERVM) NEGET OMINA CAVSIS incusat poeta eos qui dicunt futura non portendi mortalibus. </p>
             </div>
 
-            <div type="schol" n="935-936">
+            <div type="schol" n="935">
                <p> (FATA PATENT HOMINI PIGET) INSERVARE (PERITQVE / VENTVRI PROMISSA FIDES) <supplied>
                      <hi rend="italic">inseruare</hi>
                   </supplied> attendere auspicia. Alii 'inseruire' legunt et est uerbum augurum de caelo seruato. Dicit ergo: piget nos insistere, <supplied>id est non</supplied> quaerimus futura, et ideo perit uenturi fides promissa. </p>
             </div>
 
-            <div type="schol" n="936-937">
+            <div type="schol" n="936">
                <p> SIC OMINA CASVM / (FECIMVS) <hi rend="italic">omina</hi> sunt rerum futurarum signa siue bonarum siue malarum. <hi rend="italic">Casus</hi> autem sunt subiti prouentus. Cum enim non quaerimus quae futura sint nec procuramus aduersa cum neglectu nostro improuisa proueniunt, mala quae accidunt casui deputamus. </p>
             </div>
 
-            <div type="schol" n="938-940">
+            <div type="schol" n="938">
                <p> FATALIS (.../.../... HARVNDO) harundinem <hi rend="italic">fatalem</hi> dixit quae futura monstraret. </p>
             </div>
 
@@ -11613,28 +11614,28 @@
                   <del>ERRORE</del> SERVNT disserunt, disputant. </p>
             </div>
 
-            <div type="schol" n="945-946">
+            <div type="schol" n="945">
                <p> (VNI REMEABILE BELLVM / ET TRISTES DOMINO SPONDEBAT HARVNDO) RECVRSVS soli Adrasto sagitta suum reditum pollicetur. </p>
             </div>
 
          </div>
 
-         <div type="lib" n="VII">
+         <div type="lib" n="7">
             <head>LIBER VII</head>
 
             <div type="pr" n="pr">
                <p>Hic liber habet indignationem Iouis contra Martem quod bella Thebana lentius gererentur, missionem Mercurii ab Ioue ad eum incitandum, descriptionem domus Martis in Thracia cum omnibus eius ministris, allocutionem Martis ad Mercurium, allocutionem Adrasti regis ad tumulum Archemori, immissionem timoris et nimiam augurii formidinem pariterque cupiditatem ad bellum ocius properandi, conquestionem Liberi apud Iouem pro Thebanis Iouisque responsionem uindictam promittentis. Sequitur descriptio catalogi exercitus Thebanorum, interrogatio Antigones, responsio Phorbantis, allocutio Eteoclis animantis exercitum, instantis belli prodigia, aduentus Argiuorum ad Thebas collocatioque castrorum, egressus cum filiabus Iocastae ad Argiuorum castra, admissio et conquestio de bello, Tydei relatio, occisio tigrium mansuetarum, deinde ingruentis belli timoris descriptio, et hinc atque illinc singularia uel confusa certamina diuerso casu uariaque uictoria cum descriptione et allocutionibus exsultantium ducum. Amphiarai praecipue pugna describitur, circa quem Apollinis fauor et postea confessio cum dolore monstratur. responsum Amphiarai commendantis filium et petentis per eum de uxore uindictam, hiatus terrae et Amphiarai cum armis et curru ad inferna descensio.</p>
             </div>
 
-            <div type="schol" n="1-2">
+            <div type="schol" n="1">
                <p> ATQVE EA CVNCTANTES (TYRII PRIMORDIA BELLI / IVPPITER HAVD AEQVO RESPEXIT CORDE PELASGOS) describitur Iouis iracundia. Allocutio apud Mercurium ut minas nuntiet Marti et accuset eum quod patiatur Graecos apud tumulum Archemori uoluptatibus occupari et ut eos furoris stimulis Mars armet ad bellum. CVNCTANTES morantes siue manentes. </p>
             </div>
 
-            <div type="schol" n="3-4">
+            <div type="schol" n="3">
                <p> (CONCVSSITQVE CAPVT MOTV QVO CELSA LABORANT / SIDERA PROCLAMATQVE ADICI) CERVICIBVS (ATLAS) dicit iracundia Iouis caelo pondus augeri et hoc Atlantem queri. </p>
             </div>
 
-            <div type="schol" n="8-9">
+            <div type="schol" n="8">
                <p> (OCEANO VETITVM) QVA PARRHASIS (IGNEM / NVBIBVS HIBERNIS ET NOSTRO PASCITVR IMBRI) <supplied>
                      <hi rend="italic">Parrhasis</hi>
                   </supplied> Arcas, a gente dicta unde fuit Callisto Lycaonis filia, quae in Vrsam hoc est in Septentrionem dicitur uersa. Lucanus:</p> 
@@ -11643,7 +11644,7 @@
                <l>'non pabula flammis'. </l>
             </div>
 
-            <div type="schol" n="15-16">
+            <div type="schol" n="15">
                <p> (OMNE QVOD) ISTHMIVS VMBO / (DISTINET ET RAVCAE CIRCVMTONAT IRA MALEAE) <supplied>
                      <hi rend="italic">isthmius</hi>
                   </supplied> 'isthmus' est terra inter duo maria in longum porrecta. Haec enim duo maria orientem occidentemque discriminant: Ionium <supplied>ab</supplied> oriente, Aegaeum <supplied>ab</supplied> occidente diuiditur. <hi rend="italic">Omne</hi> ergo <hi rend="italic">quod Isthmius umbo distinet</hi> id est <del>quod</del> Achaiam, in cuius parte Pelops regnauit, et quicquid intra se Peloponnesos includit ac tenet. Duo maria circumdant adeo ut insulam facerent nisi utrumque pelagus interiecta terra diuideret. Ideo autem <hi rend="italic">umbonem</hi> montis dixit quia eius pars erectior imminet mari. MALEAE Malea promuntorium est Graeciae quod intrat mare et per quinquaginta milia introrsus extenditur, ubi unda ita saeua est ut nauigantes persequi uideatur. Vnde Vergilius:</p> 
@@ -11651,7 +11652,7 @@
                <p>Hoc autem promuntorium a Maleo, Graeciae rege, nomen accepit. </p>
             </div>
 
-            <div type="schol" n="17-18">
+            <div type="schol" n="17">
                <p> ILLI VIX MVROS (LIMENQVE EGRESSA IVVENTVS / SACRA COLVNT) <supplied>
                      <hi rend="italic">muros limenque</hi>
                   </supplied> id est fines patriae. Figura <supplied>
@@ -11664,7 +11665,7 @@
                <p> OFFENSI<del>QVE SEDENT</del> irati quod eorum gratia perisset Archemorus. Siue <hi rend="italic">offensi</hi> 'occupati' nouo sermone dixit. SEPVLCRI Archemori, cui ludos funebres celebrant. </p>
             </div>
 
-            <div type="schol" n="20-21">
+            <div type="schol" n="20">
                <p> (HICNE TVVS GRADIVE FVROR) SONAT ORBE RECVSSO / (DISCVS ET OEBALII COEVNT IN PROELIA CAESTVS) furore tuo haec, Gradiue, fecisti certamina ut aut disco certarent aut caestibus? OEBALII Pollucis. Vt supra:</p> 
                <l>'Oebalio donem lugere magistro?'</l>
             </div>
@@ -11677,11 +11678,11 @@
                <p> NVNC LENIS (BELLI NOSTRAQVE REMITTITVR IRA) quasi ideo nunc Mars lenis sit, nec nostra iracundia flectitur. </p>
             </div>
 
-            <div type="schol" n="29-30">
+            <div type="schol" n="29">
                <p> NIL EQVIDEM CRVDELE MINOR (SIT MITE BONVMQVE / NVMEN ET EFFRENI LAXENTVR IN OTIA MORES) nil illi minor quod crudele sit, id est Marti, sed bonum <supplied>et</supplied> mite numen efficiam. Minatur Iuppiter se mitem Martem efficere quod scit cruento numini esse contrarium ut mores illi qui infreni esse consueuerant otii languore torpescant et sit numen eius mite. Graue enim est malum faciendo bonum a suo instituto traducere. </p>
             </div>
 
-            <div type="schol" n="31-32">
+            <div type="schol" n="31">
                <p> (NEC SANGVINIS VLTRA) / IVS ERIT (AVSPICIVM) humani sanguinis aut ius aut auspicium non erit: <hi rend="italic">ius</hi> potestas, <hi rend="italic">auspicium</hi> frequentia. </p>
             </div>
 
@@ -11718,7 +11719,7 @@
                </p>
             </div>
 
-            <div type="schol" n="&lt;43&gt;">
+            <div type="schol" n="43">
                <p> 
                   <supplied>FERREA COMPAGO</supplied> 
                   <del>id est</del> ab ea materia qua murata est. LATERVM parietum. </p>
@@ -11735,7 +11736,7 @@
                <p> LAEDITVR ADVERSVM (PHOEBI IVBAR) offuscatur. <hi rend="italic">Phoebi iubar</hi> id est solis splendor <hi rend="italic">laeditur</hi>: splendor ferro <supplied>non</supplied> repercutitur. </p>
             </div>
 
-            <div type="schol" n="47-48">
+            <div type="schol" n="47">
                <p> (DIGNA LOCO STATIO PRIMIS SALIT) IMPETVS AMENS / (E FORIBVS) singulis ministeriis Martis epitheta <del>nomina aptando</del> coniunxit et finxit officiorum diuersitates ut omnia Martis ministeriis conuenirent. </p>
             </div>
 
@@ -11747,7 +11748,7 @@
                <p> INNVMERIS (STREPIT AVLA MINIS) mire numerum infinitum finxit, quippe pro peccatorum genere. <supplied>STREPIT ... MINIS</supplied> iam minatur supplicia diuersorum. TRISTISSIMA VIRTVS non religionis aut pietatis causa commota. Sed ideo in hoc bello <hi rend="italic">tristem</hi> dixit esse Virtutem quia parricidiis militauit. </p>
             </div>
 
-            <div type="schol" n="52-53">
+            <div type="schol" n="52">
                <p> (VVLTVQVE CRVENTO) / MORS ARMATA SEDET quia semper eripit uitam. </p>
             </div>
 
@@ -11759,11 +11760,11 @@
                <p> PAENE ETIAM GEMITVS egregie, ut in cruenta domo omnia ingemiscentia cernerentur. </p>
             </div>
 
-            <div type="schol" n="60-61">
+            <div type="schol" n="60">
                <p> VBIQVE IPSVM (SED NON VSQVAM ORE REMISSO / CERNERE ERAT) subaudis 'Martem putares ubique simulatum', nusquam tamen hilariore uultu conspicitur. </p>
             </div>
 
-            <div type="schol" n="62-63">
+            <div type="schol" n="62">
                <p> NONDVM RADIIS (MONSTRATVR ADVLTER / FOEDA CATENATO LVERAT CONVBIA LECTO) quaestionem quae poterat commoueri, quare adultero Marti Vulcanus habitaculum fundauisset, argutissime diuinus hoc loco poeta dissoluit. Dicit enim ante domum Marti aedificasse Vulcanum quam iniuriam pateretur. <supplied>RADIIS</supplied> quia Sol radiis suis magnifici flagitii detector fuisse narratur. Sed si ideo res male commissa displicuit, superest ut inueniatur carissimum numen. FOEDA CATENATO (LVERAT CONVBIA LECTO) haec, inquit, limina prius Vulcanus exstruxit quam Martis et Veneris de Solis indicio adulterium cognouisset. Quo comperto utrumque subtilissimis deuinxit catenis atque in conuentum numinum adulteros adduxit. </p>
             </div>
 
@@ -11787,7 +11788,7 @@
                <p> (DANT SILVAE) NIX(QVE) ALTA LOCVM adueniente deo omnia quae in medio sunt locum dare necesse est. </p>
             </div>
 
-            <div type="schol" n="75-76">
+            <div type="schol" n="75">
                <p> (IPSI REVERENTIA PATRI / SI PROPE SIT DEMATQVE MINAS) NEC TALIA MANDET si aduentum Martis talem iuxta Iouem casus afferret, multa de ira sua et mandatorum acerbitate minuisset. </p>
             </div>
 
@@ -11799,7 +11800,7 @@
                <p> OCCVPAT ARMIPOTENS interrogando Mars praeuenit. </p>
             </div>
 
-            <div type="schol" n="79-80">
+            <div type="schol" n="79">
                <p> (CVI ROSCIDA IVXTA) / MAENALA (ET AESTIVI CLEMENTIOR AVRA LYCAEI) Maenalus et Lycaeus montes Arcadiae amoenissimi. </p>
             </div>
 
@@ -11819,7 +11820,7 @@
                <p> PAX IPSA TVMET ipsa tranquillitas inquieta. </p>
             </div>
 
-            <div type="schol" n="87-88">
+            <div type="schol" n="87">
                <p> (PONTVMQVE IACENTEM) / EXANIMIS (IAM VOLVIT HIEMS) <supplied>
                      <hi rend="italic">exanimis</hi>
                   </supplied> sine uento. Id est: reliquiae tempestatis, licet sine flatu uentorum, tamen adhuc exagitant mare. </p>
@@ -11833,22 +11834,22 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;92&gt;">
+            <div type="schol" n="92">
                <p> 
                   <supplied>VINA SOLO FVNDENS</supplied> dis enim inferis et manibus. </p>
             </div>
 
-            <div type="schol" n="&lt;93-94&gt;">
+            <div type="schol" n="93">
                <p> 
                   <supplied>DA PARVE TVVM TRIETERIDE MVLTA / INSTAVRARE DIEM d a</supplied> hoc, ut inter triennium haec tibi sacra celebrentur frequentius. TRIETERIDE MVLTA trieterica sacra sunt quae intermisso triennio redeunt et celebrantur. </p>
             </div>
 
-            <div type="schol" n="94-95">
+            <div type="schol" n="94">
                <p> 
                   <del>NEC</del> SAVCIVS <del>ARCADAS</del> ... / ... (PELOPS) Pelops scilicet, qui a patre Tantalo numinibus est epulandus appositus. </p>
             </div>
 
-            <div type="schol" n="95-96">
+            <div type="schol" n="95">
                <p> ELEA<del>QVE PVLSET</del> ... / (TEMPLA) Elea <supplied>Elis</supplied> 
                   <del>id est Graeciae</del>, ubi ludi funebres et Olympicus institutus est agon, in quo certamine oleastro uictores coronari consueuerunt. EBVRNA ... / MANV ut:</p> 
                <l>'humeroque Pelops insignis eburno'. </l>
@@ -11872,17 +11873,17 @@
                <p> (MAESTAQVE PERPETVIS SOLLEMNIA) IVNGIMVS (ASTRIS) ludos tuos caelestium agonibus conferimus. </p>
             </div>
 
-            <div type="schol" n="101-103">
+            <div type="schol" n="101">
                <p> (MAGNIS TVNC DIGNIOR ARIS / TVNC DEVS INACHIAS NEC TANTVM CVLTA) PER VRBES / NVMINA (CAPTIVIS ETIAM IVRABERE THEBIS) promittit Adrastus se numen Archemori omnibus Graeciae ciuitatibus indicaturum, non solum liberis, uerum etiam bello uictis. </p>
             </div>
 
-            <div type="schol" n="106-107">
+            <div type="schol" n="106">
                <p> (QVA SVMMAS CAPVT) ACROCORINTHVS (IN AVRAS / TOLLIT ET ALTERNA GEMINVM MARE PROTEGIT VMBRA) <supplied>
                      <hi rend="italic">Acrocorinthus</hi>
                   </supplied> mons est circa Corinthum immensae altitudinis, cuius umbra utrumque mare tegi poeta describit. </p>
             </div>
 
-            <div type="schol" n="112-113">
+            <div type="schol" n="112">
                <p> BONVS OMNIA CREDI / (AVCTOR) ad omnia credenda idoneus auctor est timor. Quo faciente interdum etiam impossibilia credimus. Nihil est enim quod credere homines non suadeat timor. </p>
             </div>
 
@@ -11894,11 +11895,11 @@
                <p> VIDISSE PVTANT ad augendam credulitatem nouarum rerum ita dicta confirmant ut quae timore mentiuntur se uidisse confirment. </p>
             </div>
 
-            <div type="schol" n="116-117">
+            <div type="schol" n="116">
                <p> TVNC ACRE NOVABAT / (INGENIVM) si deorum aliquis mentiatur, facile potest falsa suadere mortalibus. </p>
             </div>
 
-            <div type="schol" n="123-124">
+            <div type="schol" n="123">
                <p> (VBI ISTE FRAGOR) NI FALLIMVR AVRE SED VNDE / (PVLVEREO STANT ASTRA GLOBO) <hi rend="italic">aure</hi> hic pro 'auditu' posuit et est oratio populi se inuicem interrogantis. NI FALLIMVR AVRE hoc est: nisi decipimur auditu. Et uidentur interposita uerba Pauoris esse quasi respondentis, ut docet ipsa commatica pronuntiatio. Denique conclusit:</p> 
                <l>'haec Pauor attonitis'. </l>
             </div>
@@ -11907,11 +11908,11 @@
                <p> (AN DVBITENT AGE DVM INFERIAS) ET BVSTA COLAMVS ironia, quasi propter remissionem animi et occupationem ludorum sint ab hoste contempti. </p>
             </div>
 
-            <div type="schol" n="127-128">
+            <div type="schol" n="127">
                <p> VARIOSQVE PER AGMINA (VVLTVS / INDVITVR) ut manifestius quae uelit timor affirmet, diuersarum gentium indutus uultibus se exercitibus miscet. </p>
             </div>
 
-            <div type="schol" n="[129]">
+            <div type="schol" n="129">
                <p> 
                   <del>PYLIVS Horatius primo:</del>
                </p> 
@@ -11932,19 +11933,19 @@
                <p> (SACRAE ...) FASTIGIA VALLIS in qua sacra fuerant celebrata in honorem Archemori. </p>
             </div>
 
-            <div type="schol" n="135">
+            <div type="schol" n="135a">
                <p> INSANI fortes. </p>
             </div>
 
-            <div type="schol" n="135-136">
+            <div type="schol" n="135b">
                <p> NVLLO / MORE RAPIT raptim facit inuadere praeter consuetudinem. </p>
             </div>
 
-            <div type="schol" n="139">
+            <div type="schol" n="139a">
                <p> PRAECIPITANT (REDIMVNTQVE MORAS) festinanter accelerant ut tarditatis moras celeritate compensent. </p>
             </div>
 
-            <div type="schol" n="139-140">
+            <div type="schol" n="139b">
                <p> (SIC LITORA VENTO) / INCIPIENTE FREMVNT uociferatione praeparantium nauigium perstrepunt litora. </p>
             </div>
 
@@ -11952,7 +11953,7 @@
                <p> VELA FLVVNT sol<supplied>ut</supplied>a descendunt. </p>
             </div>
 
-            <div type="schol" n="145-146 ">
+            <div type="schol" n="145">
                <p> (RAPIDVM) GLOMERARE (... / ...ITER) praeter ordinem festinanter impingere. </p>
             </div>
 
@@ -12005,7 +12006,7 @@
                <p> DECEPTIQVE LARIS dolo Iunonis dicit morte<del>m</del> matris suae Semeles uiduatos penates. </p>
             </div>
 
-            <div type="schol" n="158-160">
+            <div type="schol" n="158">
                <p> (ESTO) OLIM INVITVS (IACVLATVS NVBIBVS IGNEM / CREDIMVS EN ITERVM ATRA REFERS INCENDIA TERRIS / NEC STYGE IVRATA NEC PAELICIS ARTE ROGATVS) <supplied>
                      <hi rend="italic">esto olim inuitus</hi>
                   </supplied> 
@@ -12020,7 +12021,7 @@
                <p> PARRHASIVMQVE NEMVS silua ubi Callisto a bue compressa est, quae postea 'Helice' nomen accepit. LEDAEAS(QVE IBIS AMYCLAS) cum ad Ledam uenisti. </p>
             </div>
 
-            <div type="schol" n="164-165">
+            <div type="schol" n="164">
                <p> (SCILICET) E CVNCTIS EGO (NEGLECTISSIMA NATIS / PROGENIES) dicit se Liber a multis saepe mortalibus fuisse neglectum ut Lycurgo atque Pentheo. Nam Ouidius quodam loco uerba Penthei iniuriantis Liberum ita descripsit:</p>
                <lg>
                   <l>'quis furor, anguigenae, proles Mauortia, uestras</l>
@@ -12036,7 +12037,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="165-167">
+            <div type="schol" n="165">
                <p> (EGO NEMPE TAMEN QVI DVLCE FERENTI) / PONDVS ERAM (CVI TV DIGNATVS LIMINA VITAE / PRAEREPTVMQVE ITER ET MATERNOS REDDERE MENSES) quoniam fulminata matre femini Iouis insutus est. Vnde Liber 'Bimater' appellatus est quod duas ueluti matres habuerit, et 'Dithyrambus' dictus est quod uelut per duas portas exierit. Sed hoc fabulosum intellegitur. Sub hac autem figura mysticum philosophiae secretum est. Nam et illud falsissimum est, quod Tiresias subiit <supplied>
                      <gap/>
                   </supplied>
@@ -12071,16 +12072,16 @@
                </lg>
             </div>
 
-            <div type="schol" n="182-183">
+            <div type="schol" n="182">
                <p> (POTVIT) LATONIA FRATER / (SAXA NEC INVIDEO DEFIGERE DELON) Apollinem dicit, qui Delon insulam in honorem materni partus stabilem fecit. </p>
             </div>
 
-            <div type="schol" n="183-184">
+            <div type="schol" n="183">
                <p> (ET IMIS) / COMMENDARE FRETIS id est duabus insulis alligare. <hi rend="italic">Freta</hi> enim proprie maria dicuntur quae aestu rapido uicinas terras interfluunt. De qua insula ait Vergilius:</p> 
                <l>'Mycono e celsa Gyaroque reuinxit'. </l>
             </div>
 
-            <div type="schol" n="184-185">
+            <div type="schol" n="184">
                <p> (CARA SVBMOVIT AB ARCE) / HOSTILES (TRITONIS AQVAS) Athenas dicit, quas cum inundasset Neptunus, Minerua eas diluuio liberauit. Pro qua urbe contendisse dicitur cum Neptuno inuentis muneribus. Quam fabulam Vergilius tetigit dicens:</p>
                <lg>
                   <l>'cui prima frementem</l>
@@ -12093,29 +12094,29 @@
                </lg>
             </div>
 
-            <div type="schol" n="185-186">
+            <div type="schol" n="185">
                <p> (POTENTEM / GENTIBVS EOIS) EPAPHVM Iouis et Ius filium, qui regnauit in Aegypto, cuius mater uersa est in iuuencam. Vnde Vergilius:</p> 
                <l>'at leuem clipeum sublatis cornibus Io'. </l>
             </div>
 
-            <div type="schol" n="187">
+            <div type="schol" n="187a">
                <p> CYLLENE Arcadia, in qua Mercurius dicitur natus. </p>
             </div>
 
-            <div type="schol" n="187-188">
+            <div type="schol" n="187b">
                <p> MINOIAVE CVRAT / (IDA) Minos et Rhadamanthus Iouis et Europae filii, Cretensium reges. </p>
             </div>
 
-            <div type="schol" n="189-190">
+            <div type="schol" n="189">
                <p> HIC TIBI QVANDO MINOR (IAM NOSTRA POTENTIA NOCTES / HERCVLEAE PLACITVSQVE VAGAE NYCTEIDOS ARDOR) <del>sed</del> ut conciliet Iouem in amorem Thebarum, commemorat quas mortalium amare dignatus fuerit feminarum, id est Alcmenam, Antiopam Nycteidem, postremo Europam, cuius frater Cadmus condidit Thebas. QVANDO quoniam. Ordo: hic tibi noctes Herculeae et ardor Nyctei<supplied>dos placitus. NYCTEIDOS Nyctei</supplied> filiae Antiopae, quae a Lyco expulsa per Dircen a Ioue in Satyrum uerso compressa est, unde Zethus et Amphion feruntur progeniti. <del>NYCTEIDOS ARDOR amor Antiopae, Nyctei filiae.</del>
                </p>
             </div>
 
-            <div type="schol" n="191">
+            <div type="schol" n="191a">
                <p> HIC TYRIVM GENVS propter Europam et Cadmum, quod Cadmus Tyrii Agenoris filius fuit, qui Thebas condidit, frater Europae. Cuius rei necessitudine Thebanis uult conciliare Iouem. </p>
             </div>
 
-            <div type="schol" n="191-192">
+            <div type="schol" n="191b">
                <p> (NOSTRO) FELICIOR IGNE / (TAVRVS) <supplied>
                      <hi rend="italic">felicior</hi>
                   </supplied> amore. Felicior ergo Europa Semele, quippe quae fulmen pro amore perpessa est. Ideo <hi rend="italic">nostro igne felicior</hi>.</p>
@@ -12127,7 +12128,7 @@
                <p>POPLITE FLEXVM genibus inclinatum. </p>
             </div>
 
-            <div type="schol" n="195-198">
+            <div type="schol" n="195">
                <p> (NON CONIVGIS ISTA / CONSILIIS VT RERE PVER NEC SAEVA ROGANTI) / SIC EXPOSTVS EGO (IMMOTO DEDVCIMVR ORBE / FATORVM VETERES SERAEQVE IN PROELIA CAVSAE) sic sum subditus Fatis ut imminentia mutare non possim. Dicit ergo: non Iunonis gratia Thebanis indicimus bellum, o puer, ut putas. Neque enim mutabilis potest esse Iuppiter qui immoto Fatorum ordine ea quae semel decreta sunt compiere non differt. Isti uero populi id est Argiui siue Thebani ad hoc fataliter nati sunt ut bellis intereant. </p>
             </div>
 
@@ -12135,32 +12136,32 @@
                <p> REPONAM reuocem, reprimam, siue cohibeam. </p>
             </div>
 
-            <div type="schol" n="204-205">
+            <div type="schol" n="204">
                <p> (AVT LAPITHAS MARTI AVT VETEREM CALYDONA DIANAE) / EXPVGNARE DEDI Mars Lapithas immissis furorum stimulis perdidit, Calydona<del>m</del> Diana missu saeuissimi apri uastauit. </p>
             </div>
 
-            <div type="schol" n="207-208">
+            <div type="schol" n="207">
                <p> (LABDACIOS VERO PELOPISQVE A STIRPE NEPOTES) / TARDVM ABOLERE (MIHI) id est: sero illis irrogo digna supplicia. </p>
             </div>
 
-            <div type="schol" n="208-209">
+            <div type="schol" n="208">
                <p> CRIMINA ... / DORICA Graeca. Propter iniurias Tantali, qui ei exstincto filio Pelope humanos artus apposuit epulandos. </p>
             </div>
 
-            <div type="schol" n="&lt;210&gt;">
+            <div type="schol" n="210">
                <p> 
                   <supplied>TE QVOQVE</supplied> in Thebas uindicem uel seuerum. </p>
             </div>
 
-            <div type="schol" n="211-214">
+            <div type="schol" n="211">
                <p> (NON TAMEN AVT PATRIO RESPERSVS) SANGVINE PENTHEVS / (AVT MATREM SCELERASSE TORIS AVE CRIMINE FRATRES / PROGENVISSE REVS LACERO TVA LVSTRA REPLEVIT / FVNERE VBI HI FLETVS VBI TVNC ARS TANTA PRECANDI) commemorando quod Pentheus innocens crudeliter sit punitus — comparando enim Oedipi Pentheique facinora, qui nec parricidium fecit nec cum matre concubuit, cum Pentheus ista non fecerit, tamen lacero funere tua lustra compleuit — ergo tu, qui tam saeuissime paruae culpae reos punire consueuisti, non debes tam flebiliter pro nefandissimis supplicare. (AVT MATREM SCELERASSE TORIS AVT CRIMINE) FRATRES / PROGENVISSE REVS quia Oedipus maritus et filius, patris filii fratres sunt. Nullus igitur ibi pietatis ordo seruatus est ubi fuit Iocasta et uxor et mater. </p>
             </div>
 
-            <div type="schol" n="219-220">
+            <div type="schol" n="219">
                <p> NON HOC STATVI (SVB TEMPORE REBVS / OCCASVM AONIIS) ordo: non hoc tempore statui Thebas euertere. Et hoc dicendo spes aliqua ueniae postulanti promittitur. Dicit enim Iuppiter se ut cetera numina imminentia mala posse differre, in totum uero immutare non posse. </p>
             </div>
 
-            <div type="schol" n="220-221">
+            <div type="schol" n="220">
                <p> (VENIET SVSPECTIOR AETAS) / VLTORESQVE ALII Theseum dicit, qui secundo bello Thebas euertet. NVNC REGIA IVNO QVERETVR nunc Iuno tristabitur quoniam in primo bello omnes excepto Adrasto Argiuorum duces peribunt. </p>
             </div>
 
@@ -12172,11 +12173,11 @@
                <p>Ergo audita <supplied>o</supplied>ratione Iouis uno Liber tempore ornatum laetitiamque recepit. </p>
             </div>
 
-            <div type="schol" n="223">
+            <div type="schol" n="223a">
                <p> (SOLE) MALO torrido seu igneo. </p>
             </div>
 
-            <div type="schol" n="223-224">
+            <div type="schol" n="223b">
                <p> TRISTI ... / ... NOTO nubilo Austro. Est autem floribus inimicus. Vnde Vergilius:</p>
                <lg>
                   <l>'floribus austrum</l>
@@ -12184,7 +12185,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224">
                <p> (SI CLARA DIES ZEPHYRIQVE REFECIT / AVRA POLVM) REDIT OMNIS HONOS sic, inquit, laetitia Liberi immutatus est uultus ex grandi tristitia quemadmodum flores flante Austro et solis nimio calore pallescunt perduntque gratiam aspectus sui ac rursus, si placidi Fauonii spirauerit flatus et uirentes herbas frigidior uentus erexerit, et odorem recipiunt et colorem. </p>
             </div>
 
@@ -12197,7 +12198,7 @@
                <l>'a nauibus itis'. </l>
             </div>
 
-            <div type="schol" n="230-231">
+            <div type="schol" n="230">
                <p> (QVACVMQVE INGRESSI) TREMERE AC MISERESCERE (CVNCTOS / THEBARVM) tremebant cuncti et terrebantur aduentu Argiuorum, qui Thebanis consanguinitate coniuncti fuerant. Qui uero erant extranei miserebantur, cum in memoriam reducerent perituras Thebas. </p>
             </div>
 
@@ -12213,7 +12214,7 @@
                <p> TESSERA bellorum signum est, ut hospitalem tesseram dicimus. Veteres enim, quoniam non poterant omnes hospites suos nosse, tesseram illis dabant quam illi ad hospitia reuersi ostendebant praeposito hospiti unde intellegebantur hospites. Hic tamen proprie <hi rend="italic">teceram</hi> signum bellicum posuit. </p>
             </div>
 
-            <div type="schol" n="238-239">
+            <div type="schol" n="238">
                <p> (SVBEVNT) CAMPO QVI PROXIMVS VRBI / (DAMNATVS BELLIS PATET EXSPECTATQVE FVRORES) campum subeunt qui patet ante urbem, qui est ad sistenda bella damnatus id est destinatus. </p>
             </div>
 
@@ -12225,11 +12226,11 @@
                <p> ANTIGONE Oedipi filia, Polynicis soror. DEFENDITVR occultatur. </p>
             </div>
 
-            <div type="schol" n="245-246">
+            <div type="schol" n="245">
                <p> (IVXTAQVE COMES QVO LAIVS IBAT) / ARMIGERO qui Laii ante armiger fuit, eo nunc Antigone utebatur custode. </p>
             </div>
 
-            <div type="schol" n="247-250">
+            <div type="schol" n="247">
                <p> SPESNE (OBSTATVRA PELASGIS / HAEC VEXILLA PATER PELOPIS DESCENDERE TOTAS / AVDIMVS GENTES DIC O PRECOR EXTERA REGVM / AGMINA) hanc oeconomiam transtulit iuxta Homerum, qui per inquisitionem narrationem catalogi inducit. Hic per Antigonen ut illic per inquisitionem Priami et relationem Helenae. (SPESNE OBSTATVRA PELASGIS) / HAEC VEXILLA hoc est: Thebanorum militum manus poterit tam immensum Argiuorum exercitum superare? Et parua multitudo contra hostium copias haec ualebit? PATER non patrem genuinum Oedipum dicit, sed ut blandiretur nutritoribus Phorbantem patrem uocauit. <supplied>DIC O PRECOR EXTERA REGVM / AGMINA</supplied> de auxiliaribus quaerit cateruis, nam suos ciues agnoscit. </p>
             </div>
 
@@ -12237,7 +12238,7 @@
                <p> MENOECEVS hic se pro patria ex responso de muro praecipitem dedit, filius Creontis, qui Eteoclis post fratrum interitum accepit imperium. </p>
             </div>
 
-            <div type="schol" n="251-252">
+            <div type="schol" n="251">
                <p> AENA / SPHINGE casside cuius altitudinem in summitate adiecta auxerat Sphinge. Siue signa Thebanomm Sphingas esse monstrauit, ut enim apud Romanos aquilae habebantur signis appositae, sic Thebanorum signa Sphingos uultus ornabat. </p>
             </div>
 
@@ -12249,11 +12250,11 @@
                <p> TANAGRAE ciuitas Boeotiae quae nunc Poemandria nuncupatur. </p>
             </div>
 
-            <div type="schol" n="255">
+            <div type="schol" n="255a">
                <p> DRYAS hic est quem Diana sagittis propter interfectum Parthenopaeum occidit. </p>
             </div>
 
-            <div type="schol" n="255-257">
+            <div type="schol" n="255b">
                <p> (HIC CVI NIVEA ARMA) TRIDENTEM / (ATQVE AVRO RVDE FVLMEN HABENT ORIONIS ALTI / NON FALSVS VIRTVTE NEPOS) ut declararet se nepotem Orionis in scuto tridentem <supplied>et fulmen</supplied> pinxerat. ORIONIS ALTI huius talis est fabula: Pelargus quidam deorum cultor Iouem Neptunum Mercuriumque honorifice suscepit hospitio. A quibus huic est facultas oblata, ut, quia in deos religiosus exstiterat, ab his quod uellet optaret. Is cum adhuc aetatis nullum filium suscepisset, postulauit ut beneficio numinum proles sibi contingeret. Minxerunt ergo numina in bouis corium quem Pelargus diis immolauerat, et hoc defodi iusserunt exactisque nouem mensibus tolli. Ex quo natus est Orion, qui ex urina nomen accepit. <foreign xml:lang="grc">οὖρον</foreign> enim Graece 'urina' dicitur. Hic de stupro compellauit Dianam. Illa irata Terrae implorauit auxilium. Ictu scorpionis interiit quem Terra in ultionem Dianae exsilire compulerat. Alii uero dicunt Orionem ipsius Dianae sagittis fuisse prostratum. Vt Horatius:</p> 
                <l>'uirginea domitus sagitta'. </l>
             </div>
@@ -12279,7 +12280,7 @@
                   <supplied>S</supplied>COLON ... ETEONON ciuitates sunt Graeciae quae Thebanis auxilia miserunt. IVGIS ... INIQVIS arduis siue excelsis. </p>
             </div>
 
-            <div type="schol" n="267-268">
+            <div type="schol" n="267">
                <p> ATALANTEAM ... / (SCHOENON) duas Atalantas fuisse certissimum est: unam Arcadem, cuius Parthenopaeus est filius; aliam de Schoeno, nobilem cursu. NOTI ... (VESTIGIA) CAMPI in quibus solebat Atalante cum procis cursu contendere. COLVNT non uenerantur, sed habitant. </p>
             </div>
 
@@ -12292,15 +12293,15 @@
                <p> (SAEVAQVE) DIFFICILES EXCLVDERE (VVLNERA PELTAS) causa scilicet breuitatis. </p>
             </div>
 
-            <div type="schol" n="271-272">
+            <div type="schol" n="271">
                <p> (NEPTVNIA PLEBES) / ONCHESTI Onchestus Neptuni filius fuit qui ex suo nomine hanc condidit ciuitatem. MYCALESSOS promuntorium est ciuitatis eiusdem. </p>
             </div>
 
-            <div type="schol" n="273">
+            <div type="schol" n="273a">
                <p> PALLADIVSQVE MELAS Boeotiae fluuius Mineruae consecratus. Alii uolunt hunc Athenarum fluuium esse, quem <hi rend="italic">Palladium</hi> ad discretionem posuit. <hi rend="italic">Palladius</hi> ergo Atticus. Est enim alter Melas in Sicyoniorum finibus. Siue Melam montem dixit oliuetis consitum. </p>
             </div>
 
-            <div type="schol" n="273-274">
+            <div type="schol" n="273b">
                <p> (HECATAEA ... GVRGITE ...) / GARGAPHIE fons <del>Dianae</del> Hecatae consecratus. </p>
             </div>
 
@@ -12313,17 +12314,17 @@
                   <del>VIRGO</del> LYRA GALEAM (TAVROQVE INSIGNIS AVITO) in cono galeae lyram habeba<del>n</del>t propter musicam qua Thebani dicuntur muri fuisse constructi. TAVRO propter Iouem et Europam uel propter Cadmum qui bouem secutus est ut Thebanam conderet ciuitatem, uel, quod manifestius, propter Dircen nouercam quam ab his tauro constat esse religatam. </p>
             </div>
 
-            <div type="schol" n="280">
+            <div type="schol" n="280a">
                <p> MACTE ANIMO (IVVENIS) ut si diceret: perfectae indolis <supplied>esto</supplied>, iuuenis. 'Mactare' enim dictum est sacrificium perfecisse. Vnde Vergilius:</p> 
                <l>'macte noua uirtute, puer'</l> 
                <p>id est 'perfice te'. </p>
             </div>
 
-            <div type="schol" n="280-281">
+            <div type="schol" n="280b">
                <p> (MEDIOS PARTE IRE PER ENSES / NVDAQVE PRO CARIS) OPPONERE PECTORA (MVRIS) bene <hi rend="italic">opponere</hi> dixit ad defensionem murorum. </p>
             </div>
 
-            <div type="schol" n="282-285">
+            <div type="schol" n="282">
                <p> (VOS ETIAM NOSTRIS) HELICONIA TVRBA (VENITIS / ADDERE REBVS OPEM TVQVE O PERMESSE CANORIS / ET FELIX OLMIE VADIS ARMASTIS ALVMNOS / BELLORVM RESIDES) per <hi rend="italic">Heliconia</hi> intellegi uult poetas etiam ad auxilia conuenisse et commemorat fluuios Musis dicatos: Heliconium, Permessum, Olmium. <supplied>CANORIS / ... FELIX OLMIE VADIS</supplied> quia apud Olmium fluuium multi sunt cygni et hi qui ab hoc fluuio ueniebant cygnorum more cantabant. </p>
             </div>
 
@@ -12331,19 +12332,19 @@
                <p> RENIDENTEM splendentem niue deposita<del>m</del>.</p>
             </div>
 
-            <div type="schol" n="296-297">
+            <div type="schol" n="296">
                <p> SED AEVI / CONFVDERE MODOS aetatis suae, dum paene aequales sunt, spatia confuderunt. NYMPHE ad ornamentum carminis sui Graecum nomen accepit. <foreign xml:lang="grc">νύμφη</foreign> enim Graece dicitur sponsa. </p>
             </div>
 
-            <div type="schol" n="298-299">
+            <div type="schol" n="298">
                <p> MARITI / IGNIBVS uiriles amores concubitus uoluptatem dicit. </p>
             </div>
 
-            <div type="schol" n="300">
+            <div type="schol" n="300a">
                <p> NEC LONGVM deest 'tempus transiit'. </p>
             </div>
 
-            <div type="schol" n="300-302">
+            <div type="schol" n="300b">
                <p> ET PVLCHER ALATREVS / (EDITVS AC PRIMAE GENITOREM IN FLORE IVVENTAE / CONSEQVITVR) natus est filius qui patri puero crescendi celeritate paene aequaeuus est. </p>
             </div>
 
@@ -12351,17 +12352,17 @@
                <p> TRAXITQVE NOTAS similitudinem patris in suo uultu signauit. </p>
             </div>
 
-            <div type="schol" n="303-304">
+            <div type="schol" n="303">
                <p> (ET NVNC SIC FRATRES MENTITO NOMINE GAVDENT) / PLVS PATER (HVNC OLIM IVVAT ET VENTVRA SENECTVS) <supplied>
                      <hi rend="italic">mentito nomine</hi>
                   </supplied> est nomen 'frater'. Hoc est: gaudet aetate antecedenti desiderio <del>VENTVRA SENECTVS</del> uno tempore senescentium patris et filii. </p>
             </div>
 
-            <div type="schol" n="307">
+            <div type="schol" n="307a">
                <p> EXILEM (GLISANTA) sterilem agrum habentem. CORONIAM nomen a Coro Centauro tractum, a quo et ciuitas dicta, quem reliqui Centauri uelut palum caedentes terrae affixerunt. </p>
             </div>
 
-            <div type="schol" n="307-308">
+            <div type="schol" n="307b">
                <p> (FERACEM / MESSE CORONIAM) BACCHO GLISANTA (COLENTES) duae ciuitates duorum numinum <supplied>im</supplied>pari gaudent munere: Coronia Baccho <supplied>in</supplied>fertilis est, Glisas Cerere infecunda tristatur. Nec euenit ut prouentu suo utraque ciuitas frumenti et uini bono gauderet. </p>
             </div>
 
@@ -12384,7 +12385,7 @@
                <l>'accipit Asopus cursus'. </l>
             </div>
 
-            <div type="schol" n="321-322">
+            <div type="schol" n="321">
                <p> (NONDVM ISTA) LICEBANT / (ETIAM SVPERIS) uitiare uirgines alienas. </p>
             </div>
 
@@ -12396,7 +12397,7 @@
                <p> AETNAEOS (IN CAELVM EFFLARE VAPORES) <supplied>Aetnaeos</supplied> fulmineos, in similitudinem Aetnae. Fulminatus est Asopus et ipsa aqua efflat adhuc fulminis minas. </p>
             </div>
 
-            <div type="schol" n="330-331">
+            <div type="schol" n="330">
                <p> (DVCIT) ITONAEOS (ET ALALCOMENAEA MINERVAE / AGMINA) <supplied>
                      <hi rend="italic">Itonaeos</hi>
                   </supplied> ut ipse supra:</p> 
@@ -12419,20 +12420,20 @@
                <l>'nuntiat excubiis uigiles arsisse Plataeas'. </l>
             </div>
 
-            <div type="schol" n="333-334">
+            <div type="schol" n="333">
                <p> REFLVVMQVE (MEATV / EVRIPVM) quia septies in die fluit et refluit quemadmodum Siciliense fretum, quod certis horis fluit ac refluit. Vnde Lucanus:</p> 
                <l>'Euripusque trahit cursum mutantibus undis'.</l>
             </div>
 
-            <div type="schol" n="334">
+            <div type="schol" n="334a">
                <p> (QVA) NOSTER <del>HABET</del> bene <hi rend="italic">noster</hi>, quia est Boeotiae et Euboeae. </p>
             </div>
 
-            <div type="schol" n="334-335">
+            <div type="schol" n="334b">
                <p> (TEQVE VLTIMA TRACTV) / ANTHEDON ciuitas Boeotiae inter Euboeam et Boeotiam constituta. </p>
             </div>
 
-            <div type="schol" n="335-337">
+            <div type="schol" n="335">
                <p> (VBI GRAMINEO DE LITORE) GLAVCVS / (POSCENTES IRRVPIT AQVAS IAM CRINE GENISQVE / CAERVLVS ET MIXTOS EXPAVIT AB INGVINE PISCES) hic piscator fuit de Anthedone ciuitate, qui extractam mari praedam proiecit in litore. Pisces herbarum tactu reuixerunt. Intellexit Glaucus hanc illorum graminum naturam esse ut immortales efficerentur qui ea gustassent. Itaque <supplied>ea</supplied> auellit et assumpsit. Quo facto ilico deposito humano corpore in marinum uersus est deum. POSCENTIS ... AQVAS quasi eum desiderarent maria deum sibi fieri. (ET MIXTOS) EXPAVIT (AB INGVINE PISCES) postquam se uidit Glaucus deformem uel biformem factum, expauit. Ita enim marina numina Vergilius formauit dicendo:</p>
                <lg>
                   <l>'cui laterum tenus hispida nanti</l>
@@ -12453,7 +12454,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="340-342">
+            <div type="schol" n="340">
                <p> (TV QVOQVE PRAECLARVM FORMA) CEPHISE (DEDISSES / NARCISSVM SED THESPIACIS IAM PALLET IN AGRIS / O TRVX PVER ORBATA FLOREM PATER ALLVIS VNDA) Cephisus fluuius, Narcissi pater, cum caede Zephyri prostratus esset, Apollinis miseratione sanatus est. Cuius etiam Lucanus meminit dicendo:</p>
                <lg>
                   <l>'quos impiger <supplied>ambit</supplied>
@@ -12478,7 +12479,7 @@
                   </supplied> Aug<supplied>i</supplied>ae famosissimi. </p>
             </div>
 
-            <div type="schol" n="346-347">
+            <div type="schol" n="346">
                <p> (PARNASSON VTRVMQVE) / AVT CIRRHAM Parnassos mons est Phocidos qui in duo iuga diuiditur id est in Cirrham et Nysam. Cirrha ergo etiam ciuitas dicitur circa montem Parnassum posita. Haec habet stagnum Apollini consecratum, de quo ipse ait superius:</p> 
                <l>'si stagna peti Cirrhaea bicorni'. </l>
             </div>
@@ -12487,7 +12488,7 @@
                <p> CORYCIVMQVE NEMVS quidam 'Ogygium' legunt, quo uocabulo antiqui Thebanos intellegi uolebant, quia post Cadmum Ogygius Thebas rexit. Post etiam nemori est hoc nomen impositum. Etiam tumulus circa Thebas ita uocatur. </p>
             </div>
 
-            <div type="schol" n="351-353">
+            <div type="schol" n="351">
                <p> (OMNIBVS IMMIXTAS CONO SVPER) ASPICE LAVRVS / (ARMAQVE VEL TITYON VEL DELON HABENTIA VEL QVAS / HIC DEVS INNVMERA LAXAVIT CAEDE PHARETRAS) ita se deuotos Apollini demonstrabant ut et lauro coronati incederent et maximos eius actus scutorum aptarent insignibus. (VEL QVAS / HIC DEVS INNVMERA LAXAVIT) CAEDE PHARETRAS Niobe, uxor Amphionis, cum quattuordecim procreasset filios — septem uirilis sexus, septem feminei — fecunditatem partuum suorum Latonae praeposuit. Qua re commota filios suos Apollinem et Dianam in ultionem suae instigauit iniuriae. Cuius Niobae filios quattuordecim uterque deus sagittis exstinxit, Apollo pueros, puellas Diana. </p>
             </div>
 
@@ -12495,13 +12496,13 @@
                <p> NAVBOLVS hic Laii fuit auriga. </p>
             </div>
 
-            <div type="schol" n="356-358">
+            <div type="schol" n="356">
                <p> (ADHVC CVRRVS) SECVRA(QVE LORA TENEBAT / CVM TVA SVBTER EQVOS IACVIT CONVVLSA CRVENTIS / ICTIBVS O VTINAM NOSTRO CVM SANGVINE CERVIX) <supplied>
                      <hi rend="italic">secura</hi>
                   </supplied> sine metu futuri parricidii. (O VTINAM) NOSTRO CVM SANGVINE <del>CERVIX</del> ostendit eo tempore quo Naubolus Laii auriga fuit se Phorbas armigerum fuisse et optat ut eo errore, quo occisus est Laius, ille pariter interisset ne ad uidendum fratrum scelera seruaretur. </p>
             </div>
 
-            <div type="schol" n="360-361">
+            <div type="schol" n="360">
                <p> (VOCISQVE) REPENS (SINGVLTVS APERTVM / INTERCEPIT ITER) <supplied>
                      <hi rend="italic">repens</hi>
                   </supplied> et aduerbium potest esse temporis et nomen participiale. Ostendit Phorbantem loqui intercepta singultibus uoce minime potuisse. </p>
@@ -12559,7 +12560,7 @@
                <p> DVM TERRA RECENS dum adhuc ros in gramine est, quo tempore gratiora sunt pecoribus pascua. </p>
             </div>
 
-            <div type="schol" n="396-397">
+            <div type="schol" n="396">
                <p> HVMVM TRACTVRA (PARENTVM / VBERA) lactis pondere praegrauata. </p>
             </div>
 
@@ -12567,7 +12568,7 @@
                <p> SVCCIDVAS tardantes a succidendo, siue, ut feturae succedentem subolem demonstraret, <hi rend="italic">succiduas</hi> dixit id est uicarias. </p>
             </div>
 
-            <div type="schol" n="401-402">
+            <div type="schol" n="401">
                <p> (PROPERATVR IN HOSTEM) / MORE FVGAE fecit enim formido ueloces. </p>
             </div>
 
@@ -12579,24 +12580,24 @@
                <p> (QVIPPE SERVNT DIROS MONITVS) VOLVCRESQVE FERAEQVE hoc loco prodigiales res poeta describit. </p>
             </div>
 
-            <div type="schol" n="405-406">
+            <div type="schol" n="405">
                <p> SIDERAQVE ... / (INFESTVMQVE TONAT PATER ET MALA FVLGVRA LVCENT) ignota sidera apparere tempore belli certissimum est et frequentia fulmina fieri. (AVERSIQVE SVIS DECVRSIBVS) AMNES inter cetera prodigiorum genera fluuiorum etiam incrementa ponuntur tempore incerto. </p>
             </div>
 
-            <div type="schol" n="&lt;410&gt;">
+            <div type="schol" n="410">
                <p> 
                   <supplied>TVNC ET APOLLINEAE TACVERE ORACVLA CIRRHAE</supplied> in Cirrha tantum prospera deorum dabantur oracula. Nam cui exitium imminebat taciturnitate templi penitus damnabatur. </p>
             </div>
 
-            <div type="schol" n="411 ELEVSIN">
-               <p> ciuitas est Atticae regionis haud longe ab Athenis in qua regnauit Celeus, qui Cererem dum filiam quaereret liberalissime suscepit hospitio. In qua ciuitate Cereris sacra consueuerant uirginum ululatibus et saltationibus celebrari. </p>
+            <div type="schol" n="411">
+               <p> ELEVSIN ciuitas est Atticae regionis haud longe ab Athenis in qua regnauit Celeus, qui Cererem dum filiam quaereret liberalissime suscepit hospitio. In qua ciuitate Cereris sacra consueuerant uirginum ululatibus et saltationibus celebrari. </p>
             </div>
 
-            <div type="schol" n="412-413">
+            <div type="schol" n="412">
                <p> (ET TEMPLIS) SPARTE (PRAESAGA RECLVSIS / VIDIT AMYCLAEOS FACINVS CONCVRRERE FRATRES) apud Spartam aperto templo eodem tempore Castor et Pollux dimicare inter se uisi sunt. Ex quo omine colligebant Eteoclen et Polynicen impia inter se bella gesturos. <supplied>SPARTE PRAESAGA</supplied> quia Apollinis oraculum est illic et Hyacinthi Amyclaei. AMYCLAEOS ... (FRATRES) <hi rend="italic">Amyclaei fratres</hi> sunt Castor et Pollux. </p>
             </div>
 
-            <div type="schol" n="414-415">
+            <div type="schol" n="414">
                <p> (ARCADES INSANAS LATRARE) LYCAONIS VMBRAS / (NOCTE FERVNT TACITA) Lycaon pater Helicae ursae fuisse dicitur, qui dolore stupratae a Ioue filiae deos humanarum carnium cibis uiolauit. Ob quam rem in formam lupi dicitur esse conuersus. </p>
             </div>
 
@@ -12604,13 +12605,13 @@
                <p> SAEVO ... CAMPO in quo uictor filiae sponsos solitus erat necare. </p>
             </div>
 
-            <div type="schol" n="[416]"> 
+            <div type="schol" n="416a"> 
                <p>
                   <del> OENOMAVM Atalantes patrem.</del>
                </p>
             </div>
 
-            <div type="schol" n="416-417">
+            <div type="schol" n="416b">
                <p> (ACHELOON VTROQVE) / DEFORMEM CORNV cum uno cornu ante fuerit ab Hercule uiduatus. Quare eum nunc poeta ambo amisisse describit ut omen diri belli tradi possit quod utroque cornu Achelous truncatus uideretur, quod signum periturorum germanorum manifestissimum fuit. </p>
             </div>
 
@@ -12626,17 +12627,17 @@
                </lg>
             </div>
 
-            <div type="schol" n="[421]">
+            <div type="schol" n="421">
                <p> 
                   <del>PALAEMONA <del>PONTO</del> Palaemon deus marinus est qui portubus praeest. Cuius nota est fabula. Athamas post furorem a Iunone immissum cum occiso Learcho Melicertam, alterum filium suum, cum uxore sua Ino persequeretur et se illi in mare praecipitassent, uoluntate numinum in deos uersi sunt: Melicerta in Portunum, qui Graece Palaemon dicitur, Ino in Matrem Matutam, quae Graece dicitur Leucothea.</del>
                </p>
             </div>
 
-            <div type="schol" n="422-423">
+            <div type="schol" n="422">
                <p> (HAEC AVDIT PELOPEA PHALANX SED BELLICVS ARDOR / CONSILIIS OBSTAT DIVVM) PROHIBETQVE TIMERI quamuis imminentia mala etiam prodigiis nuntientur, ne caueant homines, numina credi uetant. </p>
             </div>
 
-            <div type="schol" n="424-425">
+            <div type="schol" n="424">
                <p> (IAM RIPAS) ASOPE TVAS (BOEOTAQVE VENTVM / FLVMINA) <supplied>
                      <hi rend="italic">Asope</hi>
                   </supplied> Thebarum fluuius, cuius Aeginam filiam in aquilam mutatus Iuppiter uitiauit. <del>FLVMINIS</del> aduentus describitur Argiuorum. </p>
@@ -12654,19 +12655,19 @@
                <p> ALTERA TELLVS ulterior ripa. </p>
             </div>
 
-            <div type="schol" n="438-440">
+            <div type="schol" n="438">
                <p> (AST VBI DVCTOR / TAVRVS INIT FECITQVE VADVM TVNC MOLLIOR VNDA / TVNC FACILES SALTVS VISAEQVE) ACCEDERE RIPAE ad opinionem rettulit armentorum quibus transeunte tauro fluuii altitudo minor et latitudo breuior uidetur effecta. </p>
             </div>
 
-            <div type="schol" n="441-442">
+            <div type="schol" n="441">
                <p> (HAVD PROCVL INDE IVGVM TVTISQVE) ACCOMMODA CASTRIS / (ARVA NOTANT) positio castrorum describitur. </p>
             </div>
 
-            <div type="schol" n="445-446">
+            <div type="schol" n="445">
                <p> (NVLLIQVE ALIIS A MONTIBVS) INSTANT / (DESPECTVS) id est: nullus erat tam excelsus prope collis cuius altitudo uel despectus castris esse posset incommodus. </p>
             </div>
 
-            <div type="schol" n="446-447">
+            <div type="schol" n="446">
                <p> NEC LONGA LABOR (MVNIMINA DVRVS / ADDIDIT) nec multo labore dicit castra munienda. </p>
             </div>
 
@@ -12690,15 +12691,15 @@
                <p> (INVALIDAEQVE) AMPHIONIS ARCES prae timore <del>arces prae timore</del> somniantibus muri Thebani, quos Amphion exstruxerat, uidebantur inualidi. </p>
             </div>
 
-            <div type="schol" n="457-458">
+            <div type="schol" n="457">
                <p> (RVMOR VBIQVE ALIOS PLVRESQVE ADNVNTIAT HOSTES) / MAIORESQVE TIMOR maiora enim nobis uidentur omnia quae timemus. </p>
             </div>
 
-            <div type="schol" n="462-463">
+            <div type="schol" n="462">
                <p> (MISERIQVE ROGOS ET CRASTINA) MANDANT / FVNERA commendant ut, si mortui fuerint, eorum sepulturas procurent. </p>
             </div>
 
-            <div type="schol" n="463-464">
+            <div type="schol" n="463">
                <p> SI TENVIS DIMISIT LVMINA SOMNVS / (BELLA GERVNT) id est: ad soporem laxauit a rigore uigiliarum. Si leuis ergo somnus eos oppresserit, uidentur sibi bellare. </p>
             </div>
 
@@ -12711,15 +12712,15 @@
                   <del>IAM</del> GELIDAM PHOEBEN noctem. Lunam enim pro nocte posuit. </p>
             </div>
 
-            <div type="schol" n="471">
+            <div type="schol" n="471a">
                <p> HAVSERAT attenuauerat, absconderat. </p>
             </div>
 
-            <div type="schol" n="471-472">
+            <div type="schol" n="471b">
                <p> TVMET (IGNE FVTVRO / OCEANVS) feruet, quia ipsum parturit Solem. </p>
             </div>
 
-            <div type="schol" n="472-473">
+            <div type="schol" n="472">
                <p> (LATEQVE NOVO TITANE) RECLVSVM / (AEQVOR ANHELANTVM RADIIS SVBSIDIT EQVORVM) <supplied>
                      <hi rend="italic">reclusum</hi>
                   </supplied> 
@@ -12728,7 +12729,7 @@
                   </supplied> siue sedatum. Oriente enim sole tempestas quiescit. </p>
             </div>
 
-            <div type="schol" n="&lt;475-476&gt;">
+            <div type="schol" n="475">
                <p> 
                   <supplied>BRACCHIA PLANCTV / NIGRA FERENS</supplied> nigro amictu tecta. </p>
             </div>
@@ -12738,7 +12739,7 @@
                <l>'odere sorores'. </l>
             </div>
 
-            <div type="schol" n="485-486">
+            <div type="schol" n="485">
                <p> (TREPIDI VISAM) EXPAVERE MANIPLI / (AVDITAMQVE MAGIS) expauerunt armati Furiae habitum qui, matrem si eminus cognouissent, poterant reuereri. </p>
             </div>
 
@@ -12746,7 +12747,7 @@
                <p> MONSTRAVERIT HOSTEM pro 'monstret'. </p>
             </div>
 
-            <div type="schol" n="494-495">
+            <div type="schol" n="494">
                <p> MATREM / MATREM <foreign xml:lang="grc">ἀναδίπλωσις</foreign>.</p>
             </div>
 
@@ -12778,11 +12779,11 @@
                <p> (ET VESTROS ETIAMNVM) EXCVSO FVRORES defendo quasi iustos in nocentia<supplied>m</supplied> mea<supplied>m</supplied>.</p>
             </div>
 
-            <div type="schol" n="522-524">
+            <div type="schol" n="522">
                <p> (SI VOBIS HIC PARVO IN TEMPORE CARVS / SITQVE PRECOR) QVID ME ORO DECET (QVIDVE ISTA PELASGI / VBERA) id est: multo plus uobis ego illum diligere debeo quem peperi. </p>
             </div>
 
-            <div type="schol" n="524-525">
+            <div type="schol" n="524">
                <p> (AB) HYRCANIS (HOC ODRYSIISVE TVLISSEM / REGIBVS ET SI QVI NOSTROS VICERE FVRORES) <supplied>
                      <hi rend="italic">Hyrcanis</hi>
                   </supplied> Armeniis. Hoc dicit: si hoc a ferissimis gentibus postulassem, potuissem mereri, ut, me media, fratrum discordia sopiretur. (SI QVI NOSTROS) VICERE FVRORES qui sunt nostris sceleribus saeuiores. </p>
@@ -12792,7 +12793,7 @@
                <p> NVTANTES (... GALEAS) capitum motu trementes. </p>
             </div>
 
-            <div type="schol" n="529-531">
+            <div type="schol" n="529">
                <p> (QVALES VBI TELA VIROSQVE / PECTORIS IMPVLSV RABIDI STRAVERE LEONES / PROTINVS) IRA MINOR uictis enim comminus uenabulis leonum ira <supplied>quiescit</supplied>.</p>
             </div>
 
@@ -12845,7 +12846,7 @@
                <p> (QVIPPE NIHIL) GRASSATA (FAMES) quae nihil depraedando uastauit. MANVS OBVIA (PASCIT) unde mansuetae dictae sunt ferae, id est: quae manu pasci consueuerunt. </p>
             </div>
 
-            <div type="schol" n="576-577">
+            <div type="schol" n="576">
                <p> VAGA RVRE (QVIES SI QVANDO ... / ... INIERE) zeu<supplied>g</supplied>ma est: siquando uaga<supplied>ri</supplied> rur<supplied>e et rur</supplied>a inire quies est. Aut certe <hi rend="italic">uaga</hi> 
                   <del>
                      <hi rend="italic">rure</hi>
@@ -12876,7 +12877,7 @@
                <p> (NEC DEFVIT) OMEN quod ab auriga incipit. </p>
             </div>
 
-            <div type="schol" n="&lt;587&gt;">
+            <div type="schol" n="587">
                <p> 
                   <supplied>IS PRIMVS</supplied> qui cito moriturus. </p>
             </div>
@@ -12889,7 +12890,7 @@
                <p> (MVLTVMQVE) HASTILE (RESVMENS) hoc est: multa simul sumpsit hastilia. </p>
             </div>
 
-            <div type="schol" n="603-605">
+            <div type="schol" n="603">
                <p> (CVLTOR BACCHEVS) ACONTEA (PHEGEVS / ... / COMMINVS ENSE PETIT) hunc Acontea, qui tigres occidit, Phegeus ense percussit. </p>
             </div>
 
@@ -12914,7 +12915,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="622-623">
+            <div type="schol" n="622">
                <p> RETRO VEXILLA (TVBAEQVE / POST TERGVM ET LITVI BELLVM INVENERE SECVTI) ut ostenderet tumultuarie pugnari, peruersum ordinem exercitus monstrat. Dicit <hi rend="italic">retro</hi> post aciem esse uexilla, quae solent militum cuneos anteire. </p>
             </div>
 
@@ -12923,7 +12924,7 @@
                   <del>HORRENT</del> TYRRHENOS (... TVMVLTVS) tubarum cantus. </p>
             </div>
 
-            <div type="schol" n="632-633">
+            <div type="schol" n="632">
                <p> SIDONIVM (PTERELAN SONIPES MALE FIDVS IN ARMIS / RVMPENTEM FRENOS DIVERSA PER AGMINA RAPTAT) <supplied>
                      <hi rend="italic">Sidonium</hi>
                   </supplied> Thebanum. Nunc ergo poeta diuersorum mortes ueluti Musa monente describit. MALE FIDVS infrenis, qui timore armorum teneri non poterat. RVMPENTEM retro trahentem ut nimio conamine frena rumpere crederetur. </p>
@@ -12941,7 +12942,7 @@
                <p> IN TERGA equina. <supplied>RECVMBIT</supplied> quasi dominus. </p>
             </div>
 
-            <div type="schol" n="640-642">
+            <div type="schol" n="640">
                <p> (STERNVNT ALTERNA FVRENTES / HIPPOMEDON SYBARIN PYLIVM PERIPHANTA MENOECEVS) / PARTHENOPAEVS (ITYN) diuersorum mortes Vergiliane poeta describit. MENOECEVS iste Thebanus est quem in catalogo Phorbas Antigonae monstrauit euntem inter duces. Dixit enim:</p> 
                <l>'quae noster signa Menoeceus'. </l>
             </div>
@@ -13004,7 +13005,7 @@
                <p> LYMPHANTE DEO hoc est: furiis incitante. </p>
             </div>
 
-            <div type="schol" n="663-664">
+            <div type="schol" n="663">
                <p> (HAEC OMINE DEXTRO / MOENIA CIRRHAEA MONSTRAVIT) APOLLO IVVENCA quia Cadmus Apollinis oraculo bouem secutus est et, ubi procubuit, illic condidit Thebas et ex bouis uocabulo regionem ipsam 'Boeotiam' nominauit. </p>
             </div>
 
@@ -13029,7 +13030,7 @@
                <p> LIBRA<supplied>BA</supplied>T considerando ubi percutiat. CVPRESSVM hastam significauit. </p>
             </div>
 
-            <div type="schol" n="678-679">
+            <div type="schol" n="678">
                <p> (VTINAM IPSE VENIRET) / CVI FVRIS id est Liber, in cuius honorem furibundus aduenis. </p>
             </div>
 
@@ -13062,7 +13063,7 @@
                <p> AD CIVES contra ciues. </p>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691">
                <p> AC MVLTO PVLVERE VERTIT / CAMPVM INDIGNANTEM quia excitus puluis notitiam loci commutat. </p>
             </div>
 
@@ -13075,11 +13076,11 @@
                <p> SIDERE splendore uel gratia. </p>
             </div>
 
-            <div type="schol" n="699-700">
+            <div type="schol" n="699">
                <p> CERTVS ET IPSE NECIS (VIRES FIDVCIA LETI / SVGGERIT) quia augurio suam praeuiderat mortem. Desperatione ergo uitae fortius dimicat. </p>
             </div>
 
-            <div type="schol" n="[701]">
+            <div type="schol" n="701a">
                <p> 
                   <del>LAETIOR</del> aiunt enim futura sentire morituros. Vt Vergilius:</p>
                <lg>
@@ -13088,7 +13089,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="701">
+            <div type="schol" n="701b">
                <p> EXPERIENTIA CAELI doctrina et scientia auguriorum. </p>
             </div>
 
@@ -13106,7 +13107,7 @@
                <p> DIVERSVS dissimilis. </p>
             </div>
 
-            <div type="schol" n="[710-711]">
+            <div type="schol" n="710">
                <p> 
                   <del>IMMOLAT VMBRIS / (IPSE SVIS) quasi uictimam, ut in sacris ipse consueuerat. Nam hoc uerbo poeta ad sacerdotis nomen allusit. Aptum est enim occidenti sacerdoti tale uerbum. Vergilius de occiso sacerdote dixit:</del>
                </p>
@@ -13123,7 +13124,7 @@
                </p>
             </div>
 
-            <div type="schol" n="712-713">
+            <div type="schol" n="712">
                <p> (FALCATO CLONIN ET CHREMETAONA) CVRRV / COMMINVS (HVNC STANTEM METIT) solent enim in axibus curruum falces exstare quae incurrentes hostilem populum caedant. </p>
             </div>
 
@@ -13131,7 +13132,7 @@
                <p> SACRVM consecratum. </p>
             </div>
 
-            <div type="schol" n="716-717">
+            <div type="schol" n="716">
                <p> INVITVS (IAM FRAXINEVM DIMISERAT HASTAE / ROBVR ET EXCVSSIS APPARVIT INFVLA CRISTIS) ostendit quomodo <hi rend="italic">inuitus</hi>. Dicit enim: ante dimiserat telum quam Lycorea agnouisset Apollini consecratum. </p>
             </div>
 
@@ -13143,21 +13144,21 @@
                <p> AVERTERE ad se conuertere. </p>
             </div>
 
-            <div type="schol" n="725">
+            <div type="schol" n="725a">
                <p> HAVD IPSE MINVS non minus Hypseus Amphiarao. </p>
             </div>
 
-            <div type="schol" n="725-726">
+            <div type="schol" n="725b">
                <p> TIRYNTHIA (FVNDENS) / ROBORA <supplied>
                      <hi rend="italic">robora</hi>
                   </supplied> agmina. Id est: Nemeaeos iuuenes et Graecam uastabat aciem. </p>
             </div>
 
-            <div type="schol" n="726-727">
+            <div type="schol" n="726">
                <p> (SED VISO PRAESENS MINOR) AVGVRE SANGVIS / (ILLVM ARMIS ANIMISQVE CVPIT) id est: cupiens cum Amphiarao confligere ceteros quasi ignauos contemnebat occidere. </p>
             </div>
 
-            <div type="schol" n="727-728">
+            <div type="schol" n="727">
                <p> PROHIBEBAT INIQVO / (AGMINE CONSERTVM CVNEI LATVS) id est: prohibebat Hypseum multitudo quae stipauerat Amphiaraum. </p>
             </div>
 
@@ -13165,7 +13166,7 @@
                <p> INDE de ipso cuneo. </p>
             </div>
 
-            <div type="schol" n="730-732">
+            <div type="schol" n="730">
                <p> (AONIDVM DIVES LARGITOR AQVARVM / CLARE GIGANTEIS ETIAMNVM) ASOPE FAVILLIS / (DA NVMEN DEXTRAE) fluuium inuocat quem dudum a Ioue diximus fulminatum, qui indignatione ereptae filiae Ioui intulit bellum. Quo facto igni diuino percussus est et, ut infamia eius excepti fulminis in aeternum maneret, dicitur hodieque illo tempore quo ictus est prunis ardentibus fluere. </p>
             </div>
 
@@ -13177,11 +13178,11 @@
                <p> INDVLGERE VOLENTEM concedere cupientem. </p>
             </div>
 
-            <div type="schol" n="741-742">
+            <div type="schol" n="741">
                <p> VVLNERA CITRA / (MORS TREPIDIS IGNAVA VENIT) sine uulneribus solo terrore Amphiarai moriebantur. IGNAVA sine ferro. </p>
             </div>
 
-            <div type="schol" n="742-743">
+            <div type="schol" n="742">
                <p> DVBIVMQVE TVENTI / (PRESSERIT INFESTOS ONVS IMPVLERITNE IVGALES) dubium erat uidentibus utrum onere tardatus esset Amphiarai an uelocior factus. </p>
             </div>
 
@@ -13189,11 +13190,11 @@
                <p> (DESILIT HORRENDVS) CAMPO TIMOR montis ruina quae de alto saltibus cadit. </p>
             </div>
 
-            <div type="schol" n="752-753">
+            <div type="schol" n="752">
                <p> (IPSE SEDENS) TELIS PARITER(QVE MINISTRAT HABENIS / DELIVS) armigeri et aurigae Apollo implebat officium. </p>
             </div>
 
-            <div type="schol" n="753-754">
+            <div type="schol" n="753">
                <p> (ADVERSAQVE FLECTIT / SPICVLA) FORTVNAM(QVE HASTIS VENIENTIBVS AVFERT) casum felicem siue euentum feriendi hastis contra Amphiaraum uenientibus detorquebat. </p>
             </div>
 
@@ -13205,21 +13206,21 @@
                <p> DEDIT immisit. </p>
             </div>
 
-            <div type="schol" n="761">
+            <div type="schol" n="761a">
                <p> RIMANTVR TERRAS rimas agunt id est scrutantur. <hi rend="italic">Rimari</hi> enim proprie dicuntur sues, cum pascentes cibi gratia terram uertunt. </p>
             </div>
 
-            <div type="schol" n="761-762">
+            <div type="schol" n="761b">
                <p> (OMNISQVE) PER ARTVS / (SVLCVS ET INCISIS ALTVM RVBET ORBITA MEMBRIS) <supplied>
                      <hi rend="italic">per artus</hi>
                   </supplied> cadauerum membra. Haec omnia signa erant hiatus futuri. </p>
             </div>
 
-            <div type="schol" n="766-767">
+            <div type="schol" n="766">
                <p> NEC INSISTI MADIDVS (DAT TEMO ROTAEQVE / SANGVINE DIFFICILES) abundantia sanguinis maiorem Amphiarao currendi lapsum faciebat. </p>
             </div>
 
-            <div type="schol" n="&lt;767-768&gt;">
+            <div type="schol" n="767">
                <p> 
                   <supplied>TARDIOR VNGVLA FOSSIS / VISCERIBVS</supplied> graues nimietate sanguinis equorum gressus. </p>
             </div>
@@ -13236,7 +13237,7 @@
                <p> (QVIS TANTVS) MISERIS HONOR parenthesis. Humiliter enim dixit se non fuisse dignum tanto honore numinis. </p>
             </div>
 
-            <div type="schol" n="784-785">
+            <div type="schol" n="784">
                <p> (ACCIPE COMMISSVM CAPITI DECVS ACCIPE LAVRVS / QVAS EREBO) DEFERRE NEFAS scelus esse dicit ornamenta infularum et sacras laurus secum ad inferos ferre. </p>
             </div>
 
@@ -13244,7 +13245,7 @@
                <p> (PVLCHRVM NATI) COMMENDO FVROREM quia in occidenda matre pro pietate peccabit. </p>
             </div>
 
-            <div type="schol" n="791-793">
+            <div type="schol" n="791">
                <p> (NON ALITER CAECO NOCTVRNI TVRBINE CAVRI) / SCIT PERITVRA RATIS (CVM IAM DAMNATA SORORIS / IGNE THERAPNAE FVGERVNT CARBASA FRATRES) parenthesis est: non aliter scit peritura ratis. Sic et Apollo sciebat periturum Amphiaraum et se subuenire non posse. (DAMNATA) SORORIS / IGNE quia nautae, cum stellam Helenae uiderint — quae Vrania dicitur, cuius tanta uis est incendii ut malum cauet et nauis ima pertundat ut, etiam si aes fuerit, hoc calore soluatur — ergo si haec stella naui insederit, sciunt se nautae sine dubio perituros. Econtra Castorum sidera sunt nauigantibus salutaria. THERAPNAEI Therapnae Laconicae ciuitas est. </p>
             </div>
 
@@ -13252,7 +13253,7 @@
                <p> (TERRAE / SVMMAQVE) TERGA <del>QVATI</del> superficies terrae. </p>
             </div>
 
-            <div type="schol" n="799-800">
+            <div type="schol" n="799">
                <p> (IAM) FRONDEA NVTANT / (CVLMINA IAM MVRI) iam siluis et cacuminibus arborum et muris dabatur cum hiatu ipsius terrae confusio. </p>
             </div>
 
@@ -13260,7 +13261,7 @@
                <p> EXCIDERVNT IRAE transitum est a causa bellorum. </p>
             </div>
 
-            <div type="schol" n="805-806">
+            <div type="schol" n="805">
                <p> BENIGNA / (TEMPESTAS) <hi rend="italic">benignam</hi> tempestatem dixit quia naualia certamina prohibentur. </p>
             </div>
 
@@ -13268,11 +13269,11 @@
                <p> (TALIS ERAT CAMPO) BELLI FLVITANTIS (IMAGO) naualis certaminis speciem titubantibus militibus fecerat terrae motus. </p>
             </div>
 
-            <div type="schol" n="809-816">
+            <div type="schol" n="809">
                <p> SIVE LABORANTES (CONCEPTO ... FRATRIBVS) dubitabant quae causa esset tremoris illius, credentes terram mole et ui uentorum fuisse laxatam, qui per cauernas terrae discurrunt, <supplied>uel</supplied> hiulca<supplied>m</supplied> uetustate soluisse uel situ aquae in solutionem uertisse, aut certe elemento oppressa<supplied>m</supplied> maris undarum cessisse uirtutibus aut ipsam terram fratribus perituris tremores ad omen fecisse. </p>
             </div>
 
-            <div type="schol" n="811-812">
+            <div type="schol" n="811">
                <p> (FERENDO) / VNDA LATENS dicunt enim quidam terram aqua fulciri uel ferri. </p>
             </div>
 
@@ -13291,7 +13292,7 @@
 
          </div>
 
-         <div type="lib" n="VIII">
+         <div type="lib" n="8">
             <head>LIBER VIII</head>
 
             <div type="pr" n="pr">
@@ -13308,23 +13309,23 @@
                <p>tamquam in rem periculosam. </p>
             </div>
 
-            <div type="schol" n="5">
+            <div type="schol" n="5a">
                <p> CORPVSQVE NOVVM id est uiuum, siue non deposita apud superos carne. </p>
             </div>
 
-            <div type="schol" n="5-6">
+            <div type="schol" n="5b">
                <p> (NEC ENIM IGNIBVS ARTVS / CONDITVS AVT MAESTA NIGER ADVENTABAT) AB VRNA Plato inducit scelera hominum in urna uersari. Et urna dicitur in qua mortuorum hominum ossa conduntur. Hic ergo <hi rend="italic">ab urna</hi> dixit in qua mortuus ponebatur. Et hoc isto sensu expediuit poeta: non Amphiaraus mortuus ab urna in qua eius condita fuerant membra ueniebat. </p>
             </div>
 
-            <div type="schol" n="9-10">
+            <div type="schol" n="9">
                <p> (NECDVM ILLVM AVT TRVNCA LVSTRAVERAT) OBVIA TAXO / EVMENIS quia taxus uenenosa est, propterea ad perfectionem feritatis ex hoc ligno faces Furiae dicuntur <supplied>gerere</supplied>.</p>
             </div>
 
-            <div type="schol" n="10-11">
+            <div type="schol" n="10">
                <p> (AVT FVRVO PROSERPINA) POSTE NOTARAT / (COETIBVS ASSVMPTVM FVNCTIS) asserunt enim poetae mortuorum capita et Furiarum lampade lustrari et eorum nomina a Proserpina in inferorum poste conscribi. </p>
             </div>
 
-            <div type="schol" n="14-15">
+            <div type="schol" n="14">
                <p> 
                   <del>ET</del> SECVRI ... / (ELYSII) id est qui Elysium inhabitant manes. <hi rend="italic">Securi</hi> idcirco, quia sunt ab sceleratorum suppliciis alieni. <hi rend="italic">Elysii</hi> ergo pro his qui in Elysio habitant posuit. </p>
             </div>
@@ -13345,7 +13346,7 @@
                <p> VARIAEQVE EX ORDINE MORTES una quidem communisque omnibus mors est, sed uarietate poenarum dissimilis. </p>
             </div>
 
-            <div type="schol" n="&lt;26&gt;">
+            <div type="schol" n="26">
                <p> 
                   <supplied>FERVNT</supplied> absoluunt. </p>
             </div>
@@ -13371,11 +13372,11 @@
                <p> (VTER HAEC MIHI) PROELIA (FRATRVM) utrum Iuppiter an Neptunus? Conuenienter proposito carmini a Thebanorum odio germanorum inducit de regno et fratres caelestes dissensisse. </p>
             </div>
 
-            <div type="schol" n="37-38">
+            <div type="schol" n="37">
                <p> (PEREANT AGEDVM DISCRIMINA RERVM) / NAM CVI DVLCE MAGIS quam mihi ut superi misceantur? Id est: expedit minori per sortem confundere quae fuerint separata. </p>
             </div>
 
-            <div type="schol" n="40-41">
+            <div type="schol" n="40">
                <p> NEC ISTE MEVS (DIRISQVE EN PERVIVS ASTRIS / INSPICITVR) meus, inquit, mundus hic non est, si hunc rector perrumpit astrorum. </p>
             </div>
 
@@ -13387,17 +13388,17 @@
                <p> (STYGIO PRAETEXAM) HYPERIONA (CAELO) <hi rend="italic">Hyperion</hi> Soli<del>s</del> aequus est. Dicit enim immissis tenebris Solis se Pluton numina turbaturum. </p>
             </div>
 
-            <div type="schol" n="49-50">
+            <div type="schol" n="49">
                <p> VTRVMQVE (TENEBO / TYNDARIDEN) Castoris et Pollucis talis est fabula: cum esset immortalis Pollux et e diuerso Castor morti teneretur obnoxius, pietatis intuitu Pollux morte uicaria fratrem redemit. Vnde Vergilius:</p> 
                <l>'si fratrem Pollux alterna morte redemit'.</l> 
                <p>Dicit ergo nunc Pluton retento Polluce, qui immortalis fuerat, cum Castore germano mortali in utroque se <del>mundo</del> posse regnare. </p>
             </div>
 
-            <div type="schol" n="50-51">
+            <div type="schol" n="50">
                <p> (CVR AVTEM AVIDIS IXIONA FRANGO / VERTICIBVS CVR NON EXSPECTANT) TANTALON VNDAE si poenarum culpas inspectes utrius<supplied>que</supplied> id est Tantali Ixionisque, utrorumque supplicia uindictae Iouis a Plutone praestantur. Ixion quippe Iunonem ausus est stupri iniuria compellare, Tantalus uero Iouis consilia mortalibus prodidit in eorum audita conuiuio. </p>
             </div>
 
-            <div type="schol" n="52-55">
+            <div type="schol" n="52">
                <p> (ANNE PROFANATVM TOTIENS CHAOS HOSPITE VIVO / PERPETIAR ME) PIRITHOI (TEMERARIVS ARDOR / TEMPTAT ET AVDACI THESEVS IVRATVS AMICO / ME FERVS ALCIDES) conqueritur his inferos patuisse qui infanda cupiebant ut ad se aut amator aut raptor intraret. Haec Pirithoi fabula talis est: Pirithous cum Proserpinam rapere suo matrimonio induxisset in animum, huius tam scelerati consilii Theseum participem fecit. Quem cum amicitiarum intuitu Theseus ad inferos Proserpinam pariter rapturus secutus fuisset, graui sunt utrique damnati supplicio. Vnde Vergilius:</p>
                <lg>
                   <l>'sedet aeternumque sedebit</l>
@@ -13405,7 +13406,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="58-59">
+            <div type="schol" n="58">
                <p> (VIDI EGOMET BLANDA INTER CARMINA TVRPES) / EVMENIDVM LACRIMAS Orpheus Thrax peritissimus citharae fuit. Is Eurydicen coniugem unico dilexit affectu. Quae cum Aristaeum, Cyrenes Nymphae filium, pudicitiam suam attrectare cupientem fugeret, calcato serpente perempta est. Hoc cum immoderate doleret Orpheus, confisus peritia citharae inferorum secreta perrupit. Cuius capti dulcedine ac miseratione lugentis manes feritate deposita Orpheo coniugem reddiderunt. Dicit ergo nunc Pluton turpes uidisse <supplied>se</supplied> lacrimas Eumenidum. <hi rend="italic">Turpes</hi> ideo quia contra inferorum legem misericordiae lacrimae fundebantur. ITERATAQVE PENSA (SORORVM) propter reditum Eurydices quem concesserant ut denuo uiuentis <del>pensa</del> fata pensis traderent. </p>
             </div>
 
@@ -13430,19 +13431,19 @@
                <p> ET SECTVM GENETRIX (MIHI COMPVTAT ANNVM) uidetur enim dimidium annum matrimonio eius Iuppiter abrogasse. Penes matrem ergo est, ut eius cura statuto tempore filia ab inferis reuertatur ad caelum. </p>
             </div>
 
-            <div type="schol" n="69-71">
+            <div type="schol" n="69a">
                <p> ATQVE ADEO FRATRES ... / ... (FRATRES ALTERNA IN VVLNERA LAETO / MARTE RVANT) Eteocles et Polynices, qui mallent hoc nefas se potius implere quam Furiam. </p>
             </div>
 
-            <div type="schol" n="69-70">
+            <div type="schol" n="69b">
                <p> (NOSTRIQVE HAEC) OMINA SVNTO / (PRIMA ODII) Eteoclis et Polynicis interitus omen sit inter me et Iouem futuri certaminis. </p>
             </div>
 
-            <div type="schol" n="72-74">
+            <div type="schol" n="72">
                <p> (QVIQVE IGNE SVPREMO / ARCEAT EXANIMES ET MANIBVS AETHERA NVDIS) / COMMACVLET ut tabe soluantur corpora, non flamma pyrarum. Nec interpositis urantur ignibus, sed in solo terrae intemperie aeris membra depereant. Sit mortuis de sepultura negata supplicium bello crudelius, ut solius caeli rogum possint habere communem. </p>
             </div>
 
-            <div type="schol" n="82-83">
+            <div type="schol" n="82">
                <p> (NON FORTIVS ... / ... ASTRIFEROS INCLINAT) IVPPITER AXES hoc est: oratione Plutonis tremefacti sunt poli. </p>
             </div>
 
@@ -13467,7 +13468,7 @@
                <p> IAM PEDES quia currus et equi cum quibus raptus fuerat uanuerunt. </p>
             </div>
 
-            <div type="schol" n="91-93">
+            <div type="schol" n="91">
                <p> (O) CVNCTIS FINITOR (MAXIME RERVM / AT MIHI QVI QVONDAM CAVSAS ELEMENTAQVE NORAM / ET SATOR) Ouidius:</p>
                <lg>
                   <l>'omnia debemus uobis paulumque morati<del>s</del>
@@ -13481,7 +13482,7 @@
                <l>'Fata serunt animas'. </l>
             </div>
 
-            <div type="schol" n="96-97">
+            <div type="schol" n="96">
                <p> NEC VENEREM (ILLICITAM CREDE HIS INSIGNIBVS AVSI / INTRAMVS LETHEN) nec Proserpinam rapiam. Thesei et Pirithoi hoc loco audaciam commemorat et ad testimonium pudicitiae ostendit infulas et insignia sacerdotis. </p>
             </div>
 
@@ -13493,7 +13494,7 @@
                <p> ET NOSTRAE VENIVNT (QVOQVE FVNERA DEXTRAE) propter sui misericordiam dicit se pugnando multas inferis animas addidisse, pro quo beneficio petit sibi esse parcendum. </p>
             </div>
 
-            <div type="schol" n="109-110">
+            <div type="schol" n="109">
                <p> (DVM PER CAVA VISCERA TERRAE / VADO DIV PENDENS ET IN) AERE VOLVOR OPERTO id est: dum per illa spatia uado quae sunt sub terra inferorum. </p>
             </div>
 
@@ -13505,7 +13506,7 @@
                <p> PARENTI Oecleo patri. </p>
             </div>
 
-            <div type="schol" n="116-117">
+            <div type="schol" n="116">
                <p> NEC DEPRECOR VMBRAM / ACCIPERE id est: nec refuto umbra esse. <hi rend="italic">Deprecor</hi> autem est 'refuto'. Vergilius:</p> 
                <l>'equidem merui nec deprecor, inquit'.</l> 
                <p>Lucanus:</p>
@@ -13515,11 +13516,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="118-119">
+            <div type="schol" n="118">
                <p> NAM TIBI PRAESAGI) QVIS IAM SVPER AVGVRIS VSVS / (CVM PARCAE TVA IVSSA TRAHANT) id est: possem rogare te ut apud inferos augur essem, si scirem et hoc mihi apud inferos profuturum. Verum cum uideam ipsa quoque fata ad tuum arbitrium fila disponere, intellego augurio tibi nil opus omnino. </p>
             </div>
 
-            <div type="schol" n="121-122">
+            <div type="schol" n="121">
                <p> ILLI FVNESTA RESERVA / (SVPPLICIA) hoc est: coniugi meae quae mihi minaris reserua supplicia, quae salutem uiri prodidit monili corrupta. </p>
             </div>
 
@@ -13536,7 +13537,7 @@
                <l>'tum demum mouet arma leo'. </l>
             </div>
 
-            <div type="schol" n="132-133">
+            <div type="schol" n="132">
                <p> (ATQVE AVIDAE TRISTIS LOCVS ILLE RVINAE / CESSAT ET INFERNI VITATVR) HONORE SEPVLCRI ad laudem Amphiarai omne spatium campi sepulturae uatis concessum est, quia huic sepulcrum praeter morem hiatus praestitit terrae, quod <hi rend="italic">infernum ... sepulcrum</hi> dixit. </p>
             </div>
 
@@ -13556,11 +13557,11 @@
                </lg>
             </div>
 
-            <div type="schol" n="153-155">
+            <div type="schol" n="153">
                <p> (SPONTE AGMINA RETRO) / NON EXSPECTATO REVOCANTVM (MORE TVBARVM / PRAECIPITANT) nemo enim militaris legis sacramenta seruauit, ne ante pedem e proelio retraheret quam receptui caneretur. Sed tali legiones turbatae nuntio neglectis, dicit, praeceptis et re<supplied>li</supplied>gione militiae uertebantur in fugam. </p>
             </div>
 
-            <div type="schol" n="155-156">
+            <div type="schol" n="155">
                <p> (FALLVNTQVE RVENTES) / GENVA VIROS solutione pedum nimio timore genua languebant et negabant cursum. Vt Vergilius:</p> 
                <l>'genua aegra <supplied>trahentem' et 'genua</supplied> labant'. </l>
             </div>
@@ -13573,7 +13574,7 @@
                <p> FOEDERE PARVO interpositione pacis modicae. </p>
             </div>
 
-            <div type="schol" n="162-163">
+            <div type="schol" n="162">
                <p> QVAE TIBI (NVNC FACIES POSTQVAM PERMISSA GEMENDI / COPIA QVI FLETVS GALEIS CECIDERE SOLVTIS) admiratiue. </p>
             </div>
 
@@ -13582,15 +13583,15 @@
                   <del>ET</del> EFFLANTES expirantes animam. (INTERNECTERE) PLAGAS insuere. Metaphoram a medicis traxit, qui solent letalia uulnera suturis adnectere. </p>
             </div>
 
-            <div type="schol" n="169-170">
+            <div type="schol" n="169">
                <p> (MENSAS) ALIMENTAQVE BELLO / (DEBITA NEC PVGNAE SVASIT TIMOR) ut cibo reficerent uires propter futuram pugnam. </p>
             </div>
 
-            <div type="schol" n="175-176">
+            <div type="schol" n="175">
                <p> HOC ANTRA LACVSQVE / (CASTALII TRIPODVMQVE FIDES) subaudis 'Amphiarao praestiterunt'. </p>
             </div>
 
-            <div type="schol" n="177-178">
+            <div type="schol" n="177">
                <p> QVIS MIHI (SIDEREOS LAPSVS MENTEMQVE SINISTRI / FVLGVRIS AVT CAESIS SALIAT QVOD NVMEN IN EXTIS) hoc est: quis mihi profert in om<supplied>i</supplied>nibus? Aut certe: prodit uoluntatem deorum augure interempto? SINISTRI propitii, dictum a 'sinendo'. Sic et Vergilius de bono augurio <hi rend="italic">sinistrum</hi> dixit:</p>
                <lg>
                   <l>'quod nisi me quacumque nouas incidere lites</l>
@@ -13601,20 +13602,20 @@
                </p>
             </div>
 
-            <div type="schol" n="186-187">
+            <div type="schol" n="186">
                <p> ADVERSAQVE SIGNA VOCASTI / (STERNERE) id est: ultro hostes ad certamen uocasti. </p>
             </div>
 
-            <div type="schol" n="&lt;189&gt;">
+            <div type="schol" n="189">
                <p> 
                   <supplied>ET NVNC TE QVIS CASVS HABET</supplied> mirantur enim mortuum quem mortuum nemo conspexit. </p>
             </div>
 
-            <div type="schol" n="191-192">
+            <div type="schol" n="191">
                <p> (ANNE SEDES HILARES IVXTA TVA NVMINA PARCAS) / ET VICE CONCORDI (DISCIS VENTVRA DOCESQVE) et hunc libenter Fata susceperunt praecepturum. </p>
             </div>
 
-            <div type="schol" n="193-194">
+            <div type="schol" n="193">
                <p> (AN TIBI FELICES LVCOS) MISERATVS AVERNI / (RECTOR) <hi rend="italic">miseratus</hi> quod dicit, non hoc ad indulgentiam ducas sed ad maximum Amphiarai <supplied>decus</supplied>. Nam ille nulli parcit. Vt Horatius:</p> 
                <l>'uictima nil miserantis Orci'. </l>
             </div>
@@ -13633,7 +13634,7 @@
                <p>Varro rerum diuinarum ita refert de Brancho: <supplied>Demo</supplied>clus quidam decimus ab Apolline cum in peregrinatione pranderet in litore ac deinde proficisceretur, oblitus est filium nomine Smicrum. Ille peruenit in saltum Patronis cuiusdam. Et cum esset receptus, coepit cum suis pueris capras pascere. Aliquando prenderunt cygnum et illum ueste cooperuerunt. Dum ipsi pugnant uter illum patri munus offerret, cum essent fatigati certamine, reiecta ueste mulierem inuenerunt. Et cum fugerent, reuocati ab ea moniti sunt ut Patron unice Smicrum diligeret puerum. Illi quae audierunt Patroni indicarunt. Tunc Patron Smicrum pro suo filio nimio dilexit affectu eique filiam suam ducendam locauit uxorem. Illa cum praegnans ex eo esset, uidit in somniis per fauces suas introisse solem et exisse per uentrem. Infans editus ideo <hi rend="italic">Branchus</hi> uocatus est quia mater eius per fauces sibi uiderat <supplied>solem in</supplied> uterum penetrasse. Hic cum in siluis Apollinem osculatus fuisset, comprehensus est ab eo et accepta corona uirgaque uaticinari coepit et subito nusquam comparuit. Templum ei factum est quod Branchi<del>a</del>don nominatur. Et Apollini et filio pariter consecrata sunt templa, quae ab osculo Branchi siue certamine puerorum 'Philesia' nuncupantur. </p>
             </div>
 
-            <div type="schol" n="199-200">
+            <div type="schol" n="199">
                <p> NEC CLARIAS (HAC LVCE FORES DIDYMAEAQVE QVISQVAM / LIMINA NEC LYCIAM SVPPLEX CONSVLTOR ADIBIT) et apud Clarium et apud Didymaeum Apollinis est oraculum. Quod autem ambos colant Apollinem Dianamque, ideo 'Clarii' uocabulo nuncupantur. Vt Vergilius:</p> 
                <l>'qui tripodas, Clarii laurus, qui sidera sentis'.</l> 
                <p>
@@ -13650,7 +13651,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="201-202">
+            <div type="schol" n="201">
                <p> (MOLOSSO) / QVERCVS (ANHELA IDVI) quam Chaoniam dicit hoc est Epiroticam, Molossia enim est in Epiro, ubi solebant columbae sub quercu responsa dare. <hi rend="italic">Anhela</hi> ergo dixit per similitudinem uatum, qui deo pleni et anhelantes responsa dant. Vt est:</p>
                <lg>
                   <l>'sed pectus anhelum,</l>
@@ -13667,17 +13668,17 @@
                <l>'praesaga mali mens'. </l>
             </div>
 
-            <div type="schol" n="206-207">
+            <div type="schol" n="206">
                <p> IAMQVE ERIT ILLE DIES (QVO TE QVOQVE CONSCIA FATIS / TEMPLA COLANT REDDATQVE TVVS RESPONSA SACERDOS) ciuitas enim in eo loco est post condita in quo hiatus terrae Amphiaraum recepit, quae Ampharma uocatur, ut Homerus ait, quod illic currus, quem Graeci <foreign xml:lang="grc">ἅρμα</foreign> appellant, deciderit. In qua etiam oraculum est, quod Amphiareon uocatur. </p>
             </div>
 
-            <div type="schol" n="212-214">
+            <div type="schol" n="212">
                <p> (SIC FORTES MINYAS SVBITO) CVM FVNERE TIPHYS / (DESTITVIT NON ARMA SEQVI NON FERRE VIDETVR / REMVS AQVAS IPSIQVE MINVS IAM DVCERE VENTI) <supplied>
                      <hi rend="italic">Minyas</hi>
                   </supplied> accusatiuum casum posuit <hi rend="italic">Minyas</hi> aut Argonautas, qui se mortuo Tiphy gubernatore priuatos esse dolueri<supplied>n</supplied>t. </p>
             </div>
 
-            <div type="schol" n="215-216">
+            <div type="schol" n="215">
                <p> (IAM FESSI GEMITV PAVLATIM ET CORDA) LEVAVIT / (EXHAVSTVS SERMONE DOLOR) per sermonis enim uarietatem et luctus leuatur et labor decrescit. Vergilius:</p> 
                <l>'uarioque uiam sermone leuabant'. </l>
             </div>
@@ -13688,7 +13689,7 @@
                <p>id est contrariae. </p>
             </div>
 
-            <div type="schol" n="220-221">
+            <div type="schol" n="220">
                <p> (IPSAEQVE AD MOENIA) MARCENT / (EXCVBIAE) ebrietate aut somno. <hi rend="italic">Moenia</hi> pro 'muris' posuit. Vt Vergilius:</p> 
                <l>'sed non ante datam cingetis moenibus urbem'. </l>
             </div>
@@ -13706,7 +13707,7 @@
                <p> ALVMNVM nutritum. <hi rend="italic">Alumnus</hi> enim ab 'alimentis' dicitur. </p>
             </div>
 
-            <div type="schol" n="224">
+            <div type="schol" n="224a">
                <p> PAEANES pro 'laudibus' posuit. Nam paeanes uersus sunt in honorem Apollini dicti propter exstinctum Pythonem. Omnis laus Graece dicitur <hi rend="italic">paean</hi> ab admiratione. <foreign xml:lang="grc">ἐπαινεῖν</foreign> etenim Graece 'laudare' dicitur. Vergilius:</p> 
                <l>'laetumque choro paeana <supplied>canentes'</supplied>
                </l> 
@@ -13717,20 +13718,20 @@
                   <supplied>'laetumque paeana</supplied> secuti'. </l>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224b">
                <p> (VBIQVE / SERTA) CORONATVMQVE MERVM secundum Homerum dixit, qui ait crateras in quibus uinum est coronari. Vergilius:</p> 
                <l>'crateras longe statuunt et uina coronant'. </l>
             </div>
 
-            <div type="schol" n="231-232">
+            <div type="schol" n="231">
                <p> (FETOSQVE CRVENTI) / MARTIS AGROS propter eos dixit qui satis draconis dentibus fuerant nati. </p>
             </div>
 
-            <div type="schol" n="232-233">
+            <div type="schol" n="232">
                <p> (TYRIAM REPTANTIA SAXA) / AD CHELYN id est <supplied>ad</supplied> Amphionis citharam, cuius dulcedine<supplied>m</supplied> secuta saxa exstruxere muros Thebanos. </p>
             </div>
 
-            <div type="schol" n="235-236">
+            <div type="schol" n="235">
                <p> ET MVLTA DEDVCTAM (LAMPADE FRATRVM / HARMONIAM) <supplied>
                      <hi rend="italic">fratrum</hi>
                   </supplied> suorum scilicet Cupidinum et Amorum. </p>
@@ -13740,16 +13741,16 @@
                <p> (GEMMIFERVM ...) HYDASPEN optima enim ibidem sunt lapidum genera. </p>
             </div>
 
-            <div type="schol" n="&lt;242&gt;">
+            <div type="schol" n="242">
                <p> 
                   <supplied>EXISSE ... VVLTV .. SERENO</supplied> ex laetitia prouenisse. </p>
             </div>
 
-            <div type="schol" n="246">
+            <div type="schol" n="246a">
                <p> QVIN HAVSISSE (DAPES) etiam hoc fecit. <supplied>QVIN</supplied> confirmantis est. </p>
             </div>
 
-            <div type="schol" n="246-247">
+            <div type="schol" n="246b">
                <p> INSICCATVMQVE CRVOREM / (DEIECISSE GENIS) inhaerentem caecitatis suae cruorem genis eluisse. </p>
             </div>
 
@@ -13757,7 +13758,7 @@
                <p> CAVSA LATET <hi rend="italic">latet</hi> causa laetitiae, quia uult poeta crudele esse quod gaudet. Quare sit ergo commutatus ad gaudium Oedipus, ignorabant Thebani. Erat autem illi causa laetitiae quod dimicat aduersum se ferro germanitas. </p>
             </div>
 
-            <div type="schol" n="252-253">
+            <div type="schol" n="252">
                <p> (SED PRIMOS COMMINVS ENSES / ET SCELERIS TACITO RIMATVR) SEMINA VOTO id est: tacito uoto auribus menteque captabat hostium motus. </p>
             </div>
 
@@ -13769,11 +13770,11 @@
                <p> (POST LONGAE PHINEVS) IEIVNIA POENAE Phineus enim propter proditionem sacrorum supplicium meruit Harpyiarum, a quibus prohibitus ne dapes attingeret longo est ieiunii cruciatu uexatus. </p>
             </div>
 
-            <div type="schol" n="262">
+            <div type="schol" n="262a">
                <p> QVAMQVAM AEGER SENIO <hi rend="italic">Senium</hi> est morbus senectutis. </p>
             </div>
 
-            <div type="schol" n="262-263">
+            <div type="schol" n="262b">
                <p> (SED AGIT) MISERANDA POTESTAS / (INVIGILARE MALIS) quia maior potestas grauiori semper malo uexatur. </p>
             </div>
 
@@ -13785,7 +13786,7 @@
                <p> (INSCRIPTAQVE) DEVS QVI NAVIGAT ALNO deum, tutelam nauis, intellegimus cum gubernatore nauigare. Habent enim uel sculptos uel pictos praesules suos, quorum nominibus nuncupantur et naues. </p>
             </div>
 
-            <div type="schol" n="271-272">
+            <div type="schol" n="271">
                <p> (TEMPVS ERAT IVNCTOS CVM IAM SOROR IGNEA PHOEBI) / SENTIT EQVOS poetice dictum. Ceterum non est ut luna solis inueniatur semper aduentu. Hic lunam pro nocte posuit. </p>
             </div>
 
@@ -13810,12 +13811,12 @@
                <p> (ILLVM INGENS) CONFVNDIT HONOS quia uictus est uerecundatur, id est iudicii ipsius gratia grauatur. </p>
             </div>
 
-            <div type="schol" n="&lt;285&gt;">
+            <div type="schol" n="285">
                <p> 
                   <supplied>SEQVE ONERI NEGAT ESSE PAREM COGIQVE MERETVR</supplied> recte ergo quod uerecunde excusabat dignus erat qui cogeretur. </p>
             </div>
 
-            <div type="schol" n="286-287">
+            <div type="schol" n="286">
                <p> 
                   <del>SICVT</del> ACHAEMENIVS (... / ... PVER) Achaemene Parthorum seu Medorum ciuitas. </p>
             </div>
@@ -13863,15 +13864,15 @@
                <p> ANIMARVM (ET SEMINA MVNDO) secundum Pythagoram, qui omnibus crescentibus <del>uel arescentibus</del> licet insensibilibus animas tribuit. </p>
             </div>
 
-            <div type="schol" n="309">
+            <div type="schol" n="309a">
                <p> (ET VOLVCRVM) REQVIES uolatus in aere est requies auium terra. </p>
             </div>
 
-            <div type="schol" n="309-310">
+            <div type="schol" n="309b">
                <p> (FIRMVM ATQVE) IMMOBILE MVNDI / (ROBVR INOCCIDVI) quia sola terra immobilitate fulcitur. </p>
             </div>
 
-            <div type="schol" n="310-312">
+            <div type="schol" n="310">
                <p> (TE VELOX MACHINA CAELI) / AERE PENDENTEM (VACVO TE CVRRVS VTERQVE / CIRCVIT) qui<del>a</del> mundum opinantur aeternum, terram aiunt pendere aere succinctam. Vnde Lucanus:</p>
                <lg>
                   <l>'dum terra fretum terramque leuabit</l>
@@ -13883,19 +13884,19 @@
                <l>'solemque suum, sua sidera norunt'. </l>
             </div>
 
-            <div type="schol" n="312-313">
+            <div type="schol" n="312">
                <p> INDIVISA(QVE MAGNIS / FRATRIBVS) quia communis est Ioui, Neptuno, et Plutoni. Etenim cum caelum, mare, inferos inter se sortis euentu diuiderent, sola terra indiuisa permansit. </p>
             </div>
 
-            <div type="schol" n="314-315">
+            <div type="schol" n="314">
                <p> SVBTERQVE <del>SVBTERQVE</del> AC DESVPER (VNA / SVFFICIS) quae nobis, antipodis, inferisque una eadem sufficis. </p>
             </div>
 
-            <div type="schol" n="320">
+            <div type="schol" n="320a">
                <p> OMNE HOMINI NATALE SOLVM omnibus est habitabilis terra et generans homines, ut uult opinio sapientum, quamuis imperiti putent rotunditatem in omni circuitu habitari non posse. Siue quia omne solum sapienti patria est. </p>
             </div>
 
-            <div type="schol" n="320-322">
+            <div type="schol" n="320b">
                <p> (SAEVO) / TAMQVAM HVMILI<del>S</del> (POPVLOS DECEAT DISTINGVERE FINE / VNDIQVE VBIQVE TVOS MANEAS COMMVNIS) duplex sensus est: tamquam humili populos deceat distinguere fine. Et alter sensus: undique ubique maneas communis. </p>
             </div>
 
@@ -13924,7 +13925,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="346-347">
+            <div type="schol" n="346">
                <p> (STVPET INSOLITO CLANGORE) CITHAERON / (MARCIDVS) horruit tubarum sonitu mons qui ante consueuerat sacrorum uoces audire. Vt Vergilius:</p> 
                <l>'nocturnusque uocat clamore Cithaeron'. </l>
             </div>
@@ -13935,11 +13936,11 @@
                   </supplied> tubarum. Sensus: stupent turres Thebanae sonitum Tisiphones, quae Amphionìs fuerant carminibus fabricatae. </p>
             </div>
 
-            <div type="schol" n="353-357">
+            <div type="schol" n="353">
                <p> OGYGIIS (IT SORTE CREON ... STIPAT DIRCAEA MENOECEVS) omnium Thebanae ciuitatis portarum nomina eleganter poeta monstrauit: <supplied>Ogygias, Neistas, Ho</supplied>moloidas, Proetias, Electras, Hypsistas, Dircaeas. </p>
             </div>
 
-            <div type="schol" n="358-361">
+            <div type="schol" n="358">
                <p> (QVALIS VBI) AVERSI (SECRETVS PABVLA CAELI / NILVS ET EOAS MAGNO BIBIT ORE PRVINAS / SCINDIT FONTIS OPES SEPTEMQVE PATENTIBVS ARVIS / IN MARE FERT HIEMES) <supplied>
                      <hi rend="italic">auersi</hi>
                   </supplied> meridiani id est Aegyptii. Nilus enim Aegypti fluuius est septem capitibus fluens, unde a Graecis <foreign xml:lang="grc">ἑπτάστομος</foreign> dictus est. Quae omnia eius ostia his nominibus nuncupantur: Pelusi<supplied>ac</supplied>on, Taniticon, Mendesi<del>ac</del>on, Pathmeticon, Sebennyticon, Bolbitinon, Canop<supplied>ic</supplied>on. PABVLA CAELI imbres enim secundum physicos alimenta sunt fluminum. (EOAS MAGNO) BIBIT ORE PRVINAS <hi rend="italic">bibit</hi> accipit. Id est: Aethiopum niues colligit quas praestat Oriens id est Aegyptus. Siue <hi rend="italic">Eoas pruinas bibit</hi> secreto fonte quo Aegyptii regnant. HIEMES aquarum incrementa qualia fluminibus hiems solet inferre. </p>
@@ -13949,7 +13950,7 @@
                <p> DVLCI ... PONTO Nilo specie maris uenienti. </p>
             </div>
 
-            <div type="schol" n="364-365">
+            <div type="schol" n="364">
                <p> PRAECIPVE ELEAE (LACEDAEMONIAEQVE COHORTES / ET PYLII) in catalogo horum meminit qui ad auxilia uenerant Amphiarai:</p>
                <lg>
                   <l>'auget resupina maniplos</l>
@@ -13971,7 +13972,7 @@
                <l>'accedunt Syriae populi'. </l>
             </div>
 
-            <div type="schol" n="368-369">
+            <div type="schol" n="368">
                <p> MINOR ILLE (PER ALAS / SEPTIMVS EXSTAT APEX) Thiodamas sex ducibus minor erat. </p>
             </div>
 
@@ -13989,11 +13990,11 @@
                <l>'atque alio Capaneus horrore canendus'</l>
             </div>
 
-            <div type="schol" n="380-381">
+            <div type="schol" n="380">
                <p> (CRVENTO) / ANGVE NOTAT dedicat morti. </p>
             </div>
 
-            <div type="schol" n="381-382">
+            <div type="schol" n="381">
                <p> (IAMQVE IN MISEROS PENSVM OMNE SORORVM) / SCINDITVR ita enim factum est ut multorum uita pariter finiretur. </p>
             </div>
 
@@ -14001,7 +14002,7 @@
                <p> ABOLET(QVE DOMOS CONVBIA NATOS) delet memoriam suorum ac desiderium illis ex animo. Et a toto transit ad partes dicendo <hi rend="italic">conubia</hi>, <hi rend="italic">natos</hi>.</p>
             </div>
 
-            <div type="schol" n="396-397">
+            <div type="schol" n="396">
                <p> (ET SPATIIS VTRIMQVE AEQVALIBVS ACTI / ADVENTAT MEDIVMQVE VIDENT) DECRESCERE CAMPVM accessione utriusque exercitus medium quod erat minuebatur spatium. Ita enim fuerant uicinitate densati ut campus qui medius fuerat interiret. </p>
             </div>
 
@@ -14038,7 +14039,7 @@
                <l>'et nostris reficit sua rura serenis'. </l>
             </div>
 
-            <div type="schol" n="415-416">
+            <div type="schol" n="415">
                <p> ET MVTVA PERDVNT / (VVLNERA) concursu telorum utrimque frustrabantur. </p>
             </div>
 
@@ -14046,7 +14047,7 @@
                <p> (FORMIDANDAE) NON VNA MORTE SAGITTAE quae et ferro perimant et ueneno. </p>
             </div>
 
-            <div type="schol" n="421-422">
+            <div type="schol" n="421">
                <p> NVNC TVRBA RECEDIT / (NVNC PREMIT AC VICIBVS TELLVREM AMITTIT ET AVFERT) modo pelluntur, modo resistentes occupant locum quem amiserant. </p>
             </div>
 
@@ -14064,7 +14065,7 @@
                <p> NE PVDOR IN TERGO hoc <supplied>est</supplied>: hastam pectori infixam retrahit, ne post tergum exeundo uulnus infame uideretur. </p>
             </div>
 
-            <div type="schol" n="436-437">
+            <div type="schol" n="436">
                <p> (DILECTA GENIS MORIENTIS OBERRANT) / TAYGETA id est: <supplied>Men</supplied>alcas moriens Tayget<supplied>a</supplied> imaginatur. <hi rend="italic">Taygeta</hi> autem mons Laconum est Libero et Apollini sacer. LAVDATAQVE VERBERA MATRI Tauricae, quam Orestes de Scythia transtulit. Consueuerat humano cruore placari. Cuius cum simulacrum in Laconiam delatum fuisset, ne quod piaculum nasceretur intermissione sollemnis sacrificii neue crudelitati Graeciae populus oboediret, inuentum est ut inter se impuberes pueri de sustinendis uerberibus contenderent ac se in hanc patientiam prouocarent et super aram Dianae impositi flagellis uerberabantur tam diu donec ex humano corpore sanguis flueret qui instar esset sacrificii. Hi autem pueri appellantur <foreign xml:lang="grc">βωμονῖκαι</foreign>.</p>
             </div>
 
@@ -14072,23 +14073,23 @@
                <p> (ET CERTI NONDVM) TACET ARCVS AMYNTAE celeritas iaculantis expressa est ut ante peremptus occumberet quam sonus de arcus tensione cessaret. </p>
             </div>
 
-            <div type="schol" n="445-447">
+            <div type="schol" n="445">
                <p> (IPHIN ATROX ACAMAS ARGVM FERVS IMPVLIT HYPSEVS / STRAVIT ABANTA PHERES) DIVERSA(QVE VVLNERA FLENTES / IPHIS EQVES PEDES ARGVS ABAS AVRIGA IACEBANT) tres occisi diuerso mortis genere sunt, quos poeta a tribus dicit esse prostratos. </p>
             </div>
 
-            <div type="schol" n="448-452">
+            <div type="schol" n="448">
                <p> INACHIDAE GEMINI (GEMINOS E SANGVINE CADMI / ... ERRASSE QVERVNTVR) Graeci gemini geminos Thebanos aggressi sunt quodam casu per errorem belli et, cum eos occidissent geminos per ignorantiam, querebantur quoniam et geminos esse se meminerant. </p>
             </div>
 
-            <div type="schol" n="450-452">
+            <div type="schol" n="450">
                <p> (SED DVM SPOLIA OMNIA CAESIS / ERIPIVNT VIDERE NEFAS ET MAESTVS VTERQVE / RESPICIT AD FRATREM PARITERQVE) ERRASSE QVERVNTVR nam nudatos armis agnouerunt. </p>
             </div>
 
-            <div type="schol" n="453-455">
+            <div type="schol" n="453">
                <p> (CVLTOR ION PISAE CVLTOREM DAPHNEA CIRRHAE / TVRBATIS PROSTRAVIT EQVIS HVNC) LAVDAT AB ALTO / (IVPPITER HVNC TARDVS FRVSTRA MISERATVR APOLLO) uictum minoris dei posuit sacerdotem, ne potioris meritis derogaret. </p>
             </div>
 
-            <div type="schol" n="456-457">
+            <div type="schol" n="456">
                <p> (INGENTES FORTVNA VIROS) ILLVSTRAT VTRIMQVE / (SANGVINE IN ADVERSO) Tydeum et Haemona<del>m</del> dicit, quorum uirtus in alternis belli partibus pro deorum fauore laudatur. </p>
             </div>
 
@@ -14125,11 +14126,11 @@
                <p> OBVERSVM obstantem ab aduersa parte. </p>
             </div>
 
-            <div type="schol" n="488-489">
+            <div type="schol" n="488">
                <p> (FINDVNTVR) VTRIMQVE / TEMPORA (DIVIDVIQVE CADVNT IN BRACCHIA CRINES) ex utraque parte diuisum est caput. </p>
             </div>
 
-            <div type="schol" n="490-491">
+            <div type="schol" n="490">
                <p> NON HOC METVENS (INOPINO LIMITE VITAE / EXSILVIT) insperato et nouo mortis genere periit. INOPINO LIMITE (VITAE) quia uitae limes semper est incertus. </p>
             </div>
 
@@ -14137,20 +14138,20 @@
                <p> SAEVVS VTERQVE DEVS quia neuter adiuuat decertantes. </p>
             </div>
 
-            <div type="schol" n="502-504">
+            <div type="schol" n="502">
                <p> FIDA SOROR (QVAENAM HVNC BELLI CALIGINE NOBIS / CONGRESSVM FORTVNA TVLIT NVM REGIA IVNO / HOC MOLITA NEFAS) nouerca enim sorori uult Herculem repugnare. </p>
             </div>
 
-            <div type="schol" n="506">
+            <div type="schol" n="506a">
                <p> (GENVS HVIC) SED MITTO AGNOSCERE subaudis: 'genus huic magnum nobileque'. Sed <foreign xml:lang="grc">ἀποσιώπησιν</foreign> fecit. Vt Vergilius:</p> 
                <l>'quos ego — ! sed motos praestat componere fluctus'. </l>
             </div>
 
-            <div type="schol" n="506-509">
+            <div type="schol" n="506b">
                <p> (SED MITTO AGNOSCERE QVANDO / TV DIVERSA FOVES NEC SI IPSVM) COMMINVS HYLLVM / (TYDEOS HASTA TVI STYGIOQVE EX ORBE REMISSVM / AMPHITRYONA PETAT) <supplied>Hyllus</supplied> et Amphitryon Herculis et Omphales filii. Hic autem Haemon genus tantum Herculis ducit. Hoc autem dicit: tanta mihi tui est reuerentia ut contra uoluntatem tuam nec pro liberis repugnarem. </p>
             </div>
 
-            <div type="schol" n="509-511">
+            <div type="schol" n="509">
                <p> (TENEO AETERNVMQVE TENEBO) / QVANTVM HAEC (DIVA MANVS QVOTIENS SVDAVERIT AEGIS / ISTA MIHI) docet poeta ingenio uirtutem cedere. Nam id agit oratio Herculis blandientis. </p>
             </div>
 
@@ -14162,11 +14163,11 @@
                <p> VVLTVS decor quem paulo ante ira mutauerat. </p>
             </div>
 
-            <div type="schol" n="519-520">
+            <div type="schol" n="519">
                <p> (SENSIT ABESSE DEVM LEVIVS CADMEIVS HAEMON) / TELA ROTAT (NVLLOQVE MANVM COGNOSCIT IN ICTV) quia iam Haemon tela irrita iaciebat. </p>
             </div>
 
-            <div type="schol" n="522-523">
+            <div type="schol" n="522">
                <p> (CEDENTEM ...) / IMPETIT composuit sibi uerbum 'impeto te'. VNI SIBI (MISSILE TELVM) quod ipse solus possit excutere. </p>
             </div>
 
@@ -14179,12 +14180,12 @@
                   <del>HVMERI</del> LIB<del>R</del>ARE perstringere aut leuiter tangere. </p>
             </div>
 
-            <div type="schol" n="534-535">
+            <div type="schol" n="534">
                <p> IN LATVS IRAS / (FRANGIT) Horatius:</p> 
                <l>'oblicum meditaris ictum'. </l>
             </div>
 
-            <div type="schol" n="536-538">
+            <div type="schol" n="536">
                <p> (ECCE DVCEM TVRMAE) CERTA INDIGNATVS (IN HOSTEM / SPICVLA FELICI PROTHOVM TORQVERE LACERTO / TVRBIDVS OENIDES) <hi rend="italic">certa ... spicula</hi> mortem peragentia, siue quae possent ferire. Indignatus Tydeus est Prothoum felici lacerto in hostem spicula certa torquere. </p>
             </div>
 
@@ -14196,19 +14197,19 @@
                <p> VTRVMQVE NEMVS suum et uitis. </p>
             </div>
 
-            <div type="schol" n="549-551">
+            <div type="schol" n="549">
                <p> (STYGII CVI CONSCIA PENSI / IPSA DIV POSITIS LETVM PRAEDIXERAT ASTRIS) / VRANIE letum eius Vranie praedixerat Musa et conscia uicinae mortis eius astra monstrauerat. </p>
             </div>
 
-            <div type="schol" n="556-557">
+            <div type="schol" n="556">
                <p> (SOCEROS NEC) TRISTIBVS (ACTIS / AVERSATVS ERAT) propter incestum et parricidium Oedipi. </p>
             </div>
 
-            <div type="schol" n="559-560">
+            <div type="schol" n="559">
                <p> (IPSE QVOQVE EGREGIVS NEC PECTORA VIRGINIS ILLI / DIVERSA INQVE VICEM SINERET FORTVNA) PLACEBAT ut ille transiret in feminam. </p>
             </div>
 
-            <div type="schol" n="562-564">
+            <div type="schol" n="562">
                <p> (RVIT PRIMIS IMMIXTVS ET AGMINA LERNAE / NVNC PEDES ENSE VAGO PRENSIS NVNC CELSVS HABENIS) / CEV SPECTETVR (AGIT) sic pugnabat quasi uirtutis suae <supplied>a</supplied> iudice spectaretur. </p>
             </div>
 
@@ -14243,7 +14244,7 @@
                <p> MAGNI ... SANGVINIS tauri aut hominis. </p>
             </div>
 
-            <div type="schol" n="577-578">
+            <div type="schol" n="577">
                <p> (MOX IGNOTVM ARMIS AC) SOLO CORPORE (MENSVS / TYDEA NON TIMVIT) non uirtute Tydeum permensus est, sed corporis paruitate. </p>
             </div>
 
@@ -14255,19 +14256,19 @@
                <p> HAVD DVBIVM FATI procul dubio periturum. </p>
             </div>
 
-            <div type="schol" n="589-590">
+            <div type="schol" n="589">
                <p> (PROCVL) ARCEAT IPSVM / (FERRE PVDOR) se ipsum dicit pudore tardari, ne sic turpes delicatas<supplied>que</supplied> de hoste exuuias domum referret. </p>
             </div>
 
-            <div type="schol" n="590-591">
+            <div type="schol" n="590">
                <p> (VIX SI BELLVM COMITATA RELICTIS / DEIPYLE THALAMIS ILLI) ILLVDENDA (TVLISSEM) ostendit arma morientis ita cultu ipso fuisse deformia ut mulieribus ad illudendum tantummodo apta uiderentur. </p>
             </div>
 
-            <div type="schol" n="597-598">
+            <div type="schol" n="597">
                <p> (AT NON SEMIANIMI CLAMORE MENOECEA LAPSVS) / FALLIT ATYS ordo: lapsus Atys non fallit Menoecea clamore semianimi. </p>
             </div>
 
-            <div type="schol" n="599-600">
+            <div type="schol" n="599">
                <p> (INSTABAT PVBES TEGEAEA IACENTI) / NEC PROHIBENT TYRII spoliabant Atyos cadauer Arcades nec repugnabant Thebani. </p>
             </div>
 
@@ -14279,7 +14280,7 @@
                <p> PIGNORA TANTA coniuges liberosque. </p>
             </div>
 
-            <div type="schol" n="608-609">
+            <div type="schol" n="608">
                <p> (PAR ALIVD MORVM MISERIQVE) INNOXIA PROLES / (OEDIPODAE) dissimiles fratribus ac per hoc moribus bonis eruditae quae se non oderant. Vt alibi:</p> 
                <l>'hinc atque hinc natae, melior iam sexus'.</l> 
                <p>Ad mores <hi rend="italic">meliorem sexum</hi> rettulit, non ad naturam. </p>
@@ -14289,7 +14290,7 @@
                <p> NEC MALA (QVAE IVXTA) id est bella praesentia. </p>
             </div>
 
-            <div type="schol" n="614-615">
+            <div type="schol" n="614">
                <p> NVTAT (VTROQVE TIMOR QVEMNAM HOC CERTAMINE VICTVM / QVEM VICISSE VELINT) dubitabant germanae cui magis fratrum timerent. </p>
             </div>
 
@@ -14305,7 +14306,7 @@
                <p> QVAE DECEPTA FIDES <hi rend="italic">fides</hi> est in somniis quia uidimus, <hi rend="italic">decepta</hi> quia falsa sunt quae uidimus. </p>
             </div>
 
-            <div type="schol" n="625-627">
+            <div type="schol" n="625">
                <p> (ECCE EGO QVAE THALAMOS NEC SI PAX ALTA MANERET) / TRACTAREM SENSV (PVDET HEV CONVBIA VIDI / NOCTE SOROR) excusauit quia illa uidere dicimur in somniis quae habemus in uoto. </p>
             </div>
 
@@ -14321,7 +14322,7 @@
                <p> RECEPTVS ab hostibus liberatus. </p>
             </div>
 
-            <div type="schol" n="639-640">
+            <div type="schol" n="639">
                <p> (DEPENDET LANGVIDA CERVIX / EXTERIOR) CLIPEO nam super clipeum ferebatur. </p>
             </div>
 
@@ -14333,11 +14334,11 @@
                <p> SVMMVM ultimum. </p>
             </div>
 
-            <div type="schol" n="647-649">
+            <div type="schol" n="647">
                <p> (QVATER IAM MORTE SVB IPSA / AD NOMEN VISVS DEIECTAQVE) FORTITER ORA / (SVSTVLIT) cum ei diceretur praesens esse Ismene eius sponsa. </p>
             </div>
 
-            <div type="schol" n="651-652">
+            <div type="schol" n="651">
                <p> (POSITVSQVE) BEATA / MORTE (PATER) qua faciente funus filii non potuit cernere. </p>
             </div>
 
@@ -14359,17 +14360,17 @@
                   </supplied> restituere in qua quinquaginta insidiantes sibi Thebanos occiderat. </p>
             </div>
 
-            <div type="schol" n="666-667">
+            <div type="schol" n="666">
                <p> (ILLE EGO) INEXPLETIS (SOLVS QVI CAEDIBVS HAVSI / QVINQVAGINTA ANIMAS) <supplied>
                      <hi rend="italic">inexpletis</hi>
                   </supplied> pro 'inexpletus'. Ad caedem transtulit uel quod ad suum animum pertinebat, quem Thebanorum contentum caede tantorum <supplied>negat</supplied>.</p>
             </div>
 
-            <div type="schol" n="671-672">
+            <div type="schol" n="671">
                <p> VBI AVTEM / (EGREGIVS DVX ILLE MIHI) sic dixit quasi in recordationem hominis illius casu inciderit. </p>
             </div>
 
-            <div type="schol" n="673-674">
+            <div type="schol" n="673">
                <p> (CAPITIS ... SVPERBI) / FVLGORE ornamento diadematis regii. </p>
             </div>
 
@@ -14377,11 +14378,11 @@
                <p> FLAMMIGER ALES aquilam dixit quae Iouis fulminibus seruit. </p>
             </div>
 
-            <div type="schol" n="678-679">
+            <div type="schol" n="678">
                <p> (IMVS) IN ARMA PALAM (TANDEMQVE OSTENDIMVS ENSES / AN NOCTEM ET SOLITAS PLACET EXSPECTARE TENEBRAS) tangit illud quod occulte illi insidiatus est, et dicit se aperta luce uirili modo uelle confligere. </p>
             </div>
 
-            <div type="schol" n="686-688">
+            <div type="schol" n="686">
                <p> (CRVDELIS ERINYS / OBSTAT ET INFANDO DIFFERT ETEOCLEA FRATRI / CVSPIS IN ARMIGERVM PHLEGYAN) PECCAVIT elocutio speciosissima quae hoc significat: cuspis missa in Eteoclen peccauit in perniciem Phlegyae quem percussit. </p>
             </div>
 
@@ -14393,16 +14394,16 @@
                <p> ILLVM iuuencum. </p>
             </div>
 
-            <div type="schol" n="&lt;698&gt;">
+            <div type="schol" n="698">
                <p> 
                   <supplied>TRVNCIS SVA MEMBRA REMITTIT</supplied> ad mortem tot homines quot membra sunt. </p>
             </div>
 
-            <div type="schol" n="706">
+            <div type="schol" n="706a">
                <p> GENTILIS APER de ea gente, unde Tydeus fuerat, id est Calydonius<del>, qui a Meleagro occisus est</del>. Et hic <hi rend="italic">aprum</hi> pro 'pelle' posuit. </p>
             </div>
 
-            <div type="schol" n="706-709">
+            <div type="schol" n="706b">
                <p> NVSQVAM ARDVA CONI / GLORIA (QVIQVE APICEM TORVAE) GRADIVVS (HABEBAT / CASSIDIS HAVD LAETVM DOMINO RVIT OMEN INVSTA / TEMPORIBVS NVDA AERA SEDENT) <supplied>
                      <hi rend="italic">Gradiuus</hi>
                   </supplied> in catalogo, dum arma ipsius poeta describeret, ait:</p> 
@@ -14419,11 +14420,11 @@
                <p> (VERTICE PERCVSSO VOLVVNTVR) IN ARMA de capite in scuta cadebant. </p>
             </div>
 
-            <div type="schol" n="711-712">
+            <div type="schol" n="711">
                <p> (IAM SAVCIA PROLVIT ATER / PECTORA PERMIXTVS SVDORE ET) SANGVINE TORRENS fluuium fecerat sudoris et sanguinis. </p>
             </div>
 
-            <div type="schol" n="713-714">
+            <div type="schol" n="713">
                <p> (PALLADA FIDAM / LONGIVS OPPOSITA CELANTEM) LVMINA PARMA quia erubescebat Minerua <supplied>de</supplied>ficere uirtuti. </p>
             </div>
 
@@ -14431,11 +14432,11 @@
                <p> (TELI) NON EMINET AVCTOR non est ausus gloriari Melanippus se auctore <del>uirtutum</del> interemptum Tydea. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718">
                <p> ASTACIDES (MELANIPPVS ERAT NEC PRODIDIT IPSE / ET VELLET LATVISSE MANVM) missor lanceae. Hic descriptio ex insidiis iaculantis Melanippi. </p>
             </div>
 
-            <div type="schol" n="&lt;724&gt;">
+            <div type="schol" n="724">
                <p> 
                   <supplied>RIMATVS</supplied> eum intuen<del>te</del>s. </p>
             </div>
@@ -14449,11 +14450,11 @@
                <p> QVIS ARDOR exclamatio per interpositionem. </p>
             </div>
 
-            <div type="schol" n="733-735">
+            <div type="schol" n="733">
                <p> (SED ET IPSE) RECEDERE CAELVM / (INGENTESQVE ANIMOS EXTREMO FRIGORE LABI / SENSIT) ad opinionem rettulit morientium. </p>
             </div>
 
-            <div type="schol" n="736-739">
+            <div type="schol" n="736">
                <p> NON OSSA PRECOR (REFERANTVR VT ARGOS / AETOLVMVE LAREM NEC ENIM MIHI CVRA SVPREMI / FVNERIS ODI ARTVS FRAGILEMQVE HVNC CORPORIS VSVM / DESERTOREM ANIMI) non quaero ut membra mea onerent patriam sepulturam, non ut ossa tumulo humata seruentur. Odi enim corpus quod spiritum uirorum fortiter pugnantium deserit. </p>
             </div>
 
@@ -14465,11 +14466,11 @@
                <p> ARGEI (... SANGVINIS) Argiui. </p>
             </div>
 
-            <div type="schol" n="743">
+            <div type="schol" n="743a">
                <p> HIPPOMEDON maritus Nealcis, Adrasti <supplied>sororis</supplied> filius. </p>
             </div>
 
-            <div type="schol" n="&lt;743-744&gt;">
+            <div type="schol" n="743b">
                <p> 
                   <supplied>O PRIMIS PVER INCLVTE BELLIS / ARCAS</supplied> id est Parthenopaeus. <supplied>ARGOLICAE CAPANEV IAM MAXIME TVRMAE</supplied> quia Tydeo uiuente hunc secundum fuisse constabat. </p>
             </div>
@@ -14486,11 +14487,11 @@
                <p> (SESEQVE) AGNOVIT IN ILLO id est: tam illum spirantem animam quam se. </p>
             </div>
 
-            <div type="schol" n="755">
+            <div type="schol" n="755a">
                <p> GLISCIT irascendo in maius accenditur. </p>
             </div>
 
-            <div type="schol" n="755-756">
+            <div type="schol" n="755b">
                <p> (TEPENTIS / LVMINA TORVA VIDENS ET ADHVC) DVBITANTIA FIGI quia his quibus recens mors est oculi uidentur errare. </p>
             </div>
 
@@ -14498,28 +14499,28 @@
                <p> NEC COMITES AVFERRE VALENT non ualent Tydeo caput tollere Melanippi. </p>
             </div>
 
-            <div type="schol" n="765-766">
+            <div type="schol" n="765">
                <p> (NEC PRIVS ASTRA SVBIT QVAM MYSTICA) LAMPAS (ET INSONS / ELISOS MVLTA PVRGAVIT LVMINA LYMPHA) scelera enim uisa aut igni aut aqua purgantur. ELISOS fluuius est. </p>
             </div>
 
          </div>
 
-         <div type="lib" n="IX">
+         <div type="lib" n="9">
             <head>LIBER IX</head>
 
             <div type="pr" n="pr">
                <p>Eteoclis allocutio hortantis exercitum ut rapiant corpus Tydei. Nuntius mortis Tydei ad Polynicen et eius lamentatio uel allocutio Hippomedontis. Pro cadauere Tydei dimicatio. Factio Furiae auertentis Hippomedontem a defensione cadaueris. Ablatio ipsius cadaueris. Allocutio Hippomedontis ad equum Tydei et eius pugnae diuersae in Ismeno flumine. Cuius cum nepotem occidisset nomine Crenaeum, matre lamentante et conquerente commotus fluuius coepit contra Hippomedontem undas mouere. Mors equi Tydei. Pedestre certamen Hippomedontis in fluuio. Conquestio Hippomedontis quod in fluuio moreretur. Iunonis apud Iouem de hac re querela. Mors Hippomedontis. Mors Hypsei, Asopi fluminis filii, ducis Thebani. Somnium Atalantes praesagium de morte filii Parthenopaei. Deploratio eius in templo Dianae. Profectio ad auxilium Parthenopaei. Occursus Apollinis et de eius morte uaticinatio. Aduentus deae ad Thebas, et quibus artibus tutata sit puerum. Indignatio Martis contra Dianam Venere stimulante. Dryantis electio. Mors Parthenopaei cum allocutione ad <supplied>D</supplied>orceum, custodem suum.</p>
             </div>
 
-            <div type="schol" n="1-2">
+            <div type="schol" n="1">
                <p> (ASPERAT AONIOS RABIES AVDITA) CRVENTI / TYDEOS crudelitatis arguitur quia caput hostis moribundus absumpsit. </p>
             </div>
 
-            <div type="schol" n="3-4">
+            <div type="schol" n="3">
                <p> (CVLPANTQVE VIRVM ET RVPISSE QVERVNTVR) / FAS ODII quod ultra fas et illicita crudelitate in mortui hominis cadauer ita furit. </p>
             </div>
 
-            <div type="schol" n="4-7">
+            <div type="schol" n="4">
                <p> (QVIN TE DIVVM IMPLACIDISSIME QVAMQVAM / PRAECIPVVM TVNC CAEDIS OPVS GRADIVE FVREBAS / OFFENSVM VIRTVTE FERVNT NEC COMMINVS IPSVM / ORA SED ET TREPIDOS RETRO TORSISSE) IVGALES tanta crudelitas in scelere Tydei fuit ut etiam cruentum numen nefas horruerit. </p>
             </div>
 
@@ -14543,11 +14544,11 @@
                <p> (SVA ...) HVMVS solum patriae suae. </p>
             </div>
 
-            <div type="schol" n="28">
+            <div type="schol" n="28b">
                <p> INCESTARVM AVIVM id est humano sanguine pollutarum, siue quia cadauera eminus sentiunt. </p>
             </div>
 
-            <div type="schol" n="28-29">
+            <div type="schol" n="28b">
                <p> 
                   <del>AVRA</del> NOCENTEM / (AERA) id est mortibus uitiatum. Vt Lucanus:</p> 
                <l>'aera non sanum motum<supplied>que</supplied> cadauera sentit'. </l>
@@ -14557,11 +14558,11 @@
                <p> (SINE) FVNERE id est sine mortis officio. </p>
             </div>
 
-            <div type="schol" n="37-38">
+            <div type="schol" n="37">
                <p> (NIMIVM NAM COGNITA VIRTVS / OENIDAE CREDI LETVM) SVADETQVE (VETATQVE) suadere uult quod nimia uirtus faciat semper incautos. Siue illud magis asserit quod interdum nimia uirtus consilio careat. </p>
             </div>
 
-            <div type="schol" n="55-56">
+            <div type="schol" n="55">
                <p> (GAVDIA) TANTI / EMPTA MIHI id est Tydei morte. </p>
             </div>
 
@@ -14573,7 +14574,7 @@
                <p> TELAMONA hic Meleagrum dicitur unice dilexisse ut Theseus Pirithoum. </p>
             </div>
 
-            <div type="schol" n="&lt;69&gt;">
+            <div type="schol" n="69">
                <p> 
                   <supplied>QVALIS</supplied> quantus. </p>
             </div>
@@ -14582,20 +14583,20 @@
                <p> QVIS (TVVS HIC QVIS AB HOSTE) CRVOR quia <del>et</del> sanguine fuerat Tydeus aspersus. </p>
             </div>
 
-            <div type="schol" n="71-72">
+            <div type="schol" n="71">
                <p> (NVM FALLOR ET IPSE) / INVIDIT PATER (ET TOTA MARS IMPVLIT HASTA) tantae uirtutis uult ostendere Tydeum fuisse ut etiam patris sui Martis tangeretur inuidia. </p>
             </div>
 
-            <div type="schol" n="75">
+            <div type="schol" n="75a">
                <p> (TVNE MEOS HOSTES) HVC VSQVE (EXOSVS) usque adeone furuisti ut inimicos dentibus suis absumeres? </p>
             </div>
 
-            <div type="schol" n="75-76">
+            <div type="schol" n="75b">
                <p> VLTRA / SOSPES EGO tibi superstes sum? Cum exprobratione dicitur. Vt Vergilius:</p> 
                <l>'morte tua uiuo'. </l>
             </div>
 
-            <div type="schol" n="&lt;89&gt;">
+            <div type="schol" n="89">
                <p> 
                   <supplied>CONLECTA ... PECTORA PARMAE</supplied> sub scuto curuata. </p>
             </div>
@@ -14620,7 +14621,7 @@
                <p> NON PVDET HOS MANES id est cadauer intueri. </p>
             </div>
 
-            <div type="schol" n="102-103">
+            <div type="schol" n="102">
                <p> (NVLLAE ILLVM VOLVCRES) NVLLA IMPIA MONSTRA (NEC IPSE / SI DEMVS PIVS IGNIS EDAT) ita Tydeum Melanippi cadauere funestatum dicit ut corpus eius horreant etiam ferae consumere. </p>
             </div>
 
@@ -14644,11 +14645,11 @@
                <p> TVNC PRIMVM FETA in primo enim partu maior est fetus affectio. </p>
             </div>
 
-            <div type="schol" n="120-121">
+            <div type="schol" n="120">
                <p> (POTESTAS) / REDDERE TELA (FVIT) in se ab hostibus missa in ipsos iterum retorquere. </p>
             </div>
 
-            <div type="schol" n="122-123">
+            <div type="schol" n="122">
                <p> (PISAEAQVE) PRAEPETIS (IDAE / TVRMA SVBIT) aut altissime posuit uolantis — ut Vergilius:</p>
                <lg>
                   <l>'quem praepes ab Ida</l>
@@ -14669,7 +14670,7 @@
                <p> SPES pro 'metu'. </p>
             </div>
 
-            <div type="schol" n="&lt;134-135&gt;">
+            <div type="schol" n="134">
                <p> 
                   <supplied>POSITVM ... / ... CAPVT</supplied> id est Tydei cadauer. </p>
             </div>
@@ -14678,7 +14679,7 @@
                <p> MINAE terrores hostium. </p>
             </div>
 
-            <div type="schol" n="148-150">
+            <div type="schol" n="148">
                <p> SED MEMOR ELYSII (REGIS NOXASQVE RECENSENS / TYDEOS IN MEDIOS ASTV SVBIT IMPIA CAMPOS / TISIPHONE) qui scelera solet ulcisci. Non enim exciderant Tisiphone<supplied>s</supplied> animo scelera quae Tydeus parricidio perpetrarat. Siue quod nuper Melanippi caput absumpserat. </p>
             </div>
 
@@ -14711,25 +14712,25 @@
                <l>'summoque ulularunt uertice Nymphae'. </l>
             </div>
 
-            <div type="schol" n="&lt;180&gt;">
+            <div type="schol" n="180">
                <p> 
                   <supplied>PRO DVRA POTENTIA FATI</supplied> exclamatio per interpositionem. </p>
             </div>
 
-            <div type="schol" n="181-183">
+            <div type="schol" n="181">
                <p> (MODO CVI THEBANA SEQVENTI / AGMINA SIVE GRADVS SEV FRENA EFFVNDERET INGENS) / LIMES (VTRIMQVE DATVS) siue equiti siue pediti uia dabatur Tydeo a fugientibus hostibus. </p>
             </div>
 
-            <div type="schol" n="184-185">
+            <div type="schol" n="184">
                <p> (IVVAT ORA RIGENTIA LETO / ET FORMIDATOS) IMPVNE LACESSERE (VVLTVS) delectabat Thebanos secure insultare cadaueri. </p>
             </div>
 
-            <div type="schol" n="&lt;194&gt;">
+            <div type="schol" n="194a">
                <p> 
                   <supplied>DAMNAQVE COMMEMORANT</supplied> rura ouiliaque uastauerat. </p>
             </div>
 
-            <div type="schol" n="194-195">
+            <div type="schol" n="194b">
                <p> (SEV IAM SVB CVLMINE FIXVS / EXCVBAT ANTIQVO SEV PENDET) GLORIA LVCO de uenatione gloria aut de ferae magnitudine. <hi rend="italic">Luco</hi> uero aut Dianae aut Siluano. Alia sunt quae figuntur, alia quae a pastoribus templorum tholis suspenduntur. Dentes et cornua figuntur, pelles et alia suspenduntur. Vt Vergilius:</p> 
                <l>'suspendiue tholo aut sacra ad fastigia fixi'. </l>
             </div>
@@ -14738,11 +14739,11 @@
                <p> SOLVTI aut fracti aut a frenis liberi. </p>
             </div>
 
-            <div type="schol" n="202">
+            <div type="schol" n="202a">
                <p> IMPEDIVNT retardant. FEMVR Hippomedontis scilicet. </p>
             </div>
 
-            <div type="schol" n="202-203">
+            <div type="schol" n="202b">
                <p> (QVOD CVSPIDE FIXVM) / REGIS ECHIONII supra enim de telo Eteoclis dixit clipeum Hippomedontis fuisse transfixum:</p>
                <lg>
                   <l>'quod in aere moratum</l>
@@ -14751,7 +14752,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="207-208">
+            <div type="schol" n="207">
                <p> (FATORVM <del>I</del>GNARVM DOMINI SOLVMQVE) FREMENTEM / (QVOD VACET) poetis licet equis humanos sensus dare. Dicit ergo poeta equum Tydei doluisse mortem domini. Vt Vergilius:</p>
                <lg>
                   <l>'post bellator equus positis insignibus Aethon</l>
@@ -14775,7 +14776,7 @@
                <p> EXTORREM in exilio degentem, quasi cuius umbra careat patria sepultura. (NEV) TV QVOQVE (LAESERIS VMBRAM) ut ego eum relinquens laesi manes Tydei. </p>
             </div>
 
-            <div type="schol" n="218-219">
+            <div type="schol" n="218">
                <p> (AVDISSE ACCENSVMQVE PVTES HOC) FVLMINE RAPTVM / (ABSTVLIT) intellegi uult poeta exhortationes Hippomedontis equum sensisse, cum significat eum in uindictam domini tantae uelocitatis nimietate correptum. </p>
             </div>
 
@@ -14807,7 +14808,7 @@
                <p> ILLA BREVIS REQVIES mora fluuii fugientibus Thebanis e tardatione Hippomedontis paruam requiem tribuit. </p>
             </div>
 
-            <div type="schol" n="228-229">
+            <div type="schol" n="228">
                <p> (STVPET) HOSPITA BELLI / (VNDA) noua cladibus, quae adhuc nullo fuerat belli cruore fuscata. </p>
             </div>
 
@@ -14819,15 +14820,15 @@
                <p> ATTONITIS Thebanis. LONGVM (DIMITTERE HABENAS) interpositio a mora. </p>
             </div>
 
-            <div type="schol" n="234">
+            <div type="schol" n="234a">
                <p> SICVT ERAT id est armatus. </p>
             </div>
 
-            <div type="schol" n="234-235">
+            <div type="schol" n="234b">
                <p> (TANTVM VIRIDI DEFIXA PARVMPER / CAESPITE POPVLEO) COMMENDAT SPICVLA (TRVNCO) sua scilicet, ne eum in flumine impedirent. </p>
             </div>
 
-            <div type="schol" n="237-238">
+            <div type="schol" n="237">
                <p> (QVANTVM / TENDERE CONATVS ANIMAE VALVERE) SVB VNDIS hoc est: quantum poterant eorum spiritus sub undis durare. Lucanus:</p> 
                <l>'animam seruare sub undis'. </l>
             </div>
@@ -14853,15 +14854,15 @@
                <p> EMICET id est delphinus. (VISIS MALIT CERTARE) CARINIS ut magis eligat carinis illudere quam insequi pisces. </p>
             </div>
 
-            <div type="schol" n="250-251">
+            <div type="schol" n="250">
                <p> (CONSVETAQVE CAMPO / FLVCTVAT ET MERSAS LEVIS VNGVLA) QVAERIT ARENAS titubat equus flumen ingressus et quaerit campum ubi firmos solet gressus infigere. </p>
             </div>
 
-            <div type="schol" n="253-254">
+            <div type="schol" n="253">
                <p> (EVASVRVMQVE) RELICTO / (AMNE) quia iam prope riuum euaserat fugiens. </p>
             </div>
 
-            <div type="schol" n="254-255">
+            <div type="schol" n="254">
                <p> (NI FATA VETENT ET) STAMINE PRIMO / (ABLATVM TELLVRE MORI) id est: erat notio uel institutio Parcarum ut in fluuio potius moreretur quam in terra. Negatum <supplied>a</supplied> Fatis. </p>
             </div>
 
@@ -14881,7 +14882,7 @@
                <p> (EFFLANTESQVE ANIMAS RETRO PREMIT) OBVIVS AMNIS exeuntem spiritum aqua infusa gutturi retardabat id est non sinebat spiritum exire de corpore. </p>
             </div>
 
-            <div type="schol" n="274-275">
+            <div type="schol" n="274">
                <p> RESOLVTVS (... / EMERSISSE VADIS) amplexu fratris liberatus flumen euadere. </p>
             </div>
 
@@ -14901,12 +14902,12 @@
                <p> INDVIT totum pertransiit. </p>
             </div>
 
-            <div type="schol" n="282">
+            <div type="schol" n="282a">
                <p> (NVSQVAM) AVCTOR (ERAT) qui uulnus inflixerat nusquam apparebat. Vergilius:</p> 
                <l>'neque enim is teli nec uulneris auctor'. </l>
             </div>
 
-            <div type="schol" n="282-283">
+            <div type="schol" n="282b">
                <p> (CONCITA TRACTV / GVRGITIS) EFFVGIENS (INVENERAT HASTA CRVOREM) hasta, dum impetu gurgitis traheretur, inuenit <supplied>cruorem</supplied>.</p>
             </div>
 
@@ -14943,7 +14944,7 @@
                </l>
             </div>
 
-            <div type="schol" n="298-299">
+            <div type="schol" n="298">
                <p> (NVDA NEC FLEBILIS VMBRA / STRIDEBIT VESTROS TYDEVS) INHVMATVS AD IGNES neque circa rogos uestros flebilis umbra Tydei et stridorem et lamenta dabit dolens quod ipsa non meruerit rogum. </p>
             </div>
 
@@ -14988,7 +14989,7 @@
                <p> PRIMA DIES quando natus est. </p>
             </div>
 
-            <div type="schol" n="[324]">
+            <div type="schol" n="324">
                <p> 
                   <del>ADVLANTEM <hi rend="italic">adulat</hi>: alludit ac blanditur, interdum supplicat.</del>
                </p>
@@ -15002,7 +15003,7 @@
                <p> (PARITERQVE) REVERTITVR AMNIS cum natante puero in originem suam recurrit. </p>
             </div>
 
-            <div type="schol" n="328-329">
+            <div type="schol" n="328">
                <p> (NON) ANTHEDONII (TEGIT HOSPITIS INGVINA PONTVS / BLANDIOR) <supplied>
                      <hi rend="italic">Anthedonii</hi>
                   </supplied> Anthedon ciuitas Glauci, qui deus maris est factus gustata herba qua pisces mortui animam receperunt. INGVINA a qua parte fuerat transformatus. </p>
@@ -15032,11 +15033,11 @@
                <p> LERNA palus est Graeciae in qua serpens plena capitibus eminebat. </p>
             </div>
 
-            <div type="schol" n="342-343">
+            <div type="schol" n="342">
                <p> DEVM(QVE) / ALTRICES (... AQVAS) Liberi patris et Herculis. Ergo numinum haec sunt fluenta. </p>
             </div>
 
-            <div type="schol" n="344-345">
+            <div type="schol" n="344">
                <p> (OPPOSVIT) CVMVLO (SE DENSIOR AMNIS / TARDAVITQVE MANVM VVLNVS (TAMEN ILLE RETENTVM / PERTVLIT) <supplied>
                      <hi rend="italic">cumulo</hi>
                   </supplied> aquarum multitudine in unum congregata. VVLNVS ... RETENTVM quod opposita mole aquarum conatus est fluuius retardare. Siue <hi rend="italic">uulnus</hi> hastam dixit. Vt Vergilius:</p>
@@ -15055,7 +15056,7 @@
                <p> (GRAVIORA) CAVAE (SONVERVNT MVRMVRA RIPAE) quia naturaliter loca concaua grauius sonant. </p>
             </div>
 
-            <div type="schol" n="349-350">
+            <div type="schol" n="349">
                <p> (VLTIMVS ILLE SONVS MORIBVNDO EMERSIT AB ORE) / MATER (IN HANC MISERI CECIDERVNT FLVMINA VOCEM) cum extrema uoce moriens matrem uocaret, extremum spiritum unda superueniens clausit. </p>
             </div>
 
@@ -15067,11 +15068,11 @@
                <p> FVRIBVNDA attonita. </p>
             </div>
 
-            <div type="schol" n="358-359">
+            <div type="schol" n="358">
                <p> (QVA MIXTA SVPREMVM / ISMENON PRIMI MVTANT) CONFINIA PONTI id est: in qua parte se mari iungebat Ismenos, mutans colorem et saporem. </p>
             </div>
 
-            <div type="schol" n="360-362">
+            <div type="schol" n="360">
                <p> (FLVCTIVAGAM SIC SAEPE DOMVM MADIDOSQVE PENATES) / ALCYONE (DESERTA GEMIT CVM PIGNORA SAEVVS / AVSTER ET ALGENTES RAPVIT THETIS INVIDA NIDOS) <hi rend="italic">alcyones</hi> aues marinae quae hieme in mari nidificant et pullos nutrire dicuntur qui dies septem tranquillissimum pelagus faciunt. </p>
             </div>
 
@@ -15079,7 +15080,7 @@
                <p> OBSTAT non sponte, sed limo et cadaueribus turbatus. </p>
             </div>
 
-            <div type="schol" n="369-370">
+            <div type="schol" n="369">
                <p> (PRONA) RECLINAT / (CORPORA) supinat ut uultus possit mortuorum rimari. </p>
             </div>
 
@@ -15095,7 +15096,7 @@
                <p> VNDARVM propter Ismenon. NEMORVM propter Faunum. </p>
             </div>
 
-            <div type="schol" n="&lt;386&gt;">
+            <div type="schol" n="386">
                <p> 
                   <supplied>ORANTESQVE TIBI SERVIRE NAPAEAE</supplied> quia rogabant tibi in matrimonium sociari. </p>
             </div>
@@ -15117,11 +15118,11 @@
                <p> NON HIC SOLVM (ACCENSVRE NEPOTEM) habebis causam aliam lacrimarum propter Hypseum Asopi filium, quem postea Capaneus occisurus est. </p>
             </div>
 
-            <div type="schol" n="401-402">
+            <div type="schol" n="401">
                <p> (QVALITER ISTHMIACO) NONDVM NEREIDA (PORTV / LEVCOTHEAN PLANXISSE FERVNT) cum adhuc in Nympham minime fuisset mutata et fieret dea iuxta Isthmum ubi fuerat demersa. </p>
             </div>
 
-            <div type="schol" n="402-403">
+            <div type="schol" n="402">
                <p> (DVM PECTORE ANHELO / FRIGIDVS IN MATREM SAEVVM MARE) REPPVLIT INFANS Palaemon uidendo flentem suam matrem <del>et</del> undas torsit quae illam ad se traxerunt. Constat autem <supplied>eam</supplied> dolore praecipitasse <supplied>se</supplied> postquam inuita filium proiecit in mare. </p>
             </div>
 
@@ -15129,7 +15130,7 @@
                <p> (MELIOR VENIT) ANNVS IN AGROS pluuiis meliora frugum incrementa proueniunt. </p>
             </div>
 
-            <div type="schol" n="407-408">
+            <div type="schol" n="407">
                <p> (VT LAMENTA PROCVL) QVAMQVAM OBSTREPIT IPSE (NOVOSQVE / ACCEPIT NATAE GEMITVS) quamquam aquarum strepitus impediebat auditum, tamen auribus filiae lamenta percepit. </p>
             </div>
 
@@ -15142,7 +15143,7 @@
                <p> SCRVPEA <del>LIMO</del> lapillosa loca circa mare uel flumina <hi rend="italic">scrupea</hi> dicuntur. </p>
             </div>
 
-            <div type="schol" n="419-420">
+            <div type="schol" n="419">
                <p> (MANVQVE GENAS ET NEXA VIRENTIBVS VLVIS / CORNVA) CONCVTIENS iracundiae signum. </p>
             </div>
 
@@ -15150,7 +15151,7 @@
                <p> (QVOD TOTIENS HOSPESQVE) TVIS ET CONSCIVS ACTIS quod recepi tua stupra et libidinum tuarum conscius fui. </p>
             </div>
 
-            <div type="schol" n="423-424">
+            <div type="schol" n="423">
                <p> FALSA (NVNC IMPROBA FRONTE / CORNVA) Antiopam, Nyctei filiam, stuprauit Iuppiter in Satyrum uersus, matrem Zethi et Amphionis. Ideo <hi rend="italic">falsa ... <supplied>fronte</supplied> cornua</hi> quia cornuti sunt Satyri quorum imaginem falsam sibi sumpserat Iuppiter. </p>
             </div>
 
@@ -15183,16 +15184,16 @@
                <p> CLAMATVS (SACRIS VLVLATIBVS) sacrorum clamore repletus. </p>
             </div>
 
-            <div type="schol" n="&lt;435&gt;">
+            <div type="schol" n="435">
                <p> 
                   <supplied>BACCHAEAQVE CORNVA</supplied> quibus Liberi caput ornatur. </p>
             </div>
 
-            <div type="schol" n="437-438">
+            <div type="schol" n="437">
                <p> STRYMONOS (IMPIA ... / STAGNA ... SPVMIFER ... HEBRVS) Thraciam dicit. </p>
             </div>
 
-            <div type="schol" n="439-440">
+            <div type="schol" n="439">
                <p> (NEC TE) ADMONET (ALTRIX / VNDA TVASQVE MANVS) nec tibi in mentem uenit. <supplied>
                      <hi rend="italic">Nec</hi>
                   </supplied> bis accipiendum est, ut sit: nec te nec manus tuas. </p>
@@ -15206,33 +15207,33 @@
                <p> NI MORTALIS EGO si non est in me immutata natura. </p>
             </div>
 
-            <div type="schol" n="446">
+            <div type="schol" n="446a">
                <p> INFRENDENS minaciter dentibus sonitum dans. <hi rend="italic">Infrendere</hi> enim est proprie dentes irascendo quatere. Vnde et 'infrendes' dicuntur pueri sine dentibus. </p>
             </div>
 
-            <div type="schol" n="446-447">
+            <div type="schol" n="446b">
                <p> (SPONTE FVRENTIBVS VNDIS) / SIGNA DEDIT furoris sui undis dedit indicia. </p>
             </div>
 
-            <div type="schol" n="447-449">
+            <div type="schol" n="447">
                <p> (MITTIT GELIDVS MONTANA CITHAERON) / AVXILIA (ANTIQVASQVE NIVES ET PABVLA BRVMAE / IRE IVBET) <supplied>
                      <hi rend="italic">auxilia</hi>
                   </supplied> fluenta niuium. Cithaeron Ismeno ni<supplied>uem</supplied> in uindictam filiae uelut auxilia misit exercitus. PABVLA BRVMAE eleganter niues <hi rend="italic">brumae pabula</hi> dixit. Certum est enim niuium incremento stridorem hiemis magis augeri. </p>
             </div>
 
-            <div type="schol" n="449">
+            <div type="schol" n="449a">
                <p> FRATER (... ASOPVS) eiusdem prouinciae fluuius. </p>
             </div>
 
-            <div type="schol" n="449-450">
+            <div type="schol" n="449b">
                <p> TACITAS (... / ... VIRES) uel sine stridore, quia dicitur Asopus lenis fluere, uel occultas per latentia spiramina terrarum uires suas fluuius refundebat. </p>
             </div>
 
-            <div type="schol" n="453-454">
+            <div type="schol" n="453">
                <p> (ATQVE AVIDOS TOLLENS AD SIDERA VVLTVS / VMENTES NEBVLAS EXHAVRIT ET) AERA SICCAT pluuiae enim ex nebulis conceptae terrae funduntur. Dicit ergo aquarum semina omnia ad incrementa huius fluuii fuisse conuersa. </p>
             </div>
 
-            <div type="schol" n="455-456">
+            <div type="schol" n="455">
                <p> (VTROQVE ...) / AGGERE riparum altitudine. </p>
             </div>
 
@@ -15247,7 +15248,7 @@
                <l>'armatumque auro circumspicit Oriona'. </l>
             </div>
 
-            <div type="schol" n="463-465">
+            <div type="schol" n="463">
                <p> (SEMPERQVE VMBONE SINISTRO / TOLLITVR ET CLIPEVM NIGRANTE SVPERVENIT) AESTV / (SPVMEVS ADSVLTANS) aquarum sonus ac fremitus Hippomedontis clipeum texit. </p>
             </div>
 
@@ -15263,11 +15264,11 @@
                <p> SVBRVTA euersa id est subtereuntia. FALLACI … LIMO qui creditos sibi gressus decipiebat et nutare faciebat. </p>
             </div>
 
-            <div type="schol" n="478">
+            <div type="schol" n="478a">
                <p> IMBELLI FAMVLATE DEO debili Libero. </p>
             </div>
 
-            <div type="schol" n="478-479">
+            <div type="schol" n="478b">
                <p> SOLVMQVE CRVOREM / (FEMINEIS EXPERTE CHORIS) quem, cum bacchantur ac se lacerant, matres effundunt. </p>
             </div>
 
@@ -15283,7 +15284,7 @@
                <p> OPPOSITI Hippomedontis. </p>
             </div>
 
-            <div type="schol" n="486-487">
+            <div type="schol" n="486">
                <p> CONVERSA(QVE LENTE / TERGA REFERT) ut ostenderet uiri fortis constantiam, dicit eum tarde cessisse uel numini. </p>
             </div>
 
@@ -15316,7 +15317,7 @@
                <p> NEC PERTVLIT (ILLA TRAHENTEM) non sustinuit arbor Hippomedonta trahentem. </p>
             </div>
 
-            <div type="schol" n="497-498">
+            <div type="schol" n="497">
                <p> (SED MAIORE SVPER QVAM STABAT) PONDERE VICTA / (SOLVITVR) tenentis uiri grauitate uulsa est. </p>
             </div>
 
@@ -15345,20 +15346,20 @@
                <p> TORRENTIS <hi rend="italic">torrentia</hi> dicuntur flumina quae subiecta montibus facillime aquarum incrementis augentur. INIQVIS magnis siue uim inferentibus. </p>
             </div>
 
-            <div type="schol" n="&lt;514-517&gt;">
+            <div type="schol" n="514">
                <p> 
                   <supplied>EN MEVS HIPPOMEDON ... / ... / ... PELAGI CRVDELIBVS IBIT / PRAEDA FERIS quando</supplied> Hippomedontis corpus fluctus abstulerint. </p>
             </div>
 
-            <div type="schol" n="517-519">
+            <div type="schol" n="517">
                <p> (CERTE TVMVLOS SVPREMAQVE VICTIS) / BVSTA DABAS (VBI CECROPIAE POST PROELIA FLAMMAE / THESEOS IGNIS VBI EST) quia, cum uetaret Creon sepeliri, liberi occisorum ducum uxoresque eorum a Theseo rege Atheniensium meruere ut bello Thebanis in<del>ob</del>lato redderet miseris sepulturam. Inuidiose hoc Iuno dixit, quoniam Thebanorum <del>et</del> crudelitatem sine miseratione tolerare <supplied>non</supplied> pot<supplied>u</supplied>erit. </p>
             </div>
 
-            <div type="schol" n="523-524">
+            <div type="schol" n="523">
                <p> RESEDIT / (TEMPESTAS) peracta siue finita. </p>
             </div>
 
-            <div type="schol" n="528-530">
+            <div type="schol" n="528">
                <p> (TVNC VVLNERA MANANT / QVIQVE SVB AMNE DIV) STVPVIT (CRVOR AERE NVDO / SOLVITVR) sanguis Hippomedontis qui frigore fluuii gelatus fuerat morte solutus aeris calore <supplied>e</supplied> uulneribus manat. </p>
             </div>
 
@@ -15374,7 +15375,7 @@
                <p> ORDINE <del>SILVAS</del> longitudine, quia ipsa post casum quercus extenditur. </p>
             </div>
 
-            <div type="schol" n="&lt;537-538&gt;">
+            <div type="schol" n="537">
                <p> 
                   <supplied>NON TAMEN AVT ENSEM GALEAMVE AVDACIA CVIQVAM / TANGERE</supplied> timore compressis. </p>
             </div>
@@ -15383,7 +15384,7 @@
                <p> (TORVOS) LAXAVIT (CASSIDE VVLTVS) nudauit galeam adimendo. </p>
             </div>
 
-            <div type="schol" n="548-549">
+            <div type="schol" n="548">
                <p> ADES O MIHI DEXTERA TANTVM / (TV PRAESENS BELLIS ET INEVITABILE NVMEN) ut Vergilius:</p>
                <l>'dextra mihi deus et telum, quod missile libro'.</l>
             </div>
@@ -15436,7 +15437,7 @@
                <p> EFFIGIESQVE SVAS (SIMVLACRAQVE NOTA CREMARI) portendebatur ei filium moriturum qui est matris effigies. </p>
             </div>
 
-            <div type="schol" n="583-584">
+            <div type="schol" n="583">
                <p> PRAECIPVOS (SED ENIM ILLA METVS PORTENDERE VISA EST / NOX MISERAE) post alias noctes haec somniis grauior uidebatur. (ILLA ...) NOX <del>MISERAE</del> in qua uidet somnium quod poeta dicturus est. </p>
             </div>
 
@@ -15444,7 +15445,7 @@
                <p> EREXIT excitauit sollicitudine. </p>
             </div>
 
-            <div type="schol" n="585-586">
+            <div type="schol" n="585">
                <p> (NOTA PER ARCADIAS) FELICI ROBORE (SILVAS / QVERCVS ERAT) <supplied>
                      <hi rend="italic">felici robore</hi>
                   </supplied> fructiferi roboris. Enarratio somnii ultimae noctis. </p>
@@ -15464,7 +15465,7 @@
                <p> IMPEDIT adoperit. </p>
             </div>
 
-            <div type="schol" n="593-594">
+            <div type="schol" n="593">
                <p> (VT FORTE IVGIS LONGO DE)FESSA (REDIBAT / VENATV) somnio quod uidit. </p>
             </div>
 
@@ -15496,11 +15497,11 @@
                <p> (NON MOLLIA) SIGNA uenationis insignia. </p>
             </div>
 
-            <div type="schol" n="609-610">
+            <div type="schol" n="609">
                <p> (FREQVENTO) / MORE NIHIL GRAIO non Graecorum more delector. </p>
             </div>
 
-            <div type="schol" n="610-611">
+            <div type="schol" n="610">
                <p> (GENS) ASPERA (RITV / COLCHIS) ubi homines immolantur sacris. </p>
             </div>
 
@@ -15532,7 +15533,7 @@
                <p> CONFESSA innocentiae proximus est qui culpam fatetur. </p>
             </div>
 
-            <div type="schol" n="620-621">
+            <div type="schol" n="620">
                <p> (INQVE MEOS REPTAVIT) PROTINVS ARCVS / (TELA PVER LACRIMIS ET PRIMA VOCE POPOSCIT) mox ut potuit ad armorum nostrorum usus accessit. </p>
             </div>
 
@@ -15540,19 +15541,19 @@
                <p> QVID TREPIDAE NOCTES (SOMNVSQVE MINANTVR) interpositio cum interrogatione. </p>
             </div>
 
-            <div type="schol" n="624-625">
+            <div type="schol" n="624">
                <p> (DA VISERE BELLI / VICTOREM VEL SI AMPLA PETO) DA VISERE TANTVM <hi rend="italic">ampla</hi> maiora. Si uictorem non possum <supplied>uisere</supplied>, restitue, quaeso, diua, uel uictum. </p>
             </div>
 
-            <div type="schol" n="626">
+            <div type="schol" n="626a">
                <p> TVAQVE ARMA uenationis, id est sagittas. </p>
             </div>
 
-            <div type="schol" n="626-627">
+            <div type="schol" n="626b">
                <p> PREME (DIRA MALORVM / SIGNA) compesce nefanda somniorum omina. </p>
             </div>
 
-            <div type="schol" n="627-628">
+            <div type="schol" n="627">
                <p> QVID (IN NOSTRIS NEMORALIS DELIA SILVIS / MAENADES HOSTILES THEBANAQVE NVMINA REGNANT) <supplied>
                      <hi rend="italic">quid</hi>
                   </supplied> quare. DELIA uocatiuus est. MAENADES Bacchae, quoniam in somnis quercum uiderat a Libero patre et Bacchis forte proscissam. </p>
@@ -15574,7 +15575,7 @@
                <p> (IN MEDIIS ...) MAENALON ASTRIS tanta est Maenali altitudo ut cacumen eius astris uideatur insertum. </p>
             </div>
 
-            <div type="schol" n="641-642">
+            <div type="schol" n="641">
                <p> (INTERIOR CAELI) QVA SEMITA LVCET / (DIS TANTVM) diis eam tantum partem significat ad transitum datam quae supremum aerem infimumque coniungit, qui locus est iuxta circulum lunae. De quo Lucanus:</p>
                <lg>
                   <l>'qua niger astriferis conectitur axibus aether,</l>
@@ -15582,7 +15583,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="643-644">
+            <div type="schol" n="643">
                <p> (PARNASSI ...) / COLLA Parnassi iuga. </p>
             </div>
 
@@ -15594,7 +15595,7 @@
                <p> LABDACIAS (... COHORTES) Thebanas <del>a patre Labdaco</del>.</p>
             </div>
 
-            <div type="schol" n="653-655">
+            <div type="schol" n="653">
                <p> (EN IPSE MEI) PVDET IRRITVS (ARMA / CVLTORIS FRONDESQVE SACRAS AD INANIA VIDI / TARTARA) quia Amphiarao auxilium ferre non potui. </p>
             </div>
 
@@ -15606,11 +15607,11 @@
                <p> ANTRA ubi oracula Apollinis dantur. </p>
             </div>
 
-            <div type="schol" n="663-665">
+            <div type="schol" n="663">
                <p> (SED DECVS EXTREMVM CERTE) CONFVSA VICISSIM / (VIRGO REFERT VERAEQVE LICET SOLACIA MORTI / QVAERERE NEC FVGIET POENAS) interposuit suam poeta personam. Ordo ergo et sensus talis est: si mihi eum non licet de proelio liberare, certe extremum decus et solacia mortis ei concedam ne inultus occumbat. Quae uerba Dianae posuit. Vt sit parenthesis ex persona poetae: <hi rend="italic">confusa uicissim uirgo refert</hi>.</p>
             </div>
 
-            <div type="schol" n="668-669">
+            <div type="schol" n="668">
                <p> LIBANDAQVE FRATRI / (... ORA TVLIT) osculata est fratrem. </p>
             </div>
 
@@ -15636,7 +15637,7 @@
                <p>CASTIGATA IVBARVM pexa et collecta iuba in ceruice equi sedebat ornata. </p>
             </div>
 
-            <div type="schol" n="688-689">
+            <div type="schol" n="688">
                <p> NEMORISQVE NOTAE (SVB PECTORE PRIMO / IACTANTVR) signa uenationis equo sub pectoris prima parte pendebant. </p>
             </div>
 
@@ -15644,7 +15645,7 @@
                <p> LVNATA in modum lunae curuata. </p>
             </div>
 
-            <div type="schol" n="691-692">
+            <div type="schol" n="691">
                <p> (HOC) NEVERAT VNVM / (MATER OPVS) interpositio. Et bene <hi rend="italic">unum</hi>, quod nisi pietate uicta filii nunquam uenatrix feminea opera contigisset. </p>
             </div>
 
@@ -15656,11 +15657,11 @@
                <p> (A CONO MISSAS IN TERGA) CATENAS a parte enim galeae descendunt catenae quae ab ictu colla sedentis defendant. </p>
             </div>
 
-            <div type="schol" n="704-705">
+            <div type="schol" n="704">
                <p> (NEC FORMAE SIBI LAVDE PLACET) MVLTVMQVE SEVERIS / (ASPERAT ORA MINIS) supra praemissa Parthenopaei pulchritudine hic est uitanda laudatio: ipse tamen formae laudem aspernatur et, ut celet pulchritudinem suam, irascitur. </p>
             </div>
 
-            <div type="schol" n="706-707">
+            <div type="schol" n="706">
                <p> (DAT SPONTE LOCVM THEBANA IVVENTVS / NATORVM MEMORES) INTENTAQVE (TELA RETORQVENT) contra Parthenopaeum parata aetatis misericordia reuocant tela. </p>
             </div>
 
@@ -15668,7 +15669,7 @@
                <p> (TACITO DVCVNT SVSPIRIA) VOTO ut nubant ei aut uincat. </p>
             </div>
 
-            <div type="schol" n="713-715">
+            <div type="schol" n="713">
                <p> QVOD INQVIT / (NVNC TIBI QVOD LETI QVAERAM DEA FIDA PROPINQVI / EFFVGIVM) dubitantis est. </p>
             </div>
 
@@ -15702,7 +15703,7 @@
                   <hi rend="italic">coryton</hi> 'theca' arcus solius dicitur, sicut 'pharetra' sagittarum et 'sagma' scuti. Nunc ergo <hi rend="italic">coryton</hi> pro 'pharetra' posuit. </p>
             </div>
 
-            <div type="schol" n="&lt;734&gt;">
+            <div type="schol" n="734">
                <p> 
                   <supplied>IPSA</supplied> 
                   <hi rend="italic">ipsa</hi> est Hecate, quae inuocatur a magis. </p>
@@ -15748,7 +15749,7 @@
                   </supplied> insidiose facta. Dicit ferrum sagittarum tres uncos habere ut infixum reuelli non possit. </p>
             </div>
 
-            <div type="schol" n="753-754">
+            <div type="schol" n="753">
                <p> (ALIO GEMINATVM LVMINE VVLNVS) / EXPLEVIT (TENEBRAS) ambos illius oculos obcaecauit. HOSTEM Parthenopaeum. </p>
             </div>
 
@@ -15769,7 +15770,7 @@
                <p> (HVNC VIRIDES) NON EXCIPIETIS AMYCLAE minime in suam patriam reuertetur. AMYCLAE ciuitas Laconicae regionis. </p>
             </div>
 
-            <div type="schol" n="&lt;775&gt;">
+            <div type="schol" n="775">
                <p> 
                   <supplied>SOLO RESPICIT ARCV</supplied> post terga sagittas mittebat fugiens sicut Parthi. Lucanus:</p> 
                <l>'et melior cessisse loco quam pellere uictus'. </l>
@@ -15787,11 +15788,11 @@
                <p> (IRAM ...) INFRA non dignus ira hostis, contemptibilis. </p>
             </div>
 
-            <div type="schol" n="786-787">
+            <div type="schol" n="786">
                <p> (QVODSI TE MAESTA SEPVLCRI) / FAMA MOVET si uis gloriose mori. </p>
             </div>
 
-            <div type="schol" n="&lt;791-792&gt;">
+            <div type="schol" n="791">
                <p> 
                   <supplied>QVISNAM ADEO PVER VT BELLARE RECVSET / TALIBVS</supplied> dicit Parthenopaeus Thebanorum debilitati etiam puerilia arma sufficere. </p>
             </div>
@@ -15860,11 +15861,11 @@
                <p> (ABIT SOLO POST HAEC EVICTA) PVDORE subaudis: cessit et auertit a Parthenopaeo faciem. </p>
             </div>
 
-            <div type="schol" n="842-844">
+            <div type="schol" n="842">
                <p> (HORRENDVMQVE DRYANTA MOVET CVI SANGVINIS AVCTOR) / TVRBIDVS ORION (COMITESQVE ODISSE DIANAE / INDE FVRIT PRIMVM) quia hic Dryas Orionis nepos fuit, qui immissu Dianae scorpionis ictu periit. <hi rend="italic">Turbidus</hi> autem quia stella eius tempestatem mouet, siue fortis uel incontinens, quippe qui nimio amore Dianae flagrauit. </p>
             </div>
 
-            <div type="schol" n="[844]">
+            <div type="schol" n="844">
                <p> 
                   <del> (INDE) FVRIT PRIMVM ex illa causa quia patrem eius Diana sagittis occiderat. Vnde Horatius:</del>
                </p> 
@@ -15881,15 +15882,15 @@
                <p> (NEC) SERVAT VIRES dum hostes insequitur. </p>
             </div>
 
-            <div type="schol" n="850-851">
+            <div type="schol" n="850">
                <p> (VRGENT PRAESAGIA MILLE / FVNERIS ET NIGRAE) PRAECEDVNT NVBILA MORTIS circumuolant. Id est: mens Parthenopaei turbabatur uicinae mortis aduentu. </p>
             </div>
 
-            <div type="schol" n="852-853">
+            <div type="schol" n="852">
                <p> VERVMQVE VIDEBAT / (DORCEA) non eum in quem Diana fuerat immutata. </p>
             </div>
 
-            <div type="schol" n="856-857">
+            <div type="schol" n="856">
                <p> (CVM TORVA CLIPEI METVENDVS) OBARSIT / (LVCE DRYAS) <supplied>
                      <hi rend="italic">obarsit</hi>
                   </supplied> effulsit uel resplenduit. Auus enim Drya<supplied>nti</supplied>s Neptuni filius fuit et Iouis <del>et Mercurii</del>. Idcirco duorum numinum armis gerebat insignia. </p>
@@ -15907,24 +15908,24 @@
                <p> (DVCIS) AONII Dryantis. </p>
             </div>
 
-            <div type="schol" n="868-869">
+            <div type="schol" n="868">
                <p> NERVIQVE (OBLIQVA) SONORI / (VINCLA SECAT PEREVNT ICTVS) arcus Parthenopaei inciso neruo, ictus quos Parthenopaeus parauerat perierunt. </p>
             </div>
 
-            <div type="schol" n="873">
+            <div type="schol" n="873a">
                <p> FACILEM mollem seu penetrabilem ut pueri scilicet. </p>
             </div>
 
-            <div type="schol" n="873-874">
+            <div type="schol" n="873b">
                <p> (SVBIT ALTERA CVSPIS / CORNIPEDISQVE FVGAM SVCCISO) POPLITE SISTIT per sedentis poplitem equum percussit. </p>
             </div>
 
-            <div type="schol" n="875-876">
+            <div type="schol" n="875">
                <p> (TVNC CADIT IPSE DRYAS MIRVM NEC VVLNERIS VMQVAM) / CONSCIVS (OLIM AVCTOR TELI CAVSAEQVE PATEBANT) a Diana intellegitur Dryas occisus, ut ipsa superius promiserat dicens:</p> 
                <l>'et nostris fas sit saeuire sagittis'. </l>
             </div>
 
-            <div type="schol" n="881-882">
+            <div type="schol" n="881">
                <p> ET PRENSIS CONCVSSA COMIS (TER COLLA QVATERQVE / STARE NEGANT) nam morituris solent erigere capita comas<del>que</del> concutiendo siue uellendo quasi reuocent illi<del>u</del>s sensum. </p>
             </div>
 
@@ -15932,16 +15933,16 @@
                <p> INCIDENTE irrumpente. </p>
             </div>
 
-            <div type="schol" n="889-890">
+            <div type="schol" n="889">
                <p> (NEV TV SVBITVS NEVE) ARMA TENENTI / (VENERIS) ne audita morte mea te aut se interficiat. </p>
             </div>
 
-            <div type="schol" n="&lt;890-891&gt;">
+            <div type="schol" n="890">
                <p> 
                   <supplied>TANDEM CVM IAM COGERE FATERI /DIC</supplied> id est: statim ut ueneris, ne dicas me occisum fuisse. </p>
             </div>
 
-            <div type="schol" n="891-893">
+            <div type="schol" n="891">
                <p> DIC MERVI (GENETRIX POENAS INVITA CAPESSE / ARMA PVER RAPVI NEC TE RETINENTE QVIEVI / NEC TIBI SOLLICITAE TANDEM INTER BELLA PEPERCI) dic meae matri ex mea persona: merui occidi quia te reuocantem me ab intentione belli non sum secutus. Et merito poenas dedi <del>CAPESSE</del> quia te contempsi aut <del>PEPERCI</del> quia audacius quam aetas poscebat bella tractaui. </p>
             </div>
 
@@ -15949,13 +15950,13 @@
                <p> PONE METVS desine pro me esse sollicita. </p>
             </div>
 
-            <div type="schol" n="&lt;900&gt;">
+            <div type="schol" n="900a">
                <p> 
                   <supplied>ORBA PARENS <hi rend="italic">orba</hi>
                   </supplied> orbata, quia filio priuaris. </p>
             </div>
 
-            <div type="schol" n="900-901">
+            <div type="schol" n="900b">
                <p> (DEXTRAQVE SECANDVM) / PRAEBVIT interpositio per poetae personam. </p>
             </div>
 
@@ -15969,7 +15970,7 @@
 
          </div>
 
-         <div type="lib" n="X">
+         <div type="lib" n="10">
             <head>LIBER X</head>
 
             <div type="pr" n="pr">
@@ -15986,7 +15987,7 @@
                <p> PROPERATA festinata. </p>
             </div>
 
-            <div type="schol" n="&lt;3-4&gt;">
+            <div type="schol" n="3">
                <p> 
                   <supplied>SED TRISTE TOT EXTRA / AGMINA ET IMMERITAS FERRO DECRESCERE GENTES</supplied> hoc miseratus est Iuppiter triste esse perire illos qui nec Thebani fuerant nec Argiui, sed utrisque partibus auxilio uenerant. </p>
             </div>
@@ -16029,11 +16030,11 @@
                   </supplied> audacia. Hinc enim fiducia Thebanis accreuerat quod quattuor Argiuorum duces eximii exstincti fuerant sorte bellorum. </p>
             </div>
 
-            <div type="schol" n="16-17">
+            <div type="schol" n="16">
                <p> (MYCENAS) / CONTENTI REDIISSE quibus sine gloria incolumibus patriam rediisse suffecerat. </p>
             </div>
 
-            <div type="schol" n="17-18">
+            <div type="schol" n="17">
                <p> DAT TESSERA SIGNVM / (EXCVBIIS) nuntius belli, quando per uigilias nunt<supplied>iat</supplied> 
                   <hi rend="italic">tessera</hi> dicitur. </p>
             </div>
@@ -16062,7 +16063,7 @@
                <p> IN MANIBVS MERCES in promptu est laboris praemium nostri. </p>
             </div>
 
-            <div type="schol" n="34-35">
+            <div type="schol" n="34">
                <p> (PRAEDAM ADSERVATIS OPESQVE) / IAM VESTRAS ad incitandum uirorum fortium animos spem praedae monstrauit. Vt Lucanus:</p>
                <lg>
                   <l>'superest pro sanguine merces,</l>
@@ -16074,7 +16075,7 @@
                <p> VERTERE GRADVM ad Argiuos. </p>
             </div>
 
-            <div type="schol" n="40-41">
+            <div type="schol" n="40">
                <p> (TVM FRONTEM) <supplied>A</supplied>VERSAQVE TERGA / (PARTITI LATERVMQVE SINVS) excubiarum inter se officia diuiserunt. </p>
             </div>
 
@@ -16090,7 +16091,7 @@
                <p> QVOD SVPEREST siquidem nihil aliud potest facere. </p>
             </div>
 
-            <div type="schol" n="52-53">
+            <div type="schol" n="52">
                <p> (FRIGIDA VVLTV) / SAXA TERVNT ita suppliciter humi procubuerunt ut uultibus suis templorum tererent limina. </p>
             </div>
 
@@ -16110,7 +16111,7 @@
                <p> DESPONSA sponsa designata. </p>
             </div>
 
-            <div type="schol" n="&lt;62&gt;">
+            <div type="schol" n="62">
                <p> 
                   <supplied>EXPERS CONVBII ET TIMIDE POSITVRA PVDOREM</supplied> nam uirginitas cum pudore deponitur feminarum. </p>
             </div>
@@ -16119,7 +16120,7 @@
                <p> TVMVLVMQVE REBELLEM <foreign xml:lang="grc">συνεκδοχή</foreign>: a parte totum. Et <hi rend="italic">tumulum</hi>, in quo natus est Liber, <hi rend="italic">rebellem</hi> contra Iunonem. </p>
             </div>
 
-            <div type="schol" n="72-73">
+            <div type="schol" n="72">
                <p> (OBVIA ...) / FORS <del>DEDIT</del> casus occurrens. </p>
             </div>
 
@@ -16127,11 +16128,11 @@
                <p> VALLVM Thebanorum. </p>
             </div>
 
-            <div type="schol" n="77-78">
+            <div type="schol" n="77">
                <p> GEMINOSQVE TONANTIS / (SECVBITVS VACVIS INDIGNARETVR IN ASTRIS) indignata est Iuno uacuis in astris geminos Iouis in Thebana urbe concubitus. </p>
             </div>
 
-            <div type="schol" n="80-81">
+            <div type="schol" n="80">
                <p> (SVAMQVE) / ORBIBVS ACCINGI (SOLITIS IVBET IRIN) Vergilius:</p> 
                <l>'mille trahit uarios aduersa luce colores'. </l>
             </div>
@@ -16202,12 +16203,12 @@
                <p> STIMVLI quibus premebatur a numine. NVDVS manifestus et euidentius patens. </p>
             </div>
 
-            <div type="schol" n="167">
+            <div type="schol" n="167a">
                <p> STAT plenus est. Vt Vergilius:</p> 
                <l>'stant et iuniperi'. </l>
             </div>
 
-            <div type="schol" n="167-168">
+            <div type="schol" n="167b">
                <p> (TREPIDAS) INCERTO (SANGVINE TENDIT / EXHAVRITQVE GENAS) <supplied>
                      <hi rend="italic">incerto</hi>
                   </supplied> trementi, siue ambiguo quia modo rubor modo pallor eius ora mutauerat. Vt Vergilius:</p>
@@ -16237,12 +16238,12 @@
                <p> SCIRE VETAT quia dolorem furor sentire non patitur. (SACRAS ...) PINVS consecratas faces. </p>
             </div>
 
-            <div type="schol" n="174">
+            <div type="schol" n="174a">
                <p> RESPERSA<del>QVE</del> polluta sanguine quem furens laniato corpore suo fuderat. Vt Vergilius:</p> 
                <l>'sparsi rorabant sanguine uepres'. </l>
             </div>
 
-            <div type="schol" n="174-175">
+            <div type="schol" n="174b">
                <p> (CVLTRIX) / ARBOR pinus quae colitur in sacris Matris Deum, sub qua iacuit Attis, Matris Deum dilectus. </p>
             </div>
 
@@ -16262,7 +16263,7 @@
                <p> SEQVE HVC CREVISSE (DOLENTES) id est: ad hos honores prouectos se dolebant ideo quod occisis ducibus per calamitatem prouecti sunt. </p>
             </div>
 
-            <div type="schol" n="&lt;182&gt;">
+            <div type="schol" n="182">
                <p>
                   <supplied> AMISSO ... PRAESIDE</supplied> id est: <supplied>a</supplied> gubernatore deserta est. </p>
             </div>
@@ -16280,15 +16281,15 @@
                <p> NOX FECVNDA (OPERVM PVLCHRAEQVE ACCOMMODA FRAVDI) fraudibus opportuna. </p>
             </div>
 
-            <div type="schol" n="196">
+            <div type="schol" n="196a">
                <p> MISERVMQVE DIEM quo uicti sumus. </p>
             </div>
 
-            <div type="schol" n="196-197">
+            <div type="schol" n="196b">
                <p> (MORASQVE) / FRANGITE PORTARVM undique uos fractis portarum claustris in hostes immittite. </p>
             </div>
 
-            <div type="schol" n="197-198">
+            <div type="schol" n="197">
                <p> (SOCIIS HOC SVBDERE FLAMMAS) / HOC TVMVLARE (SVOS) <supplied>
                      <hi rend="italic">tumulare</hi>
                   </supplied> sepelire. Id est: poena<del>m</del> quam hostibus temptamus inferre pro sepultura erit exstinctis sociis nostris, quasi ultione gaudeant peremptorum manes. EQVIDEM (HAEC ET MARTE DIVRNO) per ironiam dictum est, id est: reuera haec opportunitas nobis etiam per diem continget ideoque debemus differre. Hoc est: ne faciendi occasio pereat, differri non debet. </p>
@@ -16298,7 +16299,7 @@
                <p> SECVNDAE prosperae. </p>
             </div>
 
-            <div type="schol" n="202-205">
+            <div type="schol" n="202">
                <p> (MODO ME SVB NOCTE SILENTI) / IPSE IPSE (ADSVRGENS ITERVM TELLVRE SOLVTA / QVALIS ERAT ... / AMPHIARAVS ADIT) ut fidem uaticinationis suae faciat, iterum se ab Amphiarao ut haec dicat admoneri significat. <del>Vt Vergilius:</del>
                </p> 
                <l>
@@ -16316,11 +16317,11 @@
                <l>'nec sopor illud erat, sed coram agnoscere uultus'. </l>
             </div>
 
-            <div type="schol" n="206-211">
+            <div type="schol" n="206">
                <p> TVNE INQVIT (INERTES / ... / 211 NOS SALTEM) inuehentis uerba. </p>
             </div>
 
-            <div type="schol" n="207-208">
+            <div type="schol" n="207">
                <p> REDDE HAEC (PARNASSIA SERTA MEOSQVE / REDDE DEOS) interpositio. </p>
             </div>
 
@@ -16328,15 +16329,15 @@
                <p> AMITTERE NOCTEM opportunitatem inuadendorum hostium perdere. </p>
             </div>
 
-            <div type="schol" n="209-210">
+            <div type="schol" n="209">
                <p> (VAGOSQVE) / EDOCVI LAPSVS auium uolatus ostendi<del>t</del>.</p>
             </div>
 
-            <div type="schol" n="213-214">
+            <div type="schol" n="213">
                <p> (NON COMMINVS HOSTES) / STERNENDI non contra uigilantes comminus pugnabimus, sed contra dormientes. </p>
             </div>
 
-            <div type="schol" n="216-217">
+            <div type="schol" n="216">
                <p> (ITERVM ECCE) BENIGNAE / NOCTIS (AVES) demonstratiue. Etenim dum loquitur <supplied>fit</supplied> iterum prosperum augurium. Vt Vergilius:</p> 
                <l>'ecce iterum stimulat'. </l>
             </div>
@@ -16365,16 +16366,16 @@
                <p> TERGA BONI sessioni utiles. </p>
             </div>
 
-            <div type="schol" n="234 NATVS">
+            <div type="schol" n="234">
                <p> naturaliter aptus. </p>
             </div>
 
-            <div type="schol" n="&lt;238-239&gt;">
+            <div type="schol" n="238">
                <p> 
                   <supplied>GENTIQVE SVPERSTES / SANGVIS</supplied> genti scilicet nostrae, quae uirtutis erat plena. </p>
             </div>
 
-            <div type="schol" n="240-241">
+            <div type="schol" n="240">
                <p> (PVLCHRAQVE MEORVM) / SEDITIONE (FRVOR) quia certabant qui magis eligeretur. </p>
             </div>
 
@@ -16386,17 +16387,17 @@
                <p> INSVPER super electos. </p>
             </div>
 
-            <div type="schol" n="250">
+            <div type="schol" n="250a">
                <p> APTVS SVADERE aptus dandis consiliis. </p>
             </div>
 
-            <div type="schol" n="250-251">
+            <div type="schol" n="250b">
                <p> (HIC ROBORE) IACTAT / NON CESSISSE PATRI <supplied>
                      <hi rend="italic">iactat</hi>
                   </supplied> gloriatur. Dat operam ne patri uideatur esse dissimilis. (COMITES TRIBVS) ORDINE DENI deni comites singulos duces sequebantur, ut cum his triginta proficiscerentur ad bellum. </p>
             </div>
 
-            <div type="schol" n="&lt;252&gt;">
+            <div type="schol" n="252">
                <p> 
                   <supplied>HORRENDVM AONIIS</supplied> quod Thebanis etiam per diem potuissent horrorem inducere. (ET CONTRA STANTIBVS) AGMEN hi pauci etiam non dormientibus et e diuerso pugnantibus sine dubio suffecissent. </p>
             </div>
@@ -16405,11 +16406,11 @@
                <p> GREMIO hoc est fidei. </p>
             </div>
 
-            <div type="schol" n="257">
+            <div type="schol" n="257a">
                <p> (LORICAM) GALEAMQVE SVBIT armatur. </p>
             </div>
 
-            <div type="schol" n="257-258">
+            <div type="schol" n="257b">
                <p> (MAGNO) / ENSE GRAVAT non dixit 'donat', sed <hi rend="italic">grauat</hi>, quia ponderosus erat. </p>
             </div>
 
@@ -16417,7 +16418,7 @@
                <p> SVPEROSQVE SEQVI quasi impius. </p>
             </div>
 
-            <div type="schol" n="260-261">
+            <div type="schol" n="260">
                <p> QVID ENIM (FALLENTIBVS VMBRIS / ARCVS ET HERCVLEAE IVVISSENT BELLA SAGITTAE) interrogatiue. </p>
             </div>
 
@@ -16445,7 +16446,7 @@
                <p> TRANSIT cito occidit. </p>
             </div>
 
-            <div type="schol" n="273-274">
+            <div type="schol" n="273">
                <p> (NOMINE ... / ...) SIGNARE <del>QVEAT</del> nomine definire. </p>
             </div>
 
@@ -16457,7 +16458,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="277-278">
+            <div type="schol" n="277">
                <p> (HVNC SERO REMISSIS) / GRESSIBVS ILLAPSVM CLIPEO hunc, qui sero, uictus somno, dum stabat, defecit ac corruit. </p>
             </div>
 
@@ -16473,7 +16474,7 @@
                <p> CALIGANTES ... IRAE incertae perturbationes siue sedatae. </p>
             </div>
 
-            <div type="schol" n="288-289">
+            <div type="schol" n="288">
                <p> CASPIA (... / TIGRIS) a mari Caspio, quod inter Armeniam et Pontum est. </p>
             </div>
 
@@ -16481,11 +16482,11 @@
                <p> RABIES fames. </p>
             </div>
 
-            <div type="schol" n="290-291">
+            <div type="schol" n="290">
                <p> (CRASSO SORDIDA TABO) / CONFVDIT MACVLAS pulchritudinem macularum cruore perfusa turbauit. SPECTAT SVA FACTA uicta fame respicit praedam. </p>
             </div>
 
-            <div type="schol" n="291-292">
+            <div type="schol" n="291">
                <p> (DOLETQVE) / DEFECISSE FAMEM dolet expletum fuisse desiderium comedendi. </p>
             </div>
 
@@ -16497,7 +16498,7 @@
                <p> (MAGNO) SATVS HERCVLE Agylleus. </p>
             </div>
 
-            <div type="schol" n="&lt;301-302&gt;">
+            <div type="schol" n="301">
                <p> 
                   <supplied>HAVD QVISQVAM VISVS AVT ORA IACENTVM / EREXIT</supplied> in quem tela iactauerat Somnus. </p>
             </div>
@@ -16506,7 +16507,7 @@
                <p> (ET TANTVM MORIENTIA) LVMINA SOLVIT id est: ad mortem suam eorum oculos <supplied>laxat</supplied>.</p>
             </div>
 
-            <div type="schol" n="304-305">
+            <div type="schol" n="304">
                <p> SVPREMA / (SIDERA) longa nocte aut illis ultima. </p>
             </div>
 
@@ -16523,7 +16524,7 @@
                <l>'semianimesque micant digiti ferrumque retractant'. </l>
             </div>
 
-            <div type="schol" n="311-313">
+            <div type="schol" n="311">
                <p> (VNDIQVE MANANT / SANGVINE PERMIXTI LATICES ET BACCHVS IN ALTOS) / CRATERAS PATERASQVE (REDIT) inuersi crateres <supplied>et paterae</supplied> fuderunt merum quod, abundantia repulsum sanguinis, iacentes repleuit <del>crateres</del>.</p>
             </div>
 
@@ -16531,11 +16532,11 @@
                <p> IMPLICITVM (FRATRI THAMYRIN) dum dormiunt mutuis se tenentes amplexibus. HAVRIT perfodit, penetrat. </p>
             </div>
 
-            <div type="schol" n="316">
+            <div type="schol" n="316a">
                <p> NESCIVS (HEV RAPITVR FATIS) quia dormiens morti dimittitur. </p>
             </div>
 
-            <div type="schol" n="316-317">
+            <div type="schol" n="316b">
                <p> HILARIS(QVE SVB VMBRAS / VITA FVGIT) quia sine sensu doloris in fata decessit. </p>
             </div>
 
@@ -16601,7 +16602,7 @@
                <p> (NVNC TIBI) CRVDVS HONOS cruentus a nobis praebetur. </p>
             </div>
 
-            <div type="schol" n="343-344">
+            <div type="schol" n="343">
                <p> AT PATRIAS SI QVANDO DOMOS (OPTATAQVE PAEAN / TEMPLA LYCIE DABIS) si nos feceris ad patriam remeare. </p>
             </div>
 
@@ -16617,12 +16618,12 @@
                <p> ASPERA MATER fortis. </p>
             </div>
 
-            <div type="schol" n="&lt;355&gt;">
+            <div type="schol" n="355">
                <p> 
                   <supplied>FVNVS VBI</supplied> interrogans uos, ubi sit funus filii. </p>
             </div>
 
-            <div type="schol" n="356-357">
+            <div type="schol" n="356">
                <p> 
                   <del>SAEVIT INOPS TVMVLI</del> (QVAMVIS) PATIENTIOR ARTVS / (ILLE NEC ABRVPTIS ADEO LACRIMABILIS ANNIS) figurata locutio: <hi rend="italic">quamuis patientiores artus</hi> habeat — id est: Tydei membra dura sunt et non cito tabescunt — nec, adulescens peritus, multis sit lacrimis dignus (quia diu uixerit), Parthenopaeus autem immatura morte consumptus est. </p>
             </div>
@@ -16648,11 +16649,11 @@
                <l>'astrorum decus et nemorum Latonia custos'. </l>
             </div>
 
-            <div type="schol" n="373-374">
+            <div type="schol" n="373">
                <p> MALVS AETHERA FRANGIT / IVPPITER nociua tempestas nubes collidit. </p>
             </div>
 
-            <div type="schol" n="374-375">
+            <div type="schol" n="374">
                <p> ABSILIVNT (NVBES ET FVLGVRE CLARO / ASTRA PATENT) <supplied>
                      <hi rend="italic">absiliunt</hi>
                   </supplied> crepitant. ASTRA pro caelo. Nam dissilientibus nubibus caelum patet. </p>
@@ -16662,11 +16663,11 @@
                <p> (OCVLIS) OSTENDITVR ORBIS mundus apparet. </p>
             </div>
 
-            <div type="schol" n="376">
+            <div type="schol" n="376a">
                <p> ACCEPIT RADIOS id est Dymas. </p>
             </div>
 
-            <div type="schol" n="376-377">
+            <div type="schol" n="376b">
                <p> EADEM PERCITVS HOPLEVS / (TYDEA LVCE VIDET) eadem luce qua radios acceperat Dymas. </p>
             </div>
 
@@ -16678,11 +16679,11 @@
                <p> REMISSOS liberatos. </p>
             </div>
 
-            <div type="schol" n="381">
+            <div type="schol" n="381a">
                <p> PROPE SAEVA DIES silentii causam exposuit. </p>
             </div>
 
-            <div type="schol" n="381-382">
+            <div type="schol" n="381b">
                <p> INDEXQVE MINATVR / (ORTVS) aduentus diei raptorum cadauerum proditionem minatur. </p>
             </div>
 
@@ -16690,7 +16691,7 @@
                <p> EXHAVSTAS finitas. PALLERE TENEBRAS lucis aduentu noctem finiri. </p>
             </div>
 
-            <div type="schol" n="384-385">
+            <div type="schol" n="384">
                <p> 
                   <del>ET</del> FORS INGENTIBVS AVSIS / (RARA COMES) inuiderunt uiris fortibus Fata, quibus semper rarus est felicitatis euentus. </p>
             </div>
@@ -16707,7 +16708,7 @@
                <p> (NESCIO QVID VISV DVBIVM) INCERTVMQVE VIDERI expressit quemadmodum in tenebris aliquid uideretur. </p>
             </div>
 
-            <div type="schol" n="394-395">
+            <div type="schol" n="394">
                <p> TIMENTQVE / NON SIBI mire poeta amantium cadauera expressit affectum. </p>
             </div>
 
@@ -16715,15 +16716,15 @@
                <p> AFFECTANS ERRARE MANVM non percutientis animo. </p>
             </div>
 
-            <div type="schol" n="399-400">
+            <div type="schol" n="399">
                <p> (AT NON MAGNANIMVS) CVRAVIT (PERDERE IACTVS / AEPYTVS ET FIXO TRANSVERBERAT HOPLEA TERGO) ad hoc Aepytus miserat telum ut Hopleum occideret. </p>
             </div>
 
-            <div type="schol" n="403-404">
+            <div type="schol" n="403">
                <p> (FELIX SI CORPVS ADEMPTVM) / NESCIAT si non sentiat interuentu mortis amici sibi corpus auferri. </p>
             </div>
 
-            <div type="schol" n="405-406">
+            <div type="schol" n="405">
                <p> (AGMINA SENTIT) / IVNCTA DYMAS Amphioni et Aepyto qui praecesserant. </p>
             </div>
 
@@ -16744,7 +16745,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="420-421">
+            <div type="schol" n="420">
                <p> ET IAM LAEVA VIRO (QVAMVIS SAEVIRE VETARET / AMPHION EREPTA MANVS) iam manus sinistra Dymanti fuerat praecisa, licet hoc instantius prohiberet Amphion. </p>
             </div>
 
@@ -16764,7 +16765,7 @@
                <p> IACENTIS / VVLTVS quia dixerat illum superius supinum trahi quemadmodum solent iacentes supplicare. </p>
             </div>
 
-            <div type="schol" n="431-433">
+            <div type="schol" n="431">
                <p> IMMO AIT AMPHION (REGEM SI TANTA CVPIDO / CONDERE QVAE TIMIDIS BELLI MENS EDE PELASGIS / QVID FRACTI EXSANGVESQVE PARENT) adhuc ignorauit Amphion exstinctos uigiles suos. </p>
             </div>
 
@@ -16808,7 +16809,7 @@
                <p> QVI TREMOR (ILLICITA CAELI DE LAMPADE TACTIS) tali tremore perculsus est, qualis solet inuadere fulminatos. ILLICITA ex longinquo epitheton traxit, eo quod non liceat tangi loca ubi iaceant fulminati. </p>
             </div>
 
-            <div type="schol" n="473-474">
+            <div type="schol" n="473">
                <p> RETORTO / PVLVERE retro contorto. Nam puluis illuc erigitur quo homines. </p>
             </div>
 
@@ -16816,7 +16817,7 @@
                <p> CONGERIE sanguinis collectione. SEMIANIMVM semianimorum. </p>
             </div>
 
-            <div type="schol" n="&lt;478&gt;">
+            <div type="schol" n="478">
                <p> 
                   <supplied>EXTERIT ARTVS <hi rend="italic">exterit</hi>
                   </supplied> extrahit, imminuit cadauera. </p>
@@ -16826,7 +16827,7 @@
                <p> IMPEDIT AXES a cursu retardat. </p>
             </div>
 
-            <div type="schol" n="482-483">
+            <div type="schol" n="482">
                <p> (OCCVLTATA ...) / DELITVIT VIRTVS noctu per insidias pugnans. </p>
             </div>
 
@@ -16834,11 +16835,11 @@
                <p> PVLVERE certamine. </p>
             </div>
 
-            <div type="schol" n="485">
+            <div type="schol" n="485a">
                <p> SVNT ET MIHI sicut Thiodamanti. </p>
             </div>
 
-            <div type="schol" n="485-486">
+            <div type="schol" n="485b">
                <p> PROVIDA DEXTRAE / (OMINA) non auium aut deorum. Vt Vergilius:</p> 
                <l>'dextra mihi deus'. </l>
             </div>
@@ -16855,11 +16856,11 @@
                <p> (EST VBI) DAT VIRES NIMIVS TIMOR contingit ut nimius timor uires faciat esse maiores. </p>
             </div>
 
-            <div type="schol" n="497">
+            <div type="schol" n="497a">
                <p> TAY<supplied>G</supplied>ETI mons Laconicae regionis. </p>
             </div>
 
-            <div type="schol" n="497-498">
+            <div type="schol" n="497b">
                <p> RIGIDI ... / EVROTAE frigidi. Eurotas fluuius Laconicae regionis. </p>
             </div>
 
@@ -16875,7 +16876,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="500-502">
+            <div type="schol" n="500">
                <p> (PRIMIS QVEM CAESTIBVS IPSE LIGARAT / TYNDARIDES NITIDI MORIENS) CONVEXA (MAGISTRI / RESPICIS AVERSO PARITER DEVS OCCIDIT ASTRO) <supplied>
                      <hi rend="italic">conuexa</hi>
                   </supplied> plaga caeli in qua lucet stella Pollucis, quam refert poeta propter mortem cultoris sui numinis in occasum fuisse conuersam. Vnde superius:</p>
@@ -16885,7 +16886,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="503-504">
+            <div type="schol" n="503">
                <p> LACAENAE / (VIRGINIS) Ledam dicit, quam Iuppiter compressit mutatus in cygnum. </p>
             </div>
 
@@ -16893,7 +16894,7 @@
                <p> FALSO ... OLORI proprie dictum, quia non cygnus, sed Iuppiter in cygnum uersus ad Ledam uenerat. </p>
             </div>
 
-            <div type="schol" n="506-507">
+            <div type="schol" n="506">
                <p> (ET QVAE TE LEGES PRAECEPTAQVE FORTIA BELLI) / ERVDIIT GENETRIX (NIMIVM DIDICISSE QVERETVR) quia mater Alcidamae Nympha fuit uenatrix quae sine dubio defleuit quod ita fortem, ita nutrierit bellicosum ut audacia uirtutis suae fretus occubuisset incautus. </p>
             </div>
 
@@ -16909,15 +16910,15 @@
                <p> PANGAEA mons Macedoniae <del>uel Maenala</del>.</p>
             </div>
 
-            <div type="schol" n="519-520">
+            <div type="schol" n="519">
                <p> SOLVITVR INTEREA (VALLVM PRIMAEQVE RECVSANT / STARE MORAE) irruperunt Argiui Thebanorum uallum nec illos uis ulla potuit ab impetu retardare. </p>
             </div>
 
-            <div type="schol" n="522-523">
+            <div type="schol" n="522">
                <p> (IMMANE PAVENTES / ABRVPTVM) MIRANTVR AGI agi se mirabantur equi a sedentibus per abrupta. </p>
             </div>
 
-            <div type="schol" n="523-524">
+            <div type="schol" n="523">
                <p> (NVNC IMPETVS IRE / MARGINE AB EXTREMO NVNC SPONTE) IN FRENA RECEDVNT <supplied>
                      <hi rend="italic">in frena recedunt</hi>
                   </supplied> in uestigia redeunt. Modo adeunt alacritate transeundi, modo timore altitudinis retrorsum redeunt. </p>
@@ -16935,7 +16936,7 @@
                <p> ARSVRAS (CAELI PER INANIA) GLANDES nam sunt plumbeae. Plumbum enim solet nimietate iactus calefactum liquefieri. </p>
             </div>
 
-            <div type="schol" n="534-535">
+            <div type="schol" n="534">
                <p> (SAXAQVE IN ADVERSOS IPSIS AVVLSA ROTABANT) / MOENIBVS pro euersione moenium ipsis moenibus pugnabatur. </p>
             </div>
 
@@ -17002,7 +17003,7 @@
                <p> CONSVMPSIT (VENTVRA TIMOR) peracta putabantur timoris magnitudine quae nondum euenerant sorte bellandi. </p>
             </div>
 
-            <div type="schol" n="570-571">
+            <div type="schol" n="570">
                <p> (NEC HABENT EXTREMA PVDOREM) / IPSAE TELA VIRIS (IPSAE IRAM ANIMOSQVE MINISTRANT) quia in calamitate nullus pudor est feminis prodire in publicum uel aliquo pro patria fungi officio. </p>
             </div>
 
@@ -17018,7 +17019,7 @@
                <p> SERIT dispergit, immittit. </p>
             </div>
 
-            <div type="schol" n="583-584">
+            <div type="schol" n="583">
                <p> (PERIIT) REVERENTIA REGIS / (SOLLICITIS) perturbationis magnitudine nulla reuerentia regiae personae apud sollicitos erat. </p>
             </div>
 
@@ -17026,7 +17027,7 @@
                <p> (PACTVMQVE HIC) COMPVTET ANNVM ut computato tempore exilii anno integro solus regnum Polynices teneret. </p>
             </div>
 
-            <div type="schol" n="585-586">
+            <div type="schol" n="585">
                <p> (PATRIAS ... / ...) TENEBRAS caecitatem patris. </p>
             </div>
 
@@ -17038,11 +17039,11 @@
                <p> INDE ALII (SERA ISTA FIDES IAM VINCERE MAVVLT) e diuerso alii contraria sentiebant dicendo: olim quidem istam fidem sequi debuimus ut Polynicen pelli minime pateremur, nunc uero semel coepto proelio est acriter dimicandum. </p>
             </div>
 
-            <div type="schol" n="592-593">
+            <div type="schol" n="592">
                <p> QVIANE ANTE DVCI (BENE CREDITA NOSTRO / CONSILIA ET MONITVS CVM PERFIDA BELLA VETAREM) <foreign xml:lang="grc">εἰρωνικῶς</foreign>: cur et modo futura non dicam qui ante, cum uentura praedicerem, ita sum libenter auditus? DVCI Eteocli. </p>
             </div>
 
-            <div type="schol" n="594-596">
+            <div type="schol" n="594">
                <p> (TE TAMEN INFELIX ...) PERITVRAQVE THEBE / (SI TACEAM NEQVEO MISER EXAVDIRE CADENTEM / ARGOLICVMQVE OCVLIS HAVRIRE VACANTIBVS IGNEM) <supplied>
                      <hi rend="italic">perituraque Thebe</hi>
                   </supplied> notandum quia <hi rend="italic">Thebe</hi> singulariter dixit. VACANTIBVS caecitate uacuatis. <del>597 VINCAMVR PIETAS</del> hoc est: decreueram quidem tacere, sed miseratione uictus patriae silere me futura non patior. </p>
@@ -17052,7 +17053,7 @@
                <p> ACIEQVE SAGACI oculorum. </p>
             </div>
 
-            <div type="schol" n="599-601">
+            <div type="schol" n="599">
                <p> (SANGVINEOS) FLAMMARVM APICES (GEMINVMQVE PER ARAS / IGNEM ET CLARA TAMEN MEDIAE FASTIGIA LVCIS / ORTA DOCET) hoc genus haruspicii <foreign xml:lang="grc">καπνομαντεία</foreign> dicitur, quia ex diuisione ipsius fumi futura monstrantur. ET CLARA TAMEN (MEDIAE FASTIGIA LVCIS) per medium splendentem apicem uictoria Thebana monstratur. FASTIGIA LVCIS summum culmen exortae flammae. </p>
             </div>
 
@@ -17073,7 +17074,7 @@
                   <del>ILLE</del> CORONATOS (... IGNES) siue flamma in coronam uersa siue quia arae omnibus sacrificiis coronabantur. </p>
             </div>
 
-            <div type="schol" n="606-607">
+            <div type="schol" n="606">
                <p> (STANT TRISTES HORRORE COMAE VITTASQVE PREMENTES / CAESARIES) INSANA LEVAT furore diuino sacerdotis crines horrebant. DIDVCTA patefacta. </p>
             </div>
 
@@ -17089,7 +17090,7 @@
                <p> SED LIMITE DVRO uictoriam nobis quidem numina pollicentur, sed dura sententia, quia aliter euenire non poterit nisi se Menoeceus occiderit. </p>
             </div>
 
-            <div type="schol" n="617-618">
+            <div type="schol" n="617">
                <p> (MAESTVS ADHVC PATRIAE ET TANTVM) COMMVNIA LVGENS / (FATA CREON) quia adhuc patriae ruinas impatienter ferebat, necdum filii orbitatem. </p>
             </div>
 
@@ -17098,7 +17099,7 @@
                <l>'agnouit longe gemitum praesaga mali mens'. </l>
             </div>
 
-            <div type="schol" n="[623]">
+            <div type="schol" n="623">
                <p> 
                   <del>LYDIO (... AESTV) Tyrrheno.</del>
                </p>
@@ -17108,7 +17109,7 @@
                <p> CELERARE IVBENTEM mortem Menoecei. </p>
             </div>
 
-            <div type="schol" n="625-626">
+            <div type="schol" n="625">
                <p> (NVNC HVMILIS GENVA AMPLECTENS NVNC) ORA CANENTIS / (NEQVIQVAM RETICERE ROGAT) Creon Tiresiam suppliciter rogabat ut funestam sibi deorum uoluntatem taceret, quia pro salute patriae unius hominis mors negari non poterat. Poposcerant enim numina ut pro Thebana uictoria Menoeceus, unus qui de semine illorum superfuerat qui satis draconis dentibus fuerant nati, se uoluntarie traderet morti. </p>
             </div>
 
@@ -17116,7 +17117,7 @@
                <p> STIMVLOS hortamina. </p>
             </div>
 
-            <div type="schol" n="629-630">
+            <div type="schol" n="629">
                <p> (NEQVE ENIM HAEC ABSENTIBVS VMQVAM / MENS HOMINI (TRANSMISSA DEIS) nemo enim talem nisi diis hortantibus susciperet mentem qualem Menoeceus accepit. </p>
             </div>
 
@@ -17124,7 +17125,7 @@
                <p> DIGESTA ordinata. </p>
             </div>
 
-            <div type="schol" n="636-637">
+            <div type="schol" n="636">
                <p> (DANT CLARA MEANTI / ASTRA LOCVM QVOSQVE IPSA POLIS) AFFIXERAT IGNES stellas uirorum fortium dicit transeunti honorem referre Virtuli quia ipsius merito possederant caelum. Dicit autem Liberum, Herculem, Castorem, Pollucem, quos</p> 
                <l>'ardens euexit ad aethera uirtus'. </l>
             </div>
@@ -17154,7 +17155,7 @@
                   <del>SIC</del> LYDIA CONIVNX Omphale, cui Hercules per amorem seruisse perhibetur. </p>
             </div>
 
-            <div type="schol" n="647-648">
+            <div type="schol" n="647">
                <p> (AMPHITRYONIADEN EXVTVM HORRENTIA TERGA) / PERDERE SIDONIOS (VMERIS RIDEBAT AMICTVS) quia Herculem non decebat muliebris habitus quia mole membrorum mollia imitari non poterat. <hi rend="italic">Perdere</hi> enim est male aliquid imitari. SIDONIOS ... AMICTVS uestem purpuream dixit. </p>
             </div>
 
@@ -17204,11 +17205,11 @@
                <p> (TERRIGENAM) CVNCTO PATRIAE (PRO SANGVINE POSCVNT) mortem libenter amplectere pro salute omnium Thebanorum. </p>
             </div>
 
-            <div type="schol" n="669-670">
+            <div type="schol" n="669">
                <p> (GAVDET CADMEIA PLEBES) / CERTA TVI certum habet patria tua tanto se a te amore diligi ut pro ea libenter te offeras morti. </p>
             </div>
 
-            <div type="schol" n="670-671">
+            <div type="schol" n="670">
                <p> (RAPE MENTE DEOS) RAPE NOBILE FATVM / (I PRECOR ADCELERA NE PROXIMVS OCCVPET HAEMON) totus hic locus celeriter pronuntiandus est ut iubentis exprimat affectum. </p>
             </div>
 
@@ -17237,11 +17238,11 @@
                <p> RESPONSA quae te iubent mori pro patria. </p>
             </div>
 
-            <div type="schol" n="696-697">
+            <div type="schol" n="696">
                <p> (SVPERINE PROFANVM) / DIGNANTVR STIMVLARE (SENEM) uult pater ab aetatis decrepitae assertione responsa destruere. Dicit enim Tiresiam iam nimia senectute non posse uera responsa proferre. </p>
             </div>
 
-            <div type="schol" n="699-701">
+            <div type="schol" n="699">
                <p> (QVID SI INSIDIIS ET) FRAVDE DOLOSA / (REX AGIT EST CVI NOSTRA IN SORTE TIMORI / NOBILITAS) quid si hoc immissu regis Eteoclis dolose Tiresias fingit? Sumus enim regi pro nostra nobilitate suspecti, ne illi succedamus in regnum. </p>
             </div>
 
@@ -17249,21 +17250,21 @@
                <p> (ILLIVS HAEC FORSAN REMVR) QVAE VERBA DEORVM forte regis haec uerba sunt, quae nos responsa credimus numinum. </p>
             </div>
 
-            <div type="schol" n="706-708">
+            <div type="schol" n="706">
                <p> SIC TVA (MATVRIS SIGNENTVR TEMPORA CANIS / ET SIS IPSE PARENS ET AD HVNC ANIMOSE) TIMOREM / PERVENIAS adiurantis affectus: <del>sic</del> quomodo ego tibi timeo, sic tu timeas liberis tuis. Id est: sic ad id aetatis peruenias, ut pater sis. </p>
             </div>
 
-            <div type="schol" n="719-721">
+            <div type="schol" n="719">
                <p> (SED NEC LACRIMAE NEC VERBA MOVEBANT / DIS VOTVM IVVENVM) QVIN ET MONSTRANTIBVS (ILLIS / FRAVDE PATREM TACITA SVBIT AVERTITQVE TIMOREM) <supplied>
                      <hi rend="italic">monstrantibus illis</hi>
                   </supplied> diis utique sibi deuotum iuuenem rationem fallendi patris monentibus. Nam eum securum deceptu fraudis effecit. </p>
             </div>
 
-            <div type="schol" n="725-726">
+            <div type="schol" n="725">
                <p> (NON SI IPSE RECLVSIS / COMMINVS EX ADYTIS) IN ME INSANIRET APOLLO si me in templo posito talia Apollo praedicaret ut meis auribus diuinantis numinis uerba perciperem, non facile credidissem. </p>
             </div>
 
-            <div type="schol" n="729-730">
+            <div type="schol" n="729">
                <p> VIX ILLVM (MEDIO DE PVLVERE BELLI / INTER VTRASQVE ACIES IAMIAMQVE TENENTIBVS ARGIS) uix illum saucium uulnere de hostium medio potui liberare. INTER VTRASQVE ACIES Argiuorum Thebanorumque. </p>
             </div>
 
@@ -17271,7 +17272,7 @@
                <p> (SVPREMIQVE) FVGAM REVOCARE (CRVORIS) sanguinis fluxum arte medicinae restringere. </p>
             </div>
 
-            <div type="schol" n="&lt;737&gt;">
+            <div type="schol" n="737">
                <p> 
                   <supplied>IMPELLVNT CREDERE PARCAE</supplied> ut magis timeat Haemoni uulnerato quam perituro filio Menoeceo. </p>
             </div>
@@ -17296,7 +17297,7 @@
                <p> DEFERAT fundat. </p>
             </div>
 
-            <div type="schol" n="751-752">
+            <div type="schol" n="751">
                <p> (NON) VLLIVS AETAS / (NON CVLTVS NON FORMA MOVET) nullius aetas aut uirtus Capaneum poterat ab impetu uirtutis suae tardare. </p>
             </div>
 
@@ -17320,7 +17321,7 @@
                <p> CONVERTIT CAMPVM ad orationem suam pugnantium ora uultusque conuertit. </p>
             </div>
 
-            <div type="schol" n="765-767">
+            <div type="schol" n="765">
                <p> FERTE RETRO BELLVM CAPTAEQVE IMPINGITE LERNAE / (RELLIQVIAS TVRPES CONFIXAQVE TERGA FOVENTES / INACHVS INDECORES PATER AVERSETVR ALVMNOS) retro agite hostes in fugam ut, qui nunc uictores sunt, Argiui uincantur et, qui insecuntur, fugiant. </p>
             </div>
 
@@ -17328,7 +17329,7 @@
                <p> PLACIDA HOSTIA quae non repugnaui. </p>
             </div>
 
-            <div type="schol" n="770-771">
+            <div type="schol" n="770">
                <p> SI NON ATTONITIS (VATIS CONSVLTA RECEPI / AVRIBVS) si non diuinantis Tiresiae uerba stupefactus accepi. ATTONITIS timidis. <hi rend="italic">Attoniti</hi> enim dicuntur, quos fragor tonitrui in unum locum defixit, quos Graeci uocant <supplied>
                      <foreign xml:lang="grc">ἐμβροντήτους</foreign>
                   </supplied> hoc est stupentes. </p>
@@ -17350,7 +17351,7 @@
                <p> LVSTRAT expiat. </p>
             </div>
 
-            <div type="schol" n="787-788">
+            <div type="schol" n="787">
                <p> CONCINITVR VVLGO (CADMVM ATQVE AMPHIONA SVPRA / CONDITOR) <hi rend="italic">concinitur</hi> collaudatur. <del>Ordo:</del> populus eum conditorem urbis suae uocabat et Cadmo atque Amphione meliorem dicebat. </p>
             </div>
 
@@ -17358,24 +17359,24 @@
                <p> VERIS HONORE SOLVTO apertis rosis. </p>
             </div>
 
-            <div type="schol" n="791-792">
+            <div type="schol" n="791">
                <p> (VICTA GENITOR) LACRIMABILIS (IRA / CONGEMIT) quia dolebat fraude se deceptum a filio et iratus eum nolebat flere. </p>
             </div>
 
-            <div type="schol" n="793-794">
+            <div type="schol" n="793">
                <p> LVSTRALEMNE (... / DEVOTVMQVE CAPVT VILIS CEV MATER ALEBAM) lustrare ciuitatem humana hostia Gallicus mos est. Nam aliquis de egentissimis proliciebatur praemiis ut se ad hoc uenderet. Qui anno toto publicis sumptibus alebatur purioribus cibis, denique certo et sollemni die per totam ciuitatem ductus ex urbe extra pomeria saxis occidebatur a populo. </p>
             </div>
 
-            <div type="schol" n="796-797">
+            <div type="schol" n="796">
                <p> (MONSTRIFERO) COITV REVOLVTA (... / PIGNORA) quoniam filii coitus in matrem rediit. Vt ipse alibi:</p> 
                <l>'proprios monstro reuolutus in ortus'. </l>
             </div>
 
-            <div type="schol" n="806">
+            <div type="schol" n="806a">
                <p> DIVERSA (MIHI) contraria, quae mihi obfuerunt per partum. </p>
             </div>
 
-            <div type="schol" n="806-809">
+            <div type="schol" n="806b">
                <p> (NIMIRVM MARTIVS ANGVIS / QVAEQVE NOVIS PROAVVM TELLVS) EFFLORVIT ARMIS / (HINC ANIMI TRISTES NIMIVSQVE IN PECTORE MAVORS / ET DE MATRE NIHIL) quia de serpente illo cuius Cadmus seuerat dentes Creon, Menoecei pater, ducebat originem. Queritur ergo mater Menoecei omnia illum a patre habuisse et nihil de matre et inde illum amore mortis abreptum. </p>
             </div>
 
@@ -17397,7 +17398,7 @@
                <p> (ALTIVS) HAVT QVISQVAM (DANAVM MVCRONE SVBISSET) ab hoste non tantum fuisset infixus gladius. </p>
             </div>
 
-            <div type="schol" n="816-817">
+            <div type="schol" n="816">
                <p> PEROSAM / (SOLANTES) odio habentem consolantes se. </p>
             </div>
 
@@ -17437,12 +17438,12 @@
                <p> ARMA IOVEM (CONTRA STYGIAE RAPVERE SORORES) inuidiose <supplied>se</supplied> contra Iouem Capaneus armauit ut gloriosa morte periret. </p>
             </div>
 
-            <div type="schol" n="&lt;834&gt;">
+            <div type="schol" n="834">
                <p> 
                   <supplied>PRAECEPS</supplied> caeca, incerta, quia interdum, quae putamus bona, mala eueniunt exitu. </p>
             </div>
 
-            <div type="schol" n="835-836">
+            <div type="schol" n="835">
                <p> SEV LAETA MALORVM / (PRINCIPIA) quoniam gaudemus arduas res et periculosas incohare quarum nos postea paenitet. </p>
             </div>
 
@@ -17451,7 +17452,7 @@
                   <del>ET</del> BLANDAE sero uenientes. </p>
             </div>
 
-            <div type="schol" n="841-842">
+            <div type="schol" n="841">
                <p> (INNVMEROSQVE GRADVS) GEMINA LATVS (ARBORE CLVSOS / AERIVM ... ITER) admirabilis periphrasis scalarum. Pomponius sane in Armorum Iudicio:</p>
                <lg>
                   <l>'tum prae se portant ascendibilem semitam</l>
@@ -17467,18 +17468,18 @@
                <p> QVID SACRA IVVENT quid prosit Thebanis mors Menoecei sacris inuenta. </p>
             </div>
 
-            <div type="schol" n="848-849">
+            <div type="schol" n="848">
                <p> 
                   <del>ET</del> ALTERNO (... GRESSV / SVRGIT) mire descripsit scalis ascendentem. ALTERNO ... GRESSV id est modo dextro, modo sinistro pede. </p>
             </div>
 
-            <div type="schol" n="849-851">
+            <div type="schol" n="849">
                <p> (QVALIS MEDIIS IN NVBIBVS AETHER) / VIDIT ALOIDAS (CVM CRESCERET IMPIA TELLVS / DESPECTVRA DEOS) <supplied>
                      <hi rend="italic">Aloidas</hi>
                   </supplied> Otus et Ephialtes, Aloei filii, tantae audaciae ut montibus constructis caelum expugnare niterentur. Icti fulmine et in Tartarum mersi sunt. </p>
             </div>
 
-            <div type="schol" n="873-875">
+            <div type="schol" n="873">
                <p> (AMPHIONIS ARCES / ... FACILES) CARMENQVE IMBELLE SECVTI / (... MVRI) quia Amphione cantante dicuntur instructae. </p>
             </div>
 
@@ -17498,17 +17499,17 @@
                <p> OBLIQVO (RESPECTANS LVMINE PATREM) non aperte aspiciens propter Iunonem siue quasi iratus Ioui. </p>
             </div>
 
-            <div type="schol" n="[888]">
+            <div type="schol" n="888">
                <p> 
                   <del> (NVNC VBI ...) CVNABVLA FLAMMAE ubi sunt mea cunabula?</del>
                </p>
             </div>
 
-            <div type="schol" n="889-890">
+            <div type="schol" n="889">
                <p> (GEMIT) AVCTOR APOLLO / (QVAS DEDIT IPSE DOMOS) quia Apollinis oraculum Cadmus secutus aedificauit Thebas. </p>
             </div>
 
-            <div type="schol" n="890-891">
+            <div type="schol" n="890">
                <p> (LERNAM THEBASQVE REPENDIT / MAESTVS ET INTENTO) DVBITAT TIRYNTHIVS (ARCV) ideo inducit Herculis dubium fauorem, <del>quia et ab Argiuis et a Thebanis ducebat originem:</del> Argiuis per patrem a Perseo uenientem, nam Perseus Danaae filius, <supplied>
                      <gap/>
                   </supplied> 
@@ -17523,7 +17524,7 @@
                <p> (INCREPAT AONIOS AVDAX) TRITONIA (DIVOS) haec etiam Argiuis fauet. </p>
             </div>
 
-            <div type="schol" n="&lt;896&gt;">
+            <div type="schol" n="896">
                <p> 
                   <supplied>IVNONEM TACITAM FVRIBVNDA SILENTIA TORQVENT</supplied> de Iunone autem nemo dubitat, quam Homerus 'Argiuam' nominat. <del>Bene ergo <hi rend="italic">tacita</hi>: ubique enim Iuno tacens describitur, unde ei oratio necessitate datur. Vnde Vergilius:</del>
                </p>
@@ -17541,7 +17542,7 @@
                <p> PACEM IOVIS otium quo iracundia carebat. </p>
             </div>
 
-            <div type="schol" n="905-906">
+            <div type="schol" n="905">
                <p> (AN PAVIDAS) TONITRV (TVRBARE PVELLAS / FORTIOR) solas potes puellas turbare fulminibus. </p>
             </div>
 
@@ -17584,18 +17585,18 @@
 
          </div>
 
-         <div type="lib" n="XI">
+         <div type="lib" n="11">
             <head>LIBER XI</head>
 
             <div type="pr" n="pr">
                <p>Continet hic liber exsultationem Thebanorum post mortem Capanei. Tisiphones Furiae signum ad Megaeram ut ab inferis emergat. Ascensio ipsius Megaerae. Allocutio Tisiphones ad eam de fratrum singulari certamine. Polynicis somnium aduersum et eius allocutio ad Adrastum de singulari certamine cum fratre suscipiendo. Sacrificatio Eteoclis pro uictoria Thebana et eiusdem sacrificii omen aduersum. Nuntius significans Polynicen ad bella procedere. Allocutio Creontis cogentis Eteoclen exire. Responsio Eteoclis. Allocutio matris Iocastae ad Eteoclen ut desistat a bello. Par allocutio Antigones de muro ad Polynicen. Eruptio Eteoclis, allocutiones inuicem fratrum. Allocutio Adrasti bellum dissuadentis. Pietatis conquestio de fraterno certamine uel eius uoluntas pacis. Tisiphones interuentus. Fugata Pietas et pugna et doli. Interitus fratrum. Lamentatio Oedipi super filiorum cadauera. Mors Iocastae. Creontis imperium de non sepeliendis cadaueribus Argiuorum quos belli casus fuderat, qui tunc primum acceperat regnum. Eiusdem Creontis imperium de exclusione Oedipi. Allocutio Oedipi superbe respondentis. Allocutio Antigones Creontem deprecantis ut ignosceret Oedipo, patri suo. Fata Graecorum.</p>
             </div>
 
-            <div type="schol" n="1-3">
+            <div type="schol" n="1">
                <p> (POSTQVAM MAGNANIMVS FVRTAS VIRTVTIS INIQVAE / CONSVMPSIT CAPANEVS) EXSPIRAVITQVE (RECEPTVM / FVLMEN) cum anima amisit. </p>
             </div>
 
-            <div type="schol" n="&lt;2&gt;">
+            <div type="schol" n="2">
                <p> 
                   <supplied>EXSPIRAVIT</supplied> excussit siue efflauit. </p>
             </div>
@@ -17612,7 +17613,7 @@
                <p> (ATQVE IPSI NON) ILLAVDATA (TONANTI) ad exaggerationem uirtutis Capanei dixit eius morte etiam Iouem sese potuisse iactare. </p>
             </div>
 
-            <div type="schol" n="12-13">
+            <div type="schol" n="12">
                <p> (APOLLINEAE) TEMERATOR MATRIS (AVERNO / TENDITVR) Tityon, Latonae concubitum uiolenter affectans, Apollinis est peremptus sagittis et a Ioue apud inferos perpetua poena damnatus. </p>
             </div>
 
@@ -17628,7 +17629,7 @@
                <p> GALEAE(QVE) TONANT uelut tonitru insonant. </p>
             </div>
 
-            <div type="schol" n="26-27">
+            <div type="schol" n="26">
                <p> (CAELIQVE TVMVLTV) / VTITVR Iouis fulmine audaciam dimicandi plebs Thebana conceperat. </p>
             </div>
 
@@ -17636,7 +17637,7 @@
                <p> MASSYLA <del>PER</del> ARVA terras Africae. </p>
             </div>
 
-            <div type="schol" n="32-33">
+            <div type="schol" n="32">
                <p> HINC PREMIT EVRYMEDON (CVI RVSTICVS HORROR IN ARMIS / RVSTICA TELA MANV) ex parte altera Eurymedon, dux Thebanorum, premebat, cuius in catalogo fecerat mentionem:</p>
                <lg>
                   <l>'proximus Eurymedon, qui pastoralia Fauni</l>
@@ -17644,7 +17645,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="34-35">
+            <div type="schol" n="34">
                <p> (TENER HINC CONATIBVS ANNOS / EGREDITVR) IVVENEMQVE PATREM<del>QVE</del> (PVER AEQVAT ALATREVS) e diuerso dicit <supplied>La</supplied>pith<supplied>a</supplied>onem cum Alatreo filio bellum mouere pari paene aetate pollentes. Et istorum meminit in catalogo:</p>
                <lg>
                   <l>'pater est natusque, sed aeui</l>
@@ -17660,7 +17661,7 @@
                <p> PVBES TIRYNTHIA iuuenes dicit qui cum Agylleo fuerant, Herculis filio. </p>
             </div>
 
-            <div type="schol" n="&lt;48&gt;">
+            <div type="schol" n="48">
                <p> 
                   <supplied>SIMILES RAMOS SIMILESQVE ... PHARETRAS</supplied> 
                   <del>sed</del> stipitibus <supplied>et sagittis</supplied> dimicabant, non gladiis. Vt in catalogo:</p>
@@ -17671,7 +17672,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="50-52">
+            <div type="schol" n="50">
                <p> (EGREGIVS LITVO DEXTRI MAVORTIS) ENIPEVS / (HORTATOR SED TVNC MISERIS DABAT VTILE SIGNVM / SVADEBATQVE FVGAM ET TVTOS IN CASTRA RECEPTVS) hic tuba bellum in Thebanos excitare solebat, sed tunc amens fugam ciuibus suadebat. </p>
             </div>
 
@@ -17683,7 +17684,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="58-59">
+            <div type="schol" n="58">
                <p> (TISIPHONE FRATERNA) CLVDERE QVAERIT / (BELLA TVBA) fratrum congressu Furia bella finire festinat. </p>
             </div>
 
@@ -17704,11 +17705,11 @@
                   <del>ET</del> PATER AETNAEOS ITERVM (RESPEXIT AD IGNES) bene <hi rend="italic">iterum</hi>: quia paulo ante fulminauerat Capaneum, nunc iterum aduersus Furiam fulmen requirit. </p>
             </div>
 
-            <div type="schol" n="73-74">
+            <div type="schol" n="73">
                <p> (QVANTVMQVE PROFVNDAE) / RARESCVNT (TENEBRAE TANTVM DE LVCE RECESSIT) Furiae, inquit, abscessu tantum inferis lucis accessit quantum aduentu eius dies splendoris amisit. </p>
             </div>
 
-            <div type="schol" n="76-77">
+            <div type="schol" n="76">
                <p> HAC GERMANA (TENVS STYGII METVENDA PARENTIS / IMPERIA ET IVSSOS POTVI TOLERARE FVRORES) supra irascentis Ditis uerba ad Furiam haec fuerant:</p>
                <lg>
                   <l>'sed quid ego haec? I, Tartareas ulciscere sedes,</l>
@@ -17720,7 +17721,7 @@
                <p> NEC PRETIVM (DEFORME MORAE CASSIQVE LABORES) et operae pretium fuit diu mansisse apud superos tantis factis stragibus. </p>
             </div>
 
-            <div type="schol" n="83-84">
+            <div type="schol" n="83">
                <p> (SED QVID) / HAEC EGO (MARS HABEAT VVLGATAQVE IACTET ENYO) quae hactenus facta sunt, sibi Mars cum Bellona uindicet. Nunc ego ad singulare <supplied>certamen</supplied> impellam. </p>
             </div>
 
@@ -17728,7 +17729,7 @@
                <p> (STYGIIS CERTE) MANIFESTVS IN VMBRIS quia similitude gestorum apud inferos exstitit. </p>
             </div>
 
-            <div type="schol" n="&lt;89-91&gt;">
+            <div type="schol" n="89">
                <p> 
                   <supplied>ME SACRA PREMEBAT / TEMPESTAS EGO MIXTA VIRI FVRIALIBVS ARMIS / BELLA DEVM ET MAGNAS RIDEBAM FVLMINIS IRAS</supplied> Capaneum quoque se<del>d</del> 
                   <supplied>im</supplied>modice fecisse dicit audacem. BELLA DEVM aut Martis et Bellonae aut Apollinis et Mineruae. </p>
@@ -17750,7 +17751,7 @@
                <p> IAM PATER EST hoc est: iam coepit Oedipus circa filios meliora uota habere et patris circa iuuenes affectum tenere. </p>
             </div>
 
-            <div type="schol" n="127-128">
+            <div type="schol" n="127">
                <p> SAT FVNERA MENSAE / (TANTALEAE) dicit Iuppiter adhuc sibi Tantali horrere conuiuio in quo Pelopem praedictus pater numinibus apposuit epulandum. </p>
             </div>
 
@@ -17803,7 +17804,7 @@
                <p> INFERNO (... TONANTI) Plutoni. PRAEVERTIT applicauit. </p>
             </div>
 
-            <div type="schol" n="211-214">
+            <div type="schol" n="211">
                <p> (LIVEAT INFANDVM) LICET ARGOS (... / SIDONIOS ... PER LITORA RAPTOR / TVRBASTI THIASOS DIGNATVS VIRGINE NOSTRA / TERGA PREMI ET PLACIDAS FALSVM MVGIRE PER VNDAS) quamuis Graeci tibi seruiant et ipsi sacrificio liueant, tamen et nos amare <supplied>debes</supplied> quia multa apud nos ob stuprum Europae amoris gaudia perfecisti. </p>
             </div>
 
@@ -17815,7 +17816,7 @@
                <p> TYRIOS NIMIVM (IRRVPISSE PENATES) propter sui uultus imaginem. Et bene <hi rend="italic">nimium</hi>, quia aduentum Iouis armati ferre non potuit uique fulminis interiit. </p>
             </div>
 
-            <div type="schol" n="220-221">
+            <div type="schol" n="220">
                <p> (LAETIQVE BENIGNVM / FVLMEN ET AVDITOS PROAVIS) AGNOVIMVS IGNES fulmina quae miseras in Semelen a proauis audiuimus nostris, nos quoque in Capaneo didicimus. </p>
             </div>
 
@@ -17823,11 +17824,11 @@
                <p> VOTIVVM sacrificio Iouis dicatum. </p>
             </div>
 
-            <div type="schol" n="232-233">
+            <div type="schol" n="232">
                <p> (IPSE INSTAVRARI SACRVM MALE FORTIS AGIQVE) / IMPERAT erat enim consuetudinis ut, si prima sacrificia minime fuissent accepta numinibus, secunda haruspex sacrificia repararet donec uiderentur esse suscepta. </p>
             </div>
 
-            <div type="schol" n="234-238">
+            <div type="schol" n="234">
                <p> (QVALIS VBI IMPLICITVM TIRYNTHIVS OSSIBVS IGNEM / SENSIT ET OETAEAS MEMBRIS) ACCEDERE VESTES / ... / ... (MOX GRANDE COACTVS / INGEMVIT VICTORQVE FVRIT PER VISCERA NESSVS) <supplied>
                      <hi rend="italic">membris accedere</hi>
                   </supplied> per membra compasci. Hercules etenim uicto Acheloo Deianiram duxit uxorem. Qui cum ad fluuium peruenisset, Nesso<del>n</del> dedit Centauro transferendam. Quam cum ille in flumine comprimere uoluisset, ab Hercule est sagittis exstinctus. Qui uestem Deianirae dedit sanguine suo tinctam ut se ulcisciretur et dixit, si uellet se perpetuo ab Hercule diligi, daret eam illi uestem induendam. Inde cum Hercules Iolam secum captam adueheret, Deianira, uerita ne ei paelex praeferretur, hac ueste Herculem induit. Quam ille indutus, cum ueneni afficeretur incendio, in Oeta monte rogum uoluntate conscendit. </p>
@@ -17841,7 +17842,7 @@
                <p> AERA FINDENS rotatu capitis aerem intuens. </p>
             </div>
 
-            <div type="schol" n="257-262">
+            <div type="schol" n="257">
                <p> (NEC DESVNT REGNI COMITES) SINE MOENIA PVLSET / (IRRITVS ILLE ... / ... 262 IVBE) membratim ista legenda sunt ut uideantur a multis satellitibus dici, ut alterius sit:</p> 
                <l>'sine, moenia pulset irritus',</l> 
                <p>alterius uero:</p> 
@@ -17892,11 +17893,11 @@
                <p> (MISERAQVE) EXAESTVAT IRA grauiter insonat. </p>
             </div>
 
-            <div type="schol" n="298-299">
+            <div type="schol" n="298">
                <p> NON FALLIS AIT (NEC TE INCLYTA NATI / FATA MOVENT CANERE ILLA PATREM ET IACTARE DECEBAT) non celas, inquit, quid tuus animus hac oratione festinet. Non luges filium, sed me pugnante regnare desideras. Laudare mortem filii et praeconiis debe<supplied>b</supplied>as efferre, qui pro patria periit, non dolere. </p>
             </div>
 
-            <div type="schol" n="310-311">
+            <div type="schol" n="310">
                <p> ICTVS VT INCERTO (PASTORIS VVLNERE SERPENS / ERIGITVR GYRO) non forti impetu percussus, et ideo erigitur. </p>
             </div>
 
@@ -17912,7 +17913,7 @@
                <p> IMPROBA LVMINA mea lumina quae spectatura sunt fratrum singulare certamen. </p>
             </div>
 
-            <div type="schol" n="&lt;335-336&gt;">
+            <div type="schol" n="335">
                <p> 
                   <supplied>MINANTIA FLECTIS / ORA</supplied> me petis. </p>
             </div>
@@ -17921,7 +17922,7 @@
                <p> OBNIXI cum conatu stricti. </p>
             </div>
 
-            <div type="schol" n="338-339">
+            <div type="schol" n="338">
                <p> (PRIVS HAEC TAMEN ARMA NECESSE EST) / EXPERIARE DOMI ut nos ante prosternas. </p>
             </div>
 
@@ -17941,7 +17942,7 @@
                <p> (SVSPECTAQVE) REGI Eteocli, propter amorem Polynicis. Dicitur enim cum eo concubuisse. </p>
             </div>
 
-            <div type="schol" n="382-383">
+            <div type="schol" n="382">
                <p> (HIS PAVLVM FVROR ELANGVESCERE DICTIS) / COEPERAT sola enim Antigone Polynicen poterat a singulari fratris certamine remouere. Supra enim de ipsa dixerat Furia:</p>
                <lg>
                   <l>'blandamque precatu</l>
@@ -17978,11 +17979,11 @@
                <p> (MIXTISQVE IVBAS) SERPENTIBVS AVGENT equorum iubas augent Furiae adiectione serpentum. </p>
             </div>
 
-            <div type="schol" n="411-412">
+            <div type="schol" n="411">
                <p> ET IPSI / (ARMORVM FVGERE DEI) Mars et Minerua. </p>
             </div>
 
-            <div type="schol" n="414-415">
+            <div type="schol" n="414">
                <p> (ET GORGONE) CRVDA (VIRAGO / ABSTITIT) <supplied>
                      <hi rend="italic">cruda</hi>
                   </supplied> aspera. Dicit Mineruam opposita Gorgone uisus suos celasse. </p>
@@ -17992,16 +17993,16 @@
                <p> ANIMIS Thebanorum. </p>
             </div>
 
-            <div type="schol" n="437-438">
+            <div type="schol" n="437">
                <p> (QVAM SCYTHA CVRVATIS ERECTVS FLVCTIBVS VMQVAM) / PONTVS (CYANEOS VETVIT CONCVRRERE MONTES) quam aqua non uetuit sibi montes collidi. </p>
             </div>
 
-            <div type="schol" n="&lt;439-440&gt;">
+            <div type="schol" n="439">
                <p> 
                   <supplied>GEMINOQVE AD PROELIA FVSOS / PVLVERE CORNIPEDES</supplied> in equis apparebat dominorum furor. </p>
             </div>
 
-            <div type="schol" n="442-443">
+            <div type="schol" n="442">
                <p> (FATA MONENTEM / CONVERSVMQVE IVGO PROPELLIT) ARIONA quia Arion, quippe Neptuni filius, diuinabat. </p>
             </div>
 
@@ -18009,7 +18010,7 @@
                <p> LAEVAE contrariae siue inanis. </p>
             </div>
 
-            <div type="schol" n="&lt;448&gt;">
+            <div type="schol" n="448">
                <p> 
                   <supplied>SVBSTITIT</supplied> institit. </p>
             </div>
@@ -18034,7 +18035,7 @@
                <p> ANIMANTVM animas habentium id est hominum. </p>
             </div>
 
-            <div type="schol" n="472-473">
+            <div type="schol" n="472">
                <p> (DESILVITQVE POLO NIVEVS SVB NVBIBVS ATRIS) / QVAMQVAM MAESTA DEAE (SEQVITVR VESTIGIA LIMES) cum Pietas de caelo descenderet ad terras, licet maesta esset tamen quacumque ibat per nigras nubes claram sui numinis lucem trahebat. </p>
             </div>
 
@@ -18062,15 +18063,15 @@
                <p> ORA REDVCENTEM uultum suum retro tollentem. </p>
             </div>
 
-            <div type="schol" n="495-496">
+            <div type="schol" n="495">
                <p> (DEIECTAM) IN LVMINA PALLAM / (DIVA TRAHIT) faciem suam, ne Furiae uultum uideret, chlamyde protegebat. </p>
             </div>
 
-            <div type="schol" n="499">
+            <div type="schol" n="499a">
                <p> REX IMPIVS Eteocles. </p>
             </div>
 
-            <div type="schol" n="499-500">
+            <div type="schol" n="499b">
                <p> (APTAT / TELA ET FVNESTAE CASVM) PRIOR OCCVPAT (HASTAE) feriturus praeuenit ac tela disponit. </p>
             </div>
 
@@ -18078,7 +18079,7 @@
                <p> (ILLA VIAM MEDIVM CLIPEI CONATA) PER ORBEM per medium scutum conata est transire. </p>
             </div>
 
-            <div type="schol" n="506-507">
+            <div type="schol" n="506">
                <p> PIABO MANVS (ET EODEM PECTORA FERRO / RESCINDAM) expiabo parricidium fratris mea morte. </p>
             </div>
 
@@ -18094,7 +18095,7 @@
                <p> PLAGA uulnus. </p>
             </div>
 
-            <div type="schol" n="&lt;516&gt;">
+            <div type="schol" n="516">
                <p> 
                   <supplied>CREDIT ET IPSE METV uulnus</supplied> metu<supplied>m</supplied> immisit. </p>
             </div>
@@ -18107,13 +18108,13 @@
                <p> LVCTATAEQVE DIV (TENEBRIS HIEMIQVE SIBIQVE) et aduersus tempestatem et aduersum se. </p>
             </div>
 
-            <div type="schol" n="525-526">
+            <div type="schol" n="525">
                <p> (IGNESCENTIA CERNVNT / PER GALEAS ODIA ET VVLTVS) RIMANTVR (ACERBO / LVMINE NIL ADEO MEDIAE TELLVRIS) <supplied>
                      <hi rend="italic">rimantur</hi>
                   </supplied> peruestigant. ACERBO / (LVMINE) toruo. (NIL ADEO MEDIAE) TELLVRIS subaudis 'intererat'. Id est: non a se multum aberant, sed comminus sua ora cernebant. </p>
             </div>
 
-            <div type="schol" n="528-529">
+            <div type="schol" n="528">
                <p> (ALTERNAQVE SAEVI / MVRMVRA CEV LITVOS RAPIVNT AVT) SIGNA TVBARVM et ceu lituo plus ad scelus excitabantur. </p>
             </div>
 
@@ -18121,11 +18122,11 @@
                <p> FVLMINEOS fortes. </p>
             </div>
 
-            <div type="schol" n="535-536">
+            <div type="schol" n="535">
                <p> (NECDVM LETALIA MISCENT / VVLNERA SED COEPTVS SANGVIS) FACINVSQVE PERACTVM (EST) tanta inerat saeuientibus feritas ut, cum nulla sibi adhuc uulnera intulissent, tamen iam se scelus perfecisse credebant. </p>
             </div>
 
-            <div type="schol" n="541-542">
+            <div type="schol" n="541">
                <p> (CVI FORTIOR IRA NEFASQVE) / IVSTIVS iustior in scelere Polynices uidebatur quia pro denegato sibi imperio <supplied>pugnabat</supplied>.</p>
             </div>
 
@@ -18137,16 +18138,16 @@
                </lg>
             </div>
 
-            <div type="schol" n="&lt;547&gt;">
+            <div type="schol" n="547">
                <p> 
                   <supplied>NEC PARCIT CADENTI ATQVE INCREPAT HOSTIS</supplied> Polynices scilicet uiso fratris uulnere imminebat. </p>
             </div>
 
-            <div type="schol" n="550-551">
+            <div type="schol" n="550">
                <p> (EXILIO REBVSQVE EXERCITA) EGENIS / (MEMBRA VIDES) has uires exilia calamitatesque nutrierunt. </p>
             </div>
 
-            <div type="schol" n="&lt;574&gt;">
+            <div type="schol" n="574">
                <p> 
                   <supplied>TRVCES</supplied> crudeles. </p>
             </div>
@@ -18173,7 +18174,7 @@
                <p> VTRAQVE CANITIES capitis et barbae. </p>
             </div>
 
-            <div type="schol" n="584-585">
+            <div type="schol" n="584">
                <p> (PROCVL ORA) GENAEQVE / INTVS ipse alibi:</p>
                <lg>
                   <l>'sedet intus</l>
@@ -18197,7 +18198,7 @@
                <p> FRIGENTIBVS defunctis. </p>
             </div>
 
-            <div type="schol" n="608-609">
+            <div type="schol" n="608">
                <p> (LACRIMAEQVE PER) ARIDA SERPVNT / (VVLNERA) caecitatem <hi rend="italic">aridam</hi> dixit eo quod deficientibus oculis lacrimarum origo cessauerat. </p>
             </div>
 
@@ -18217,7 +18218,7 @@
                <p> (ALLOQIVMQVE) AFFARE <del>LICET</del> pro merito dicere. </p>
             </div>
 
-            <div type="schol" n="616-617">
+            <div type="schol" n="616">
                <p> HEV IVSTO MAGIS (EXAVDITA PARENTIS / VOTA MALAEQVE PRECES) plus iusto diis uisum est parentis in filios mala uota audire. </p>
             </div>
 
@@ -18225,7 +18226,7 @@
                <p> DICTAVIT FATIS ut euenirent, fataliter fecit. </p>
             </div>
 
-            <div type="schol" n="635-636">
+            <div type="schol" n="635">
                <p> (ENSEM) / ENSEM <foreign xml:lang="grc">ἀναδίπλωσις</foreign>.</p>
             </div>
 
@@ -18246,7 +18247,7 @@
                <p> (INFELIX LVSTRATVR) SANGVINE LECTVS cruore infelicis lectuli purgauit incestu<supplied>m</supplied>.</p>
             </div>
 
-            <div type="schol" n="644-647">
+            <div type="schol" n="644">
                <p> QVALIS MARATHONIDE (SILVA / FLEBILIS ERIGONE CAESI PROPE FVNERA PATRIS / QVESTIBVS ABSVMPTIS TRISTEM IAM SOLVERE NODVM / COEPERAT ET FORTES RAMOS MORITVRA LEGEBAT) Marathon mons Atticae regionis in quo Icar<supplied>i</supplied>us est occisus. Ad quem locum Erigone, filia eius, cane praeeunte peruenit et se nimio luctus dolore laqueauit fortioribus ramis electis, ne forte infirmioribus fractis mortem corporis ruina declinaret. Pinus autem in qua pependit regionem illam sua umbra uastabat. Vt placaretur exstincta, ora in humanam speciem ipsa formata in eadem arbore suspendebant et pastorum congressibus cantibusque diem illum celebrem faciebant. Quod Vergilius aliud agendo perstrinxit:</p>
                <lg>
                   <l>'tibique</l>
@@ -18255,7 +18256,7 @@
                <p>NODVM laqueum quo se regina suspenderat. (FORTES RAMOS MORITVRA) LEGEBAT quibus se suspenderet. </p>
             </div>
 
-            <div type="schol" n="656-657">
+            <div type="schol" n="656">
                <p> (NVMQVAMNE) PRIORVM / (HAEREBVNT DOCVMENTA NOVIS) quod non admonentur fatis priorum. </p>
             </div>
 
@@ -18280,7 +18281,7 @@
                <p> (REGVM) CALCARE RVINAS afflictorum regum insultare casibus. </p>
             </div>
 
-            <div type="schol" n="682-683">
+            <div type="schol" n="682">
                <p> (SED CVR NOVA) CONTRAHIS AMENS / (IVRA) <hi rend="italic">contrahis</hi> absumis. Minando parua et non maiora regum contrahis iura. </p>
             </div>
 
@@ -18293,7 +18294,7 @@
                   </hi> immo imbue, id est: in me auspicare innocentum caedem quasi nouus tyrannus. </p>
             </div>
 
-            <div type="schol" n="686-687">
+            <div type="schol" n="686">
                <p> (VENIAT CVPIDVS PARERE) SATELLES / (INTREPIDVSQVE SECET NON EVITANTIA COLLA) <supplied>
                      <hi rend="italic">satelles</hi>
                   </supplied> id est armiger qui me possit occidere. </p>
@@ -18311,24 +18312,24 @@
                <p> (SATIS OMINA) SANXI satis imprecatus sum. </p>
             </div>
 
-            <div type="schol" n="718-719">
+            <div type="schol" n="718">
                <p> ALTVSQVE IACENTES / (PRAETEREAS) elatus imperii dignitate miseros humilesque despicias. </p>
             </div>
 
-            <div type="schol" n="719-720">
+            <div type="schol" n="719">
                <p> (MAGNA DVCVM VEREARE) PRIORVM / (FVNERA) ante oculos habeas fata priorum ducum. </p>
             </div>
 
-            <div type="schol" n="&lt;723&gt;">
+            <div type="schol" n="723">
                <p> 
                   <supplied>NECDVM EXSVL ERAT</supplied> subaudis: cum haec mala accidissent. </p>
             </div>
 
-            <div type="schol" n="748-750">
+            <div type="schol" n="748">
                <p> (SED NON TAMEN OMNIA RECTOR) / SVPPLICIS (INDVLGET LACRIMIS PARTEMQVE RECIDIT / MVNERIS) ueniam Oedipo sub certa condicione promittit. </p>
             </div>
 
-            <div type="schol" n="753-754">
+            <div type="schol" n="753">
                <p> (HAEC ECCE TVIS) HABITABILIS VMBRIS / (QVA BELLVM GEMINAEQVE IACENT IN SANGVINE GENTES) ubi filii se tui mutuis uulneribus peremerunt. QVA BELLVM Thebana et Argiua gentes mouerunt. </p>
             </div>
 
@@ -18338,20 +18339,20 @@
 
          </div>
 
-         <div type="lib" n="XII">
+         <div type="lib" n="12">
             <head>LIBER XII</head>
 
             <div type="pr" n="pr">
                <p>In hoc libro continetur: egressio Thebanorum ad campos hostibus iam fugatis. Crematio cadauerum. Sepultura Menoecei. Creontis allocutio in filium plena pietatis. Profectio Argiuarum matrum post auditam mortem suorum. Occursus Ornyti uulnerati. Allocutio suadentis matribus ut non Thebas eant, sed Athenas et a Theseo auxilium poscant quo possint sepeliri earum mariti. Dissensio Argiae. Ipsius Argiae segregatio a ceteris matribus et profectio ad Thebas uno comite Menoete. Eius aduentus ad campum ubi iacebat maritus. Iunonis ad Lunam allocutio ut illustret campos splendore radiorum. Agnitio. Allocutiones Argiae et Antigones et iunctus labor ad sepeliendum Polynicis cadauer. Qui cum impositus fuisset Eteoclis rogo per ignorantiam, subito flamma dissensit. Antigones lamentatio. Vigilum interuentus et captiuitas Antigones et Argiae. Descriptio asyli apud Athenas, quo Argiuae confugerant matres. Aduentus Thesei et triumphus eius de Amazonibus. Allocutio Euadnes, Capanei uxoris, ad Theseum et deprecatio de sepultura maritorum. Indignatio Thesei contra Creontem et transmissio nuntii qui diceret Creonti ut aut sineret sepeliri Argiuos aut se pararet ad bellum. Catalogus exercitus Thesei. Aduentus nuntii a Theseo missi ad Creontem. Creontis superba responsio. Aduentus Thesei. Pugna et singulare certamen cum Creonte. Interitus Creontis. Deditio Thebarum. Argiuorum sepultura.</p>
             </div>
 
-            <div type="schol" n="1-2">
+            <div type="schol" n="1">
                <p> (NONDVM CVNCTA POLO VIGIL) INCLINAVERAT (ASTRA / ORTVS) <supplied>
                      <hi rend="italic">inclinauerat</hi>
                   </supplied> occidere fecerat. Id est: nondum omnia astra aduentus exterserat solis. </p>
             </div>
 
-            <div type="schol" n="9-10">
+            <div type="schol" n="9">
                <p> (VIX PRIMO PROFERRE GRADVM ET) MVNIMINA VALLI / (SOLVERE) <hi rend="italic">primo</hi> pro 'primum'. Quamuis fugati essent Argiui, tamen exire de ciuitate Thebani metuebant. </p>
             </div>
 
@@ -18359,7 +18360,7 @@
                <p> (VIX TOTAS) RESERARE AVDACIA PORTAS nondum audebant terrore praeteritorum malorum omne portarum spatium reserare. </p>
             </div>
 
-            <div type="schol" n="12-13">
+            <div type="schol" n="12">
                <p> (VT ASSIDVO IACTATIS AEQVORE TELLVS) / PRIMA LABAT Vergilius:</p> 
                <l>'dum trepidi egressique labant uestigia prima'. </l>
             </div>
@@ -18388,7 +18389,7 @@
                <p> VBIQVE <del>PARATO</del> ad omnia cadauera. </p>
             </div>
 
-            <div type="schol" n="&lt;55&gt;">
+            <div type="schol" n="55">
                <p> 
                   <supplied>MISERABILE</supplied> pro 'miserabiliter'. </p>
             </div>
@@ -18436,7 +18437,7 @@
                   <del>IMPVLSAS</del> CINERI tuo scilicet. </p>
             </div>
 
-            <div type="schol" n="84-85">
+            <div type="schol" n="84">
                <p> (EADEMNE DIES EADEM IMPIA BELLA / TE PVER ET DIROS MISERE IN TARTARA) FRATRES una sorte te et eadem die cum nefandis fratribus bellorum fortuna coniunxit. </p>
             </div>
 
@@ -18444,11 +18445,11 @@
                <p> LIBAMENTA dona sacrata superis, <supplied>siue</supplied> initia mortis. </p>
             </div>
 
-            <div type="schol" n="89">
+            <div type="schol" n="89a">
                <p> REGIMEN DEXTRAE sceptrum siue regalis uirga. </p>
             </div>
 
-            <div type="schol" n="89-90">
+            <div type="schol" n="89b">
                <p> FRONTISQVE SVPERBAE / VINCVLA diadema. Ostendit poeta Creontem regni insignia in ardentis filii pyram iecisse. </p>
             </div>
 
@@ -18491,11 +18492,11 @@
                <p> ARCANOS (... EXTVLIT IGNES) secretos siue sacrificiorum ignes ostendit. EXTVLIT eleuauit. </p>
             </div>
 
-            <div type="schol" n="134-139">
+            <div type="schol" n="134">
                <p> IPSA PER AVERSOS (DVCIT SATVRNIA CALLES / ... / ... / NEC NON FVNCTA DVCVM REFOVENDI CORPORA CVRAM / IRIS HABET PVTRESQVE ARCANIS RORIBVS ARTVS / AMBROSIAEQVE RIGAT SVCIS) ipsa Iuno et auia monstrat itinera et refouebat corpora mortuorum. Mandat simul curam Iridi quae ambrosiis sucis perfundens ea tabe resolui uetaret. </p>
             </div>
 
-            <div type="schol" n="135-136">
+            <div type="schol" n="135">
                <p> NE PLEBS (CONGRESSA SVORVM / IRE VETET) ne coniuncta fugientium multitudo a coepto deterreat<supplied>ur</supplied>.</p>
             </div>
 
@@ -18515,11 +18516,11 @@
                <p> (FLAMMAS NON ANTE) FATISCANT ut occisorum corpora putredine non ante soluantur quam rogos accipiant. Et est ordo: ante flammas non fatiscant. </p>
             </div>
 
-            <div type="schol" n="146-147">
+            <div type="schol" n="146">
                <p> (FEMINEVMQVE GREGEM QVAE IAM) SVPER AGMINA LERNE / (SOLA VIDET) <supplied>id est</supplied>: tantummodo mulieres superesse. Nominatiuus Graecus est: 'haec Lerne'. </p>
             </div>
 
-            <div type="schol" n="149-150">
+            <div type="schol" n="149">
                <p> (FVNVSNE) PEREMPTIS / SPERATIS (CINEREMQVE VIRIS) speratis<supplied>ne</supplied> uos mortuis sepulturae solacia posse praestare? </p>
             </div>
 
@@ -18531,16 +18532,16 @@
                <p> BVSIRIDIS ARAS hic rex Aegypti fuit, aduenas solitus ad aras mactare. Postremo aduentu Herculis immolatus exemplo est. </p>
             </div>
 
-            <div type="schol" n="156">
+            <div type="schol" n="156a">
                <p> ODRYSIIQVE (FAMEM STABVLI) Diomedes, rex Thracum, equos habebat quos humanis carnibus nutriebat. Hos Hercules occiso Diomede ad solita pabula id est ad gramina mollita feritate reuocauit. </p>
             </div>
 
-            <div type="schol" n="156-157">
+            <div type="schol" n="156b">
                <p> SICVLOSQVE LICEBIT / (EXORARE DEOS) Iuppiter Aetnam nympham compressit. Quam cum Iuno persequeretur, illa Terrae implorauit auxilium et in sinus eius recepta enixa est geminos necdum partu maturo. Hos Terra intra gremium suum tamdiu fouit quamdiu lex uteri postulabat, posteaque enixa est. Vnde Palici <supplied>id est</supplied> 'bis geniti' appellati sunt. Hos autem immites fuisse et humano sanguine placari consuetos fabula disserente firmatum est. Quod uidetur etiam strictim tetigisse Vergilius:</p> 
                <l>'et placabilis ara Palici'. </l>
             </div>
 
-            <div type="schol" n="&lt;162&gt;">
+            <div type="schol" n="162">
                <p> 
                   <supplied>INANIA BVSTA</supplied> sine corporibus sepulturae. </p>
             </div>
@@ -18549,7 +18550,7 @@
                <p> THERMODONTIACO (...TRIVMPHO) Thracio, a fluuio Thermodonte Thraciae regionis. </p>
             </div>
 
-            <div type="schol" n="165-166">
+            <div type="schol" n="165">
                <p> (BELLO COGENDVS ET ARMIS) / IN MORES HOMINEMQVE (CREON) <supplied>
                      <hi rend="italic">in mores hominemque</hi>
                   </supplied> in humanam consuetudinem, id est: ut mortuos sepulturae concedat, bello cogendus est Creon. </p>
@@ -18584,7 +18585,7 @@
                <p>AVGVRIVMQVE ANIMI praediuinatio<del>nem</del>.</p>
             </div>
 
-            <div type="schol" n="217-218">
+            <div type="schol" n="217">
                <p> VIS NVLLA DOLENTI / (MORS NVSQVAM) nusquam est animi magnitudo quae perducat ad mortem. </p>
             </div>
 
@@ -18592,7 +18593,7 @@
                <p> HORTARIS EVNTEM uerbis dehortantibus cohortaris. </p>
             </div>
 
-            <div type="schol" n="224-225">
+            <div type="schol" n="224">
                <p> NOCTE VELVT PHRYGIA (CVM LAMENTATA RESVLTANT / DINDYMA) sacra Matris nocte a Phrygibus colebantur in monte Dindymo, in quibus se Galli abscidere consueuerant. Quod genus sacrificii strictim Vergilius tetigit:</p>
                <lg>
                   <l>'ite per alta</l>
@@ -18604,7 +18605,7 @@
                <p> PINIGERI ferentis faces. RAPITVR ducitur. </p>
             </div>
 
-            <div type="schol" n="226-227">
+            <div type="schol" n="226">
                <p> (CVIVS DEA) SANGVINE LECTO / (IPSA DEDIT FERRVM ET VITTATA FRONDE NOTAVIT) quem sibi ipsa elegit. </p>
             </div>
 
@@ -18638,7 +18639,7 @@
                <p>id est blandimentis induceres. </p>
             </div>
 
-            <div type="schol" n="247-248">
+            <div type="schol" n="247">
                <p> EGENA SEPVLCRI / (BVSTA) cadauera sepultura carentia. <del>BVSTA corpora semiusta.</del> AESTVAT AER grauiter exhalat. </p>
             </div>
 
@@ -18674,7 +18675,7 @@
                <p> (ERRORE) FATISCERE VANO fatigari errore superfluo quia mariti corpus inuenire non poterat. </p>
             </div>
 
-            <div type="schol" n="300-301">
+            <div type="schol" n="300">
                <p> (CERTE IOVIS) IMPROBA (IVSSV / TER NOCTEM HERCVLEAM) <supplied>
                      <hi rend="italic">improba</hi>
                   </supplied> aduersa aut certe tunc improba. TER NOCTEM HERCVLEAM Iuppiter cum Alcmenam Amphitryonis amasset uxorem et ad eam corrumpendam demutatus in Amphitryonis specie uenisset, ne aduentu diei concuhitus minucretur uoluptas, iussit Iuppiter illam noctem triplicem fieri, qua triplices cursus Luna peregit. Ex quo compressu Alcmenae Hercules dicitur natus. Merito ergo <hi rend="italic">noctem Herculeam</hi> dixit in qua conceptus est Hercules. </p>
@@ -18692,14 +18693,14 @@
                <p> ORBITA rotarum uia. </p>
             </div>
 
-            <div type="schol" n="307-308">
+            <div type="schol" n="307">
                <p> HVNC QVOQVE (QVI CVRRV MADIDAS TIBI PRONVS HABENAS / DVCIT IN AONIOS VIGILES DEMITTE SOPOREM) id est: Somnus, qui praecedit bigas tuas, uigiles occupet Thebanorum eosque laxet in somnum. Et est ordo: hunc quoque Soporem <supplied>
                      <gap/>
                   </supplied>
                </p>
             </div>
 
-            <div type="schol" n="310-311">
+            <div type="schol" n="310">
                <p> FVLGORQVE RECISVS / (SIDERIBVS) lucente enim luna necesse est ut stellarum minuatur splendor. </p>
             </div>
 
@@ -18753,11 +18754,11 @@
                <p> SI MISERA ES si aeque luges. </p>
             </div>
 
-            <div type="schol" n="379-380">
+            <div type="schol" n="379">
                <p> (CARI) POLYNICIS AD IGNES / (ETSI REGNA VETANT) <supplied>subaudis: </supplied> si audes, ueni. </p>
             </div>
 
-            <div type="schol" n="&lt;389&gt;">
+            <div type="schol" n="389">
                <p> 
                   <supplied>MODO HAEC FRATREM MEMORAT NVNC ILLA MARITVM</supplied> suum scilicet. </p>
             </div>
@@ -18770,7 +18771,7 @@
                <p> SACRVM exsequiale. </p>
             </div>
 
-            <div type="schol" n="&lt;396&gt;">
+            <div type="schol" n="396">
                <p> 
                   <supplied>TE CVPIIT VNAM</supplied> solam. Vt ipse superius:</p>
                <lg>
@@ -18783,7 +18784,7 @@
                <p> PERFERTE incohate <supplied>et</supplied> perficite. </p>
             </div>
 
-            <div type="schol" n="413-414">
+            <div type="schol" n="413">
                <p> TEPIDO ... / ... PADO propter incendia quae paulo ante restrinxerat. </p>
             </div>
 
@@ -18791,11 +18792,11 @@
                <p> (FLENTES STABANT AD FLVMINA) SILVAE Heliades, Phaethontis sorores, quae flendo sunt in populeas arbores demutatae. </p>
             </div>
 
-            <div type="schol" n="416-417">
+            <div type="schol" n="416">
                <p> (MEMBRISQVE REVERSVS) / MORTIS HONOS insigne enim mortis est pallor. </p>
             </div>
 
-            <div type="schol" n="&lt;419&gt;">
+            <div type="schol" n="419">
                <p> 
                   <supplied>OMNIA BVSTA QVIESCVNT</supplied> cadente in cinere<supplied>m</supplied> lignorum structura quiescunt. </p>
             </div>
@@ -18816,7 +18817,7 @@
                <p> CORVSCANT lucent. </p>
             </div>
 
-            <div type="schol" n="433-434">
+            <div type="schol" n="433">
                <p> (PALLIDVS EVMENIDVM VELVTI) COMMISERIT IGNES / (ORCVS) ita rogi flamma diuisa est ut et hoc instinctu Furiae perpetratum credatur. </p>
             </div>
 
@@ -18824,11 +18825,11 @@
                <p> MINAX eminens. CONATVR VTERQVE se ab inuicem separare. </p>
             </div>
 
-            <div type="schol" n="447-448">
+            <div type="schol" n="447">
                <p> (SVBITVS) CAMPOS TREMOR (ALTAQVE TECTA / IMPVLIT ADIVVITQVE ROGI DISCORDIS HIATVS) id est: sceleris horrore quo se flammae diuiserant terrae factus est motus. Diuidebantur quidem odio flammae, sed plus disiunctae sunt terrae. Prodigiale enim monstrum exhorruit terra. </p>
             </div>
 
-            <div type="schol" n="449-450">
+            <div type="schol" n="449">
                <p> (QVIBVS) IPSE MALORVM / (FINGEBANT SIMVLACRA SOPOR) quae per diem fecerant, ea ante oculos uersabant<supplied>ur</supplied> in somniis. </p>
             </div>
 
@@ -18884,7 +18885,7 @@
                <p> DVPLICES THALAMOS Procnae et Philomelae. </p>
             </div>
 
-            <div type="schol" n="481-482">
+            <div type="schol" n="481">
                <p> (NVLLI) CONCESSA POTENTVM / (ARA DEVM) <foreign xml:lang="grc">Ἐλέου βωμόν</foreign> dicit. Hanc aram Cicero Misericordiae nominat. Eius Terentius meminit:</p>
                <lg>
                   <l>'nec tu <supplied>a</supplied>ram tibi</l>
@@ -18920,17 +18921,17 @@
                <p> TREPIDOS supplices. </p>
             </div>
 
-            <div type="schol" n="495-496">
+            <div type="schol" n="495">
                <p> HORRET EGENIS / (COETIBVS) horridior fit miseris. </p>
             </div>
 
-            <div type="schol" n="497-498">
+            <div type="schol" n="497">
                <p> FAMA EST (DEFENSOS ACIE) POST BVSTA PATERNI / (NVMINIS HERCVLEOS SEDEM FVNDASSE NEPOTES) <supplied>
                      <hi rend="italic">fama est</hi>
                   </supplied> Atheniensium scilicet. Hyllus Deianirae et Herculis filius et reliqui ex eodem nati, postquam Hercules terris abiit, pulsi ab Eurystheo Athenas confugerunt. A quibus postquam tam facile auxilium meruerunt, hanc aram consecrasse memorantur asserentes apud Athenas tantummodo sedes Misericordiam posuisse. </p>
             </div>
 
-            <div type="schol" n="&lt;499&gt;">
+            <div type="schol" n="499">
                <p> 
                   <supplied>FAMA MINOR FACTIS</supplied> minus dicit quam res habet. </p>
             </div>
@@ -18939,7 +18940,7 @@
                <p> CEV LEGES <del>HOMINEMQVE</del> (... RITVSQVE SACRORVM) primi enim Athenienses inter reliqua bona legum tabulas inuenerunt. Sic ergo huc confugiunt ceu ad leges et humanos ritus. </p>
             </div>
 
-            <div type="schol" n="503-504">
+            <div type="schol" n="503">
                <p> SIC SACRASSE LOCO (COMMVNE ANIMANTIBVS AEGRIS / CONFVGIVM) Ouidius de Athenis, ad quas uenit Inuidia:</p>
                <lg>
                   <l>'ingeniis opibusque et festa pace uirentem,</l>
@@ -18947,20 +18948,20 @@
                </lg>
             </div>
 
-            <div type="schol" n="504-505">
+            <div type="schol" n="504">
                <p> (VNDE PROCVL STARENT IRAEQVE MINAEQVE / REGNAQVE ET A IVSTIS) FORTVNA RECEDERET ARIS <supplied>
                      <hi rend="italic">fortuna</hi>
                   </supplied> ut ne casus quidem laederet qui ad has aras confugissent, quamuis melius <hi rend="italic">fortunam</hi> debemus accipere regis aut potentioris fortunae uiri. Et uult hoc loco intellegi poeta nulla ui potentium religionem huius arae posse perfringi. </p>
             </div>
 
-            <div type="schol" n="509-510">
+            <div type="schol" n="509">
                <p> (MOX HOSPITA SEDES) / VICIT ET OEDIPODAE FVRIAS <hi rend="italic">mox ... uicit</hi>, quia nondum factum est. Hoc tamen significat: Oedipus expulsus Creontis imperio <supplied>Colonum</supplied> confugit <del>
                      <foreign xml:lang="grc">ἐπὶ Κολωνόν</foreign>
                   </del>, in quo lucus erat Furiis consecratus. Sed misericordia Atheniensium illa sede est erutus hospitaliterque tractatus. Hanc tragoediam <supplied>
                      <foreign xml:lang="grc">Οἰδίπους ἐπὶ Κολωνῷ</foreign> Sophocles senex composuit, ut</supplied> Aristophanes scripsit. </p>
             </div>
 
-            <div type="schol" n="510-511">
+            <div type="schol" n="510">
                <p> FVNVS OLYNTIII / (TEGIT) Olynthus ciuitas Athenis seruiens. Haec se auctoribus Lasthene et Euthycrate Philippo tradidit <supplied>
                      <gap/>
                   </supplied>, ob quam culpam <del>Atheniensibus</del> placuit euertere ciuitatem. Quo comperto ad aram Miseri<supplied>cordiae confugerunt</supplied>.</p>
@@ -18976,7 +18977,7 @@
                   <hi rend="italic">Summouit</hi> ait, quasi sequentis matris umbram religio arae summouerit. Illic enim, ut supra dictum est, furore purgatus est. </p>
             </div>
 
-            <div type="schol" n="512-513">
+            <div type="schol" n="512">
                <p> (MANVS ANXIA LERNAE / DEVENIVNT CEDIT MISERORVM) TVRBA PRIORVM asyli prior turba discessit Argolicis uenientibus matribus.</p>
                <p>
                   <del>...</del>
@@ -18987,7 +18988,7 @@
                <p> (GELIDVM) BRAVRONA Brauron locus Atticae regionis in Boeotiam uergens. </p>
             </div>
 
-            <div type="schol" n="615-616">
+            <div type="schol" n="615">
                <p> (RVRA ...) / MONYCHIA <hi rend="italic">
                      <supplied>rura Monychia</supplied>
                   </hi> 
@@ -18998,7 +18999,7 @@
                <p> (ET NONDVM EOO CLARVM) MARATHONA TRIVMPHO necdum ibi ab Atheniensibus uictus fuerat Perses. In hoc enim loco postea Persarum classis exstincta est, quod in orientali fama manifestum est. Ideo <hi rend="italic">E<supplied>o</supplied>um ... triumphum</hi> dixit. </p>
             </div>
 
-            <div type="schol" n="620-621">
+            <div type="schol" n="620">
                <p> AEGALEOS ... PARNESQVE ... / ... ET ... LYCABESSOS montes Attici. </p>
             </div>
 
@@ -19010,7 +19011,7 @@
                <p> (QVAEQVE RVDES THYRSOS HEDERIS VESTISTIS) ACHARNAE in hoc loco primum Dionysia et inuenta et celebrata dicuntur. </p>
             </div>
 
-            <div type="schol" n="&lt;627&gt;">
+            <div type="schol" n="627">
                <p> 
                   <supplied>CEREALIS ELEVSIN</supplied> Ceres a Dite filiam raptam dum quaerit hospitio regis Eleusii fertur fuisse suscepta. Cuius filium Triptolemum pro beneficii gratia sustulit nutriendum, cui agriculturam et inueniendi frumenti artificium Ceres ostendit. </p>
             </div>
@@ -19019,17 +19020,17 @@
                <p> CALLIRHOE (NOVIENS ERRANTIBVS VNDIS) fons nouem capitibus means. </p>
             </div>
 
-            <div type="schol" n="630-631">
+            <div type="schol" n="630">
                <p> (ET RAPTAE QVI CONSCIVS) ORITHYIAE / (CELAVIT RIPIS GETICOS ELISOS AMORES) <supplied>
                      <hi rend="italic">Orithyiae</hi>
                   </supplied> Orithyia Erecthei filia. Hanc Boreas Thracius rapuit a flumine Eliso, ex qua Zethus et Calais oriuntur. </p>
             </div>
 
-            <div type="schol" n="632-634">
+            <div type="schol" n="632">
                <p> IPSE QVOQVE (... COLLIS VBI INGENS / LIS SVPERVM DVBIIS DONEC NOVA SVRGERET ARBOR / RVPIBVS) Acropolin dicit, arcem Athenarum, de qua Neptuno et Mineruae dicitur fuisse certamen. <supplied>Neptunus</supplied> percussa terra equum dedit, indicium belli, Minerua uero oliuam, pacis insigne. </p>
             </div>
 
-            <div type="schol" n="&lt;634&gt;">
+            <div type="schol" n="634">
                <p> 
                   <supplied>LONGA REFVGVM MARE FRANGERET VMBRA</supplied> magnitudinem arboris ostendit ex umbrae quantitate qua obscurat. FRANGERET insultaret uicto Neptuno. </p>
             </div>
@@ -19038,7 +19039,7 @@
                <p> GLISCERE cum furore cupere. </p>
             </div>
 
-            <div type="schol" n="&lt;642-643&gt;">
+            <div type="schol" n="642">
                <p> 
                   <supplied>TERRARVM LEGES ET MVNDI FOEDERA MECVM / DEFENSVRA COHORS</supplied> inuocatio. </p>
             </div>
@@ -19067,11 +19068,11 @@
                <p> ADEO in tantum. OPERI itineris magnitudini. </p>
             </div>
 
-            <div type="schol" n="672-673">
+            <div type="schol" n="672">
                <p> CVM SAEPTVS (IMAGINE TORVA / INGREDITVR PVGNAS) cum armatus esset pictura Minotauri. </p>
             </div>
 
-            <div type="schol" n="675-676">
+            <div type="schol" n="675">
                <p> (METVENDAQVE QVONDAM) / LIMINA Labyrinthi. </p>
             </div>
 
@@ -19093,7 +19094,7 @@
                <p> DOCVMENTA exempla quae in uictos edidimus quos prohibuimus sepeliri. </p>
             </div>
 
-            <div type="schol" n="692-693">
+            <div type="schol" n="692">
                <p> (PVLVERE CRASSO) / CALIGARE <del>DIEM</del> faciente caligine<supplied>m</supplied> non parere. </p>
             </div>
 
@@ -19121,7 +19122,7 @@
                <p> QVERCVM pro 'hasta'. </p>
             </div>
 
-            <div type="schol" n="733-734">
+            <div type="schol" n="733">
                <p> EDONOS (... / ... CVRRVS) Thracicos. </p>
             </div>
 
@@ -19157,7 +19158,7 @@
                <p> (QVOS) VLCISCARE fratres uidelicet in se inuicem parricidas. </p>
             </div>
 
-            <div type="schol" n="774-775">
+            <div type="schol" n="774">
                <p> (QVA SVB TEGMINE DVRO / MVLTIPLICEM TENVES ITERANT) THORACA CATENAE <hi rend="italic">tegmine duro</hi> textu ferrato. Iuxta eam partem ubi est loricae medietas. </p>
             </div>
 
@@ -19173,7 +19174,7 @@
                <p> GAVDENT (LAMENTA) luctus mutantur in gaudia. </p>
             </div>
 
-            <div type="schol" n="800-801">
+            <div type="schol" n="800">
                <p> (TVRBINE QVO SESE CARIS INSTRAVERIT AVDAX) / IGNIBVS EVADNE haec Capanei uxor nimio amore et dolore flammata in rogum coniugis se praecipitem dedit. </p>
             </div>
 
@@ -19190,7 +19191,7 @@
                   <del>VIX</del> NOVVS (... FVROR) noui carminis iteratio. </p>
             </div>
 
-            <div type="schol" n="812-814">
+            <div type="schol" n="812">
                <p> (IAM CERTE PRAESENS TIBI FAMA BENIGNVM) / STRAVIT ITER (COEPITQVE NOVAM MONSTRARE FVTVRIS / IAM TE MAGNANIMVS DIGNATVR NOSCERE CAESAR) Fama sternente benignum iter ad posteros <supplied>et</supplied> usque ad proceres. </p>
             </div>
 
@@ -19198,7 +19199,7 @@
                <p> TEMPTA prouoces.</p>
             </div>
 
-            <div type="schol" n="818-819">
+            <div type="schol" n="818">
                <p>(MOX TIBI SI QVIS ADHVC PRAETENDIT NVBILA LIVOR / OCCIDET ET MERITI POST ME) REFERENTVR HONORES post mortem meam te honorabit inuidia.</p>
             </div>
 

--- a/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
@@ -132,12 +132,12 @@
                <p> VNDE GRAVES I(RAE) C(OGNATA) I(N) M(OENIA) B(ACCHO) Pentheus aspernabatur Liberi patris mysteria. Iratus Liber furorem eius matri immisit, quae armata furore Pentheum filium necauit. Et bene dixit <hi rend="italic">cognata</hi>. Agaue enim, Semele, Autonoe, Ino sorores fuerunt Thebanae.</p>
             </div>
 
-            <div type="schol" n="12">
+            <div type="schol" n="12a">
                <p> QVOD SAEVAE I(VNONIS) O(PVS) Iuno dum uideret a Ioue Semelen diligi, in aniculam uersa est <del>Iuno</del> 
                   <unclear>decoratam</unclear>. Dolum meditans Semeles limen ingressa est, cui ita locuta est: Si te, ut perhibent, integre amat Iuppiter, hoc ab eo impetra, ut talis ad te ueniat, qualis Iunoni solet uideri. Quae ita inducta Iouem rogauit. Qui cum negaret et diceret aspectum dei nullo modo ferre posse mortalem, tandem promisit tali se habitu ad eam esse uenturum, quali ad Iunonem consueuit. Qui cum uenisset cum fulmine, Semele sustinere non potuit et obiit. Iuppiter uero aperto eius uelocissime utero Liberum patrem <del>aperto</del> femore abdidisse dicitur, ut expletis nouem mensibus legitime nasceretur.</p>
             </div>
 
-            <div type="schol" n="12">
+            <div type="schol" n="12b">
                <p> CVI SVMPSERIT ARCVM / INFELIX ATHAMAS (CVR NON EXPAVERIT INGENS / IONIVM SOCIO CASVRA PALAEMONE MATER) Leucothea, quae et Ino, Liberi patris nutrix fuisse dicitur. Huius marito Athamanti talem furorem Iuno immisit, ut filios suos uellet occidere, sperans quod Liberum patrem inuenire posset et simili sorte perimere<del>t</del>. Qui Athamas unum filium suum Learchum Herculis sagittis exstinxit. Leucothea uero, ubi maritum suum furere conspexit, cum Palaemone filio suo se dedit in mare. Quae postmodum in marinam deam conuersa est et uocatur Mater Matuta, filius eius deus Portunus. Vnde Vergilius:</p>
                <lg>
                   <l>'manu magna P(ortunus) e(untem)</l>
@@ -157,11 +157,11 @@
                <p> LIMES <del>MIHI</del> principium et finis dicitur <hi rend="italic">limes</hi>.</p>
             </div>
 
-            <div type="schol" n="17">
+            <div type="schol" n="17a">
                <p> CONFVSA DOMVS quia idem filius et maritus, eadem mater et uxor, idem filii qui nepotes.</p>
             </div>
 
-            <div type="schol" n="17">
+            <div type="schol" n="17b">
                <p> (QVANDO ITALA NONDVM / SIGNA NEC ARCTOOS AVSIM) SPIRARE T(RIVMPHOS) ideo Graeca bella scribo, quia Latina non possum.</p>
             </div>
 
@@ -962,11 +962,11 @@
                <p> MALA G(AVDIA) M(ATRVM) aut propter Agauen, quae parricidio suo insana gaudebat, aut propter Iocastam, quae cum filio laeta concubuit. </p>
             </div>
 
-            <div type="schol" n="230">
+            <div type="schol" n="230a">
                <p> ERRORESQVE F(EROS) N(EMORVM) Athamantis scilicet, qui furiata mente cum Learchum filium iugularet, leonem se putauit occidere. </p>
             </div>
 
-            <div type="schol" n="230">
+            <div type="schol" n="230b">
                <p> ET RETICENDA D(EORVM) / C(RIMINA) et hoc <foreign xml:lang="grc">ἀμφίβολον</foreign>: aut quae homines in deos commiserunt aut quae dii irrogauere mortalibus. Si hominum in deos, haec sunt: Niobe Latonae, Pentheus Libero, Semele Iunoni; uel propter Tantalum, qui uolens deorum mentes inquirere Pelopem filium suum diis posuit epulandum. Quae a Pentheo inlata sunt in Liberum, Ouidius refert <supplied>
                      <gap/>
                   </supplied> haec enim deorum crimina. </p>
@@ -1328,12 +1328,12 @@
                <p> TENVAVERAT AERA BIGA bene <hi rend="italic">tenuauerat</hi>, quia diei aer crassior est, noctis tenuis. </p>
             </div>
 
-            <div type="schol" n="339">
+            <div type="schol" n="339a">
                <p> IAM PECVDES V(OLVCRES)Q(VE) T(ACENT) sic Vergilius:</p> 
                <l>'cum tacet omnis ager, p(ecudes) p(ictae)q(ue) u(olucres)'.</l>
             </div>
 
-            <div type="schol" n="339-340">
+            <div type="schol" n="339b">
                <p> IAM SOMNVS AVARIS / INSERPIT CVRIS <hi rend="italic">auaris</hi> indefessis. Auarus enim animus difficile fatigatur. Vt Horatius:</p> 
                <l>'addunt auaro diuitias mari'.</l>
             </div>
@@ -1860,12 +1860,12 @@
                <p> VOCALIBVS ANTRIS fatidico Apollinis specu. <supplied>VOCALIBVS</supplied> responsa promentibus. </p>
             </div>
 
-            <div type="schol" n="493">
+            <div type="schol" n="493a">
                <p> OBTVTV fixo aspectu, id est aut stupore animi aut senectute. Vt</p> 
                <l>'obtutu tenet ora soloque i(mmobilis) h(aeret)'. </l>
             </div>
 
-            <div type="schol" n="493">
+            <div type="schol" n="493b">
                <p> (LAETVSQVE PER ARTVS) / HORROR IIT medie dictum. Horror enim aut gaudiorum est aut maeroris. Sed modo gaudii intellegendum. Timoris horror est, quem Vergilius dicit:</p> 
                <l>'horror ubique animos, simul i(psa) s(ilentia) t(errent)',</l> 
                <p>laetitiae, ut Terentius:</p>
@@ -2076,7 +2076,7 @@
                <p> (AMPLEXVM DELPHOS SQVAMISQVE ...) TERENTEM crebris amplexibus tenuantem. </p>
             </div>
 
-            <div type="schol" n="564a">
+            <div type="schol" n="564b">
                <p> (ANNOSA / ROBORA) CASTALIIS (... FONTIBVS) magnae arbores iuxta Castalium fontem sunt, qui in Boeotia esse dicitur Musis consecratus. </p>
             </div>
 
@@ -2477,7 +2477,7 @@
                <p> TVM MOTVS A(DRASTVS) / (HOSPITIIS) motus affectu, quo quis circa hospites suos solet moueri. </p>
             </div>
 
-            <div type="schol" n="682">
+            <div type="schol" n="682a">
                <p> 
                   <supplied>AGNOVIT ENIM</supplied> aut quod ipse Oedipoden aliquando susceperat aut quod ipse ab Oedipo fuerat aliquando susceptus. </p>
             </div>
@@ -2530,7 +2530,7 @@
                <p> (REBVS) MEREARE S(ECVNDIS) / (EXCVSARE TVOS) sensus: enitendum tibi est, ut factis tuis non solum parentibus uideare dissimilis, sed etiam illos facias innocentes. </p>
             </div>
 
-            <div type="schol" n="682">
+            <div type="schol" n="682b">
                <p> ET IAM TEMONE S(VPINO) / L(ANGVET) H(YPERBOREAE) G(LACIALIS) P(ORTITOR) V(RSAE) Ophiuchum significat, qui sub Vrsa est. Aduentu enim diei incipiunt sidera septentrionis hebescere. </p>
             </div>
 
@@ -3479,7 +3479,7 @@
                <p>id est nutrire. </p>
             </div>
 
-            <div type="schol" n="255a">
+            <div type="schol" n="255b">
                <p> PRIMOSQVE SOLEBANT / EXCVSARE TOROS id est: in templo Mineruae solebant uirgines nupturae placare deam quae sit fautrix uirginitatis et excusare quod necessitate et lege naturali nubere cogebantur. </p>
             </div>
 
@@ -4248,7 +4248,7 @@
 
             <div type="schol" n="543">
                <p> VIDVO ... LIGNO cuspide: ab ea parte quae ferro caret ac per hoc infirma. Metaphora a muliere: ut quae auxilio mariti caret infirma est, ita lignum quod non habet ferrum unde uulnus infligat infirmum est. </p>
-            <lg/></div>
+            </div>
 
             <div type="schol" n="545">
                <p> (PALLENTIAQVE) IRA (ORA) <supplied>
@@ -5245,11 +5245,11 @@
                <l>'Gradiuumque patrem, Geticis qui praesidet aruis'. </l>
             </div>
 
-            <div type="schol" n="223">
+            <div type="schol" n="223a">
                <p> FVLMINE CRISTATVM (GALEAE IVBAR) quod exibat de crista galeae infinitum luminis habens, eratque galea in morem fulminis cristis ornata. </p>
             </div>
 
-            <div type="schol" n="223">
+            <div type="schol" n="223b">
                <p> (ARMAQVE IN AVRO) / TRISTIA quae quamquam essent aurea, tamen tristitia non carerent, ut esset terror in proelio. </p>
             </div>
 
@@ -6384,7 +6384,7 @@
                </p>
             </div>
 
-            <div type="schol" n="683">
+            <div type="schol" n="683a">
                <p> IAM NOCTE (SVPREMA) id est in fine constituta, cum explicatur <hi rend="italic">ante nouos ortus</hi> id est ante aduentum diei. </p>
             </div>
 
@@ -6401,7 +6401,7 @@
                <p> (IVRA...) GENIALIA coniugalia. Viris enim <hi rend="italic">genius</hi> conuenit, mulieribus <hi rend="italic">Iuno</hi>: sed bene uxor super coniugis iurauerit partes. </p>
             </div>
 
-            <div type="schol" n="683">
+            <div type="schol" n="683b">
                <p> (NON SI MIHI) TIGRIDIS HORROR / (AEQVOREAEQVE SVPER RIGEANT PRAECORDIA CAVTES) totum Vergiliane amantis expressit affectum. Dido enim, ut Aeneae exprobraret duritiam cordis, ait:</p>
                <lg>
                   <l>'sed duris genuit te Caucasus horrens</l>
@@ -6548,11 +6548,11 @@
                <p> TVQVE O NEMORIS (REGINA SONORI / CALLIOPE) <hi rend="italic">nemoris</hi> Pindi uel Parnassi, unde uox funditur Pieridum. </p>
             </div>
 
-            <div type="schol" n="37">
+            <div type="schol" n="37a">
                <p> SVBLATA MOLIRE LYRA heroicum iam ardorem innectens <supplied>non</supplied> remissa lyra commemora<del>ta</del>.</p>
             </div>
 
-            <div type="schol" n="37">
+            <div type="schol" n="37b">
                <p> (NEQVE ENIM ALTIOR VLLI) / MENS HAVSTO DE FONTE VENIT quia illic tu donas eloquia.</p>
             </div>
 
@@ -8046,11 +8046,11 @@
                <p> LERNAEOS (... ALVMNOS) Graecos a Lerna, palude Argiae. </p>
             </div>
 
-            <div type="schol" n="639">
+            <div type="schol" n="639a">
                <p> HOS TERRAE MONSTRA propter Amphiaraum, qui hiatu terrae demersus est, seu propter Tydeum, qui prodigialiter Melanippi, percussoris sui, cerebrum uorando defunctus est. </p>
             </div>
 
-            <div type="schol" n="639">
+            <div type="schol" n="639b">
                <p> DEVMQVE / TELA (MANENT) propter Capaneum, qui eo clarior fuit, quod Iouis fulmine meruerit interire. </p>
             </div>
 
@@ -8527,11 +8527,11 @@
                <p> (TELLVS IAM PVLVERE PRIMO) / CRESCIT quia dum erigitur puluis crescit terra in altitudinem. </p>
             </div>
 
-            <div type="schol" n="11">
+            <div type="schol" n="11a">
                <p> PHARIIS (... SERENIS) Aegyptiis. Pharos enim ciuitas est Aegypti. </p>
             </div>
 
-            <div type="schol" n="11">
+            <div type="schol" n="11b">
                <p> (QVALIA ...) / RAVCA PARAETONIO (DECEDVNT AGMINA NILO / CVM FERA PONIT HIEMS) laetitiae congrua comparatio. Sic Argiui post sitim laeti erant et alacres ut redeuntes grues ex Aegypto in Thraciam quando fugiunt Notum, qui in Aegypto calorem aeri<supplied>s</supplied> tempore auget aestatis. CVM FERA PONIT HIEMS desinit. Vt Vergilius:</p> 
                <l>'cum uenti posuere'. </l>
             </div>
@@ -9199,7 +9199,7 @@
                   </supplied> nomen est, non participium. Nam tempore caret, patiendi significatione priuatur, et indicat non pudentem, sed pudenti similem, quae erubescit admissum facinus temporis alieni et lucet, etiamsi nollet nocturnae caedis crudelitate foedari. </p>
             </div>
 
-            <div type="schol" n="297">
+            <div type="schol" n="297a">
                <p> (AVERSVM ...) IVBAR ostendit poeta generis neutri. Et Ouidius hoc genere declinauit:</p>
                <lg>
                   <l>'per iubar hoc ...</l>
@@ -9207,7 +9207,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="297">
+            <div type="schol" n="297b">
                <p> DECLINIA (TITAN / OPPOSITA IVGA NVBE REFERT) <supplied>
                      <hi rend="italic">declinia</hi>
                   </supplied> quae declinarent et fugerent. Opposita enim nube ante uultus suos Lemniadum crimine declinauerat Sol. IVGA pro 'equis'. REFERT refugit. Fugit enim Sol crudelitatem. Aut <hi rend="italic">refert</hi> 'deflectit' melius intellegamus. </p>
@@ -10399,7 +10399,7 @@
                <p> SPECIESQVE H(ORRENDA) (COROEBI) hic est Coroebus, qui monstrum Apollinis interemit et pro omnibus se deuouit. Ideo <hi rend="italic">horrenda</hi> id est uenerabilis, aut <hi rend="italic">horrenda</hi> specie: <del>et</del> terribili, quasi contemptor uitae mortisque. </p>
             </div>
 
-            <div type="schol" n="287">
+            <div type="schol" n="287a">
                <p> ET DANAE (CVLPATA SINVS) Danae Acrisii filia. Haec cum a patre ob custodiendam uirginitatem artius seruaretur, dicitur eius specie captus Iuppiter sese in imbrem aureum demutasse et ita in modum pluuiae Danaes sinum penetrasse. Ex qua coniunctione Iuppiter Perseum edidit. Vnde Horatius:</p>
                <lg>
                   <l>'si non Acrisium, uirginis abditae</l>
@@ -10414,7 +10414,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="287">
+            <div type="schol" n="287b">
                <p> (ET IN AMNE REPERTO) / TRISTIS (AMYMONE) Belus Danai pater, Danaus Amymones. Amymone a Neptuno compressa Nauplion generauit, Nauplius Palameden. Vnde Vergilius:</p> 
                <l>'Belidae nomen Palamedis'. </l>
             </div>
@@ -10668,11 +10668,11 @@
                <p> (CAMPO DOMINVM) CIRCVMSPICIT OMNI id est: pro omni campo circumcurrendo fugit, huc atque illuc circumspiciendo. </p>
             </div>
 
-            <div type="schol" n="436">
+            <div type="schol" n="436a">
                <p> CHROMIS ASPER Herculis filius. </p>
             </div>
 
-            <div type="schol" n="436">
+            <div type="schol" n="436b">
                <p> (ASPER) / HIPPODAMVS Oenomai filius. </p>
             </div>
 
@@ -10762,7 +10762,7 @@
                <p> PVTRI ... TELLVRE definitio pulueris. </p>
             </div>
 
-            <div type="schol" n="508">
+            <div type="schol" n="508a">
                <p> TAENARII CVRRVS Amphiarai scilicet. THESSALVS AXIS Admeti. Aurigas modo demonstrauit a locis siue ab equis. Sic Vergilius duces non suis nominibus, sed nauium, intellegendos fecit dicendo:</p>
                <lg>
                   <l>'et nunc Pistris habet, nunc uictam praeterit ingens</l>
@@ -10771,7 +10771,7 @@
                <p>Sergestum significare uolens et Mnestheum. </p>
             </div>
 
-            <div type="schol" n="508">
+            <div type="schol" n="508b">
                <p> HEROS / LEMNIVS unum de geminis Hypsipylae dicit, quorum alter, Thoas, iam ruerat, dum Admetum praeterire festinat. </p>
             </div>
 
@@ -11021,11 +11021,11 @@
                <p> ORBEM discum. </p>
             </div>
 
-            <div type="schol" n="658">
+            <div type="schol" n="658a">
                <p> HVNC RAPITE raptim mittite. </p>
             </div>
 
-            <div type="schol" n="658">
+            <div type="schol" n="658b">
                <p> (AST ILLVD) CVI NON IACVLABILE (DEXTRAE / PONDVS) interrogatiue cum despectu. </p>
             </div>
 
@@ -11278,11 +11278,11 @@
                <p> DOCTIOR HIC Alcidamas. DIFFERT ANIMVM spiritum seruat. </p>
             </div>
 
-            <div type="schol" n="766">
+            <div type="schol" n="766a">
                <p> (CVNCTATVS) VIRES DISPENSAT id est: paulatim erogat. </p>
             </div>
 
-            <div type="schol" n="766">
+            <div type="schol" n="766b">
                <p> AT ILLE NOCENDI / (PRODIGVS) Capaneus in aduersarii nece profusior. </p>
             </div>
 
@@ -11428,11 +11428,11 @@
                <p> CLEONAEVS (... AGYLLEVS) Cleonae ciuitas Corintho uicina. </p>
             </div>
 
-            <div type="schol" n="838">
+            <div type="schol" n="838a">
                <p> NEC MOLE MINOR magnitudine corporis non inferior. </p>
             </div>
 
-            <div type="schol" n="838">
+            <div type="schol" n="838b">
                <p> (SIC GRANDIBVS ALTE / INSVRGENS VMERIS HOMINEM SVPER IMPROBVS) EXIT proceritate corporis humanam formam uidebatur excedere. </p>
             </div>
 
@@ -11816,11 +11816,11 @@
                <p> RVIT cadit uel desinit flare. </p>
             </div>
 
-            <div type="schol" n="87">
+            <div type="schol" n="87a">
                <p> PAX IPSA TVMET ipsa tranquillitas inquieta. </p>
             </div>
 
-            <div type="schol" n="87">
+            <div type="schol" n="87b">
                <p> (PONTVMQVE IACENTEM) / EXANIMIS (IAM VOLVIT HIEMS) <supplied>
                      <hi rend="italic">exanimis</hi>
                   </supplied> sine uento. Id est: reliquiae tempestatis, licet sine flatu uentorum, tamen adhuc exagitant mare. </p>
@@ -11891,11 +11891,11 @@
                <p> LYMPHARE furiare. </p>
             </div>
 
-            <div type="schol" n="116">
+            <div type="schol" n="116a">
                <p> VIDISSE PVTANT ad augendam credulitatem nouarum rerum ita dicta confirmant ut quae timore mentiuntur se uidisse confirment. </p>
             </div>
 
-            <div type="schol" n="116">
+            <div type="schol" n="116b">
                <p> TVNC ACRE NOVABAT / (INGENIVM) si deorum aliquis mentiatur, facile potest falsa suadere mortalibus. </p>
             </div>
 
@@ -13286,7 +13286,7 @@
                <p> RESPEXITQVE CADENS (CAELVM) uel dolore morientis uel ut Apollinem quaereret utpote uates. </p>
             </div>
 
-            <div type="schol" n="822-823">
+            <div type="schol" n="822">
                <p> DONEC LEVIOR (DISTANTIA RVRSVS / MISCVIT ARVA TREMOR LVCEMQVE EXCLVSIT AVERNO) quia graui sonitu solida disiunguntur nec tamen eodem fragore hiulca iunguntur. </p>
             </div>
 
@@ -13643,7 +13643,7 @@
                <p>Clarium ergo ciuitas est in qua tres dii id est Iuppiter, Neptunus, et Pluton mundum dicuntur fuisse sortiti. In hac Apollo maxime oracula mortalibus dare consueuerat. </p>
             </div>
 
-            <div type="schol" n="201">
+            <div type="schol" n="201a">
                <p> (CORNIGERI) VATIS NEMVS quia in Syrtibus in eo tantum loco ubi Iouis Hammonis templum est, nemus inuenitur. Vt Lucanus:</p>
                <lg>
                   <l>'solus nemus abstulit Hammon.</l>
@@ -13651,7 +13651,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="201">
+            <div type="schol" n="201b">
                <p> (MOLOSSO) / QVERCVS (ANHELA IDVI) quam Chaoniam dicit hoc est Epiroticam, Molossia enim est in Epiro, ubi solebant columbae sub quercu responsa dare. <hi rend="italic">Anhela</hi> ergo dixit per similitudinem uatum, qui deo pleni et anhelantes responsa dant. Vt est:</p>
                <lg>
                   <l>'sed pectus anhelum,</l>
@@ -14252,7 +14252,7 @@
                <p> HAVSIT penetrauit siue percussit. </p>
             </div>
 
-            <div type="schol" n="587">
+            <div type="schol" n="5">
                <p> HAVD DVBIVM FATI procul dubio periturum. </p>
             </div>
 
@@ -14544,7 +14544,7 @@
                <p> (SVA ...) HVMVS solum patriae suae. </p>
             </div>
 
-            <div type="schol" n="28b">
+            <div type="schol" n="28a">
                <p> INCESTARVM AVIVM id est humano sanguine pollutarum, siue quia cadauera eminus sentiunt. </p>
             </div>
 
@@ -15709,7 +15709,7 @@
                   <hi rend="italic">ipsa</hi> est Hecate, quae inuocatur a magis. </p>
             </div>
 
-            <div type="schol" n="735 ">
+            <div type="schol" n="735">
                <p> (FERAS ...) HERBAS magicae disciplinae aptas. </p>
             </div>
 
@@ -16450,7 +16450,7 @@
                <p> (NOMINE ... / ...) SIGNARE <del>QVEAT</del> nomine definire. </p>
             </div>
 
-            <div type="schol" n="277">
+            <div type="schol" n="277a">
                <p> HVNC TEMERE (EXPLICITVM STRATIS) neglegentem et sine cura aliqua dormientem. EXPLICITVM extensum. Lucanus:</p>
                <lg>
                   <l>'et omnem</l>
@@ -16458,7 +16458,7 @@
                </lg>
             </div>
 
-            <div type="schol" n="277">
+            <div type="schol" n="277b">
                <p> (HVNC SERO REMISSIS) / GRESSIBVS ILLAPSVM CLIPEO hunc, qui sero, uictus somno, dum stabat, defecit ac corruit. </p>
             </div>
 
@@ -18917,11 +18917,11 @@
                <p> SVPPLICIS ARBOR OLIVAE per quam pax petitur supplicando. Et in secundo diximus hanc ab Atheniensibus <foreign xml:lang="grc">εἰρεσιώνην</foreign> dici, a reliquis autem Graecis <foreign xml:lang="grc">ἱκετήριαν</foreign>. <hi rend="italic">Supplicis</hi> autem <hi rend="italic">oliuae</hi>, non quod ipsa sit supplex, sed quod omnes qui rogant hac suppliciter utuntur. </p>
             </div>
 
-            <div type="schol" n="495">
+            <div type="schol" n="495a">
                <p> TREPIDOS supplices. </p>
             </div>
 
-            <div type="schol" n="495">
+            <div type="schol" n="495a">
                <p> HORRET EGENIS / (COETIBVS) horridior fit miseris. </p>
             </div>
 
@@ -18984,11 +18984,11 @@
                </p>
             </div>
 
-            <div type="schol" n="615">
+            <div type="schol" n="615a">
                <p> (GELIDVM) BRAVRONA Brauron locus Atticae regionis in Boeotiam uergens. </p>
             </div>
 
-            <div type="schol" n="615">
+            <div type="schol" n="615b">
                <p> (RVRA ...) / MONYCHIA <hi rend="italic">
                      <supplied>rura Monychia</supplied>
                   </hi> 

--- a/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
+++ b/data/stoa0171a/stoa001/stoa0171a.stoa001.digilibLT-lat1.xml
@@ -4248,7 +4248,7 @@
 
             <div type="schol" n="543">
                <p> VIDVO ... LIGNO cuspide: ab ea parte quae ferro caret ac per hoc infirma. Metaphora a muliere: ut quae auxilio mariti caret infirma est, ita lignum quod non habet ferrum unde uulnus infligat infirmum est. </p>
-            </lg></div>
+            </div>
 
             <div type="schol" n="545">
                <p> (PALLENTIAQVE) IRA (ORA) <supplied>


### PR DESCRIPTION
Chemin du fichier : data/stoa0171a/stoa001/stoa0171.stoa001.digilibLT-lat1.xml
Issue : #112 
Modifications réalisées : 

- [ ]  Correction des problèmes de duplicate nodes : correction du refsDecl, et une vingtaine de duplicatas

- [ ] Forbidden character : plusieurs centaines de node avec un identifiant en caractères interdits; reprise à la main. 

5 commits : pour dégrossir, refaire les tests, puis corriger. Très gros fichier à corriger ; quasiment une erreur tous les 10 nodes (j'y ai passé 3h non stop, j'espère que cela sera utile). 
**NB** : Pour le premier livre : je n'ai pas adopté un système cohérent de remplacement des identifiants lorsqu'ils étaient de type x-y : j'essayait d'avoir le moins de doublons possible. Pour tous les autres livres, j'ai fait xa ou xb en cas de doublo, en abandonnant les y.  Explications plus poussées dans le revisionDesc. 
